### PR TITLE
feat(midaz): add MULTI_TENANT_CACHE_TTL_SEC and MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC to configmaps

### DIFF
--- a/charts/midaz/templates/crm/configmap.yaml
+++ b/charts/midaz/templates/crm/configmap.yaml
@@ -49,6 +49,10 @@ data:
   PLUGIN_AUTH_ADDRESS: {{ .Values.crm.configmap.PLUGIN_AUTH_ADDRESS | default "plugin-auth" | quote }}
   PLUGIN_AUTH_ENABLED: {{ .Values.crm.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
 
+  # MULTI-TENANT
+  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.crm.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
+  MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: {{ .Values.crm.configmap.MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC | default "30" | quote }}
+
   # Extra Env Vars
   {{- with .Values.crm.extraEnvVars }}
   {{- toYaml . | nindent 2 }}

--- a/charts/midaz/templates/ledger/configmap.yaml
+++ b/charts/midaz/templates/ledger/configmap.yaml
@@ -173,6 +173,12 @@ data:
   BALANCE_SYNC_WORKER_ENABLED: {{ .Values.ledger.configmap.BALANCE_SYNC_WORKER_ENABLED | default "false" | quote }}
   BALANCE_SYNC_MAX_WORKERS: {{ .Values.ledger.configmap.BALANCE_SYNC_MAX_WORKERS | default "5" | quote }}
 
+  # =============================================================================
+  # MULTI-TENANT
+  # =============================================================================
+  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.ledger.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
+  MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: {{ .Values.ledger.configmap.MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC | default "30" | quote }}
+
   # Extra Env Vars
   {{- with .Values.ledger.extraEnvVars }}
   {{- toYaml . | nindent 2 }}


### PR DESCRIPTION
## What

Adds two missing multi-tenant env vars to the Midaz Helm chart configmaps:

- `MULTI_TENANT_CACHE_TTL_SEC` (default: `120`) — in-memory cache TTL for tenant config
- `MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC` (default: `30`) — interval between tenant config revalidation checks

Both vars are already consumed by the `ledger` and `crm` components via their Go config structs, but were not exposed in the Helm chart.

## Components affected

- `templates/ledger/configmap.yaml`
- `templates/crm/configmap.yaml`

## How to override

```yaml
ledger:
  configmap:
    MULTI_TENANT_CACHE_TTL_SEC: "120"
    MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: "30"

crm:
  configmap:
    MULTI_TENANT_CACHE_TTL_SEC: "120"
    MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: "30"
```