### PR TITLE
fix: disable fees frontend UI and update tracer secrets template

### DIFF
--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -141,7 +141,7 @@ frontend:
   # -- Service name
   name: plugin-fees-ui
   # -- Enable or disable the frontend service
-  enabled: true
+  enabled: false
   # -- Number of old ReplicaSets to retain for deployment rollback
   revisionHistoryLimit: 10
   # -- Number of replicas for the deployment

--- a/charts/tracer/templates/secrets.yaml
+++ b/charts/tracer/templates/secrets.yaml
@@ -7,8 +7,10 @@ metadata:
   labels:
     {{- include "tracer.labels" (dict "context" . "component" .Values.tracer.name "name" .Values.tracer.name) | nindent 4 }}
 type: Opaque
-stringData:
-  {{- range $key, $value := .Values.tracer.secrets }}
-  {{ $key }}: {{ $value | quote }}
-  {{- end }}
+data:
+  # PostgreSQL Secrets
+  DB_PASSWORD: {{ .Values.tracer.secrets.DB_PASSWORD | default "lerian" | b64enc | quote }}
+
+  # API Key Secrets
+  API_KEY_SECRET: {{ .Values.tracer.secrets.API_KEY_SECRET | default "" | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
## Changes

### plugin-fees
- Disabled frontend UI (`frontend.enabled: false`) — UI is no longer used by plugin-fees.

### tracer
- Updated secrets template to use explicit keys with `b64enc` (matching matcher pattern) instead of `stringData` range loop.
- Ensures gitops can properly create the secret in the namespace.

Requested by @gabrielferreira in [#devops-team](https://lerianstudio.slack.com/archives/C06RBGTLE92/p1761164443929519).