### PR TITLE
fix: replace hardcoded namespace refs with .Release.Namespace

### DIFF
--- a/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd-job/configmap.yaml
+++ b/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd-job/configmap.yaml
@@ -33,14 +33,14 @@ data:
   CORE_PIX_SERVER: {{ .Values.job.configmap.CORE_PIX_SERVER | default "jd" | quote }}
 
   # JD Pix Integration Configuration
-  JD_BASE_URL: {{ .Values.job.configmap.JD_BASE_URL | default "http://jd-pix.midaz-plugins.svc.cluster.local:3000" | quote }}
+  JD_BASE_URL: {{ .Values.job.configmap.JD_BASE_URL | default (printf "http://jd-pix.%s.svc.cluster.local:3000" .Release.Namespace) | quote }}
   JD_CLIENT_ID: {{ .Values.job.configmap.JD_CLIENT_ID | default "" | quote }}
   JD_GRANT_TYPE: {{ .Values.job.configmap.JD_GRANT_TYPE | default "client_credentials" | quote }}
   JD_BANK_ID: {{ .Values.job.configmap.JD_BANK_ID | default "37040044" | quote }}
 
   # Database
   DATABASE_ACQUIRE: {{ .Values.pix.configmap.DATABASE_ACQUIRE | default "10000" | quote }}
-  DATABASE_HOST: {{ .Values.pix.configmap.DATABASE_HOST | default "plugin-br-pix-direct-jd-postgresql.midaz-plugins.svc.cluster.local" | quote }}
+  DATABASE_HOST: {{ .Values.pix.configmap.DATABASE_HOST | default (printf "plugin-br-pix-direct-jd-postgresql.%s.svc.cluster.local" .Release.Namespace) | quote }}
   DATABASE_IDLE: {{ .Values.pix.configmap.DATABASE_IDLE | default "20000" | quote }}
   DATABASE_USER: {{ .Values.pix.configmap.DATABASE_USER | default "pix" | quote }}
   DATABASE_NAME: {{ .Values.pix.configmap.DATABASE_NAME | default "pix" | quote }}
@@ -50,7 +50,7 @@ data:
 
   # AUTH CONFIGS - Access Manager (OAuth2)
   PLUGIN_AUTH_ENABLED: {{ .Values.job.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
-  PLUGIN_AUTH_HOST: {{ .Values.job.configmap.PLUGIN_AUTH_HOST | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000" | quote }}
+  PLUGIN_AUTH_HOST: {{ .Values.job.configmap.PLUGIN_AUTH_HOST | default (printf "http://plugin-access-manager-auth.%s.svc.cluster.local:4000" .Release.Namespace) | quote }}
 
   # Midaz
   MIDAZ_ORGANIZATION_ID: {{ .Values.job.configmap.MIDAZ_ORGANIZATION_ID | default "" | quote }}
@@ -62,11 +62,11 @@ data:
   MIDAZ_URL_TRANSACTION: {{ .Values.job.configmap.MIDAZ_URL_TRANSACTION | default "http://midaz-transaction.midaz.svc.cluster.local:3001" | quote }}
 
   # CRM
-  CRM_URL: {{ .Values.job.configmap.CRM_URL | default "http://plugin-crm.midaz-plugins.svc.cluster.local:4003" | quote }}
+  CRM_URL: {{ .Values.job.configmap.CRM_URL | default (printf "http://plugin-crm.%s.svc.cluster.local:4003" .Release.Namespace) | quote }}
 
   # JD Pix Configuration
   JD_JD_PIX_URL: {{ .Values.pix.configmap.JD_JD_PIX_URL | default "" | quote }}
-  JD_BASE_URL: {{ .Values.pix.configmap.JD_BASE_URL | default "http://jd-mock-api.jd-mock.svc.cluster.local:4013" | quote }}
+  JD_BASE_URL: {{ .Values.pix.configmap.JD_BASE_URL | default (printf "http://jd-mock-api.%s.svc.cluster.local:4013" .Release.Namespace) | quote }}
   JD_GRANT_TYPE: {{ .Values.pix.configmap.JD_GRANT_TYPE | default "client_credentials" | quote }}
 
   # OpenTelemetry - Shared Midaz LGTM Infrastructure

--- a/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/configmap.yaml
+++ b/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/configmap.yaml
@@ -39,7 +39,7 @@ data:
 
   # Database
   DATABASE_ACQUIRE: {{ .Values.pix.configmap.DATABASE_ACQUIRE | default "10000" | quote }}
-  DATABASE_HOST: {{ .Values.pix.configmap.DATABASE_HOST | default "plugin-br-pix-direct-jd-postgresql.midaz-plugins.svc.cluster.local" | quote }}
+  DATABASE_HOST: {{ .Values.pix.configmap.DATABASE_HOST | default (printf "plugin-br-pix-direct-jd-postgresql.%s.svc.cluster.local" .Release.Namespace) | quote }}
   DATABASE_IDLE: {{ .Values.pix.configmap.DATABASE_IDLE | default "20000" | quote }}
   DATABASE_USER: {{ .Values.pix.configmap.DATABASE_USER | default "pix" | quote }}
   DATABASE_NAME: {{ .Values.pix.configmap.DATABASE_NAME | default "pix" | quote }}
@@ -49,7 +49,7 @@ data:
 
   # AUTH CONFIGS - Access Manager (OAuth2)
   PLUGIN_AUTH_ENABLED: {{ .Values.pix.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
-  PLUGIN_AUTH_HOST: {{ .Values.pix.configmap.PLUGIN_AUTH_HOST | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000" | quote }}
+  PLUGIN_AUTH_HOST: {{ .Values.pix.configmap.PLUGIN_AUTH_HOST | default (printf "http://plugin-access-manager-auth.%s.svc.cluster.local:4000" .Release.Namespace) | quote }}
 
   # Midaz
   MIDAZ_ORGANIZATION_ID: {{ .Values.pix.configmap.MIDAZ_ORGANIZATION_ID | default "" | quote }}
@@ -61,7 +61,7 @@ data:
   MIDAZ_URL_TRANSACTION: {{ .Values.pix.configmap.MIDAZ_URL_TRANSACTION | default "http://midaz-transaction.midaz.svc.cluster.local:3001" | quote }}
 
   # CRM
-  CRM_URL: {{ .Values.pix.configmap.CRM_URL | default "http://plugin-crm.midaz-plugins.svc.cluster.local:4003" | quote }}
+  CRM_URL: {{ .Values.pix.configmap.CRM_URL | default (printf "http://plugin-crm.%s.svc.cluster.local:4003" .Release.Namespace) | quote }}
 
   # OpenTelemetry - Shared Midaz LGTM Infrastructure
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.pix.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-pix-direct-jd" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/templates/inbound/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/inbound/configmap.yaml
@@ -51,7 +51,7 @@ data:
   ENABLE_TELEMETRY: {{ .Values.inbound.configmap.ENABLE_TELEMETRY | default "true" | quote }}
 
   # Routing Configuration
-  WEBHOOK_INBOUND_BASE_URL: {{ .Values.inbound.configmap.WEBHOOK_INBOUND_BASE_URL | default "http://plugin-br-pix-indirect-btg.midaz-plugins.svc.cluster.local:4014" | quote }}
+  WEBHOOK_INBOUND_BASE_URL: {{ .Values.inbound.configmap.WEBHOOK_INBOUND_BASE_URL | default (printf "http://plugin-br-pix-indirect-btg.%s.svc.cluster.local:4014" .Release.Namespace) | quote }}
 
   # HTTP Client Configuration
   WEBHOOK_HTTP_CLIENT_TIMEOUT: {{ .Values.inbound.configmap.WEBHOOK_HTTP_CLIENT_TIMEOUT | default "5s" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
@@ -15,7 +15,7 @@ data:
 
   # AUTH PLUGIN
   PLUGIN_AUTH_ENABLED: {{ .Values.pix.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
-  PLUGIN_AUTH_ADDRESS: {{ .Values.pix.configmap.PLUGIN_AUTH_ADDRESS | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000" | quote }}
+  PLUGIN_AUTH_ADDRESS: {{ .Values.pix.configmap.PLUGIN_AUTH_ADDRESS | default (printf "http://plugin-access-manager-auth.%s.svc.cluster.local:4000" .Release.Namespace) | quote }}
 
   # VALKEY
   REDIS_HOST: {{ .Values.pix.configmap.REDIS_HOST | default (printf "plugin-br-pix-indirect-btg-valkey-master.%s.svc.cluster.local" .Release.Namespace) | quote }}
@@ -101,7 +101,7 @@ data:
   BTG_BASE_URL: {{ .Values.pix.configmap.BTG_BASE_URL | default "https://developer.api.btgpactual.com" | quote }}
 
   ## CRM
-  PLUGIN_CRM_BASE_URL: {{ .Values.pix.configmap.PLUGIN_CRM_BASE_URL | default "http://plugin-crm.midaz-plugins.svc.cluster.local:4003" | quote }}
+  PLUGIN_CRM_BASE_URL: {{ .Values.pix.configmap.PLUGIN_CRM_BASE_URL | default (printf "http://plugin-crm.%s.svc.cluster.local:4003" .Release.Namespace) | quote }}
 
   ## Midaz
   MIDAZ_ORGANIZATION_ID: {{ .Values.pix.configmap.MIDAZ_ORGANIZATION_ID | default "" | quote }}
@@ -114,7 +114,7 @@ data:
 
   ## Fee Configuration
   CASHIN_FEE_CALCULATION_TYPE: {{ .Values.pix.configmap.CASHIN_FEE_CALCULATION_TYPE | default "" | quote }}
-  FEE_SERVICE_URL: {{ .Values.pix.configmap.FEE_SERVICE_URL | default "http://plugin-fees.midaz-plugins.svc.cluster.local:4002" | quote }}
+  FEE_SERVICE_URL: {{ .Values.pix.configmap.FEE_SERVICE_URL | default (printf "http://plugin-fees.%s.svc.cluster.local:4002" .Release.Namespace) | quote }}
   FEE_SERVICE_TIMEOUT: {{ .Values.pix.configmap.FEE_SERVICE_TIMEOUT | default "5000" | quote }}
 
   # LICENSE

--- a/charts/plugin-br-pix-indirect-btg/templates/reconciliation/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/reconciliation/configmap.yaml
@@ -56,15 +56,15 @@ data:
   BTG_TIMEOUT: {{ .Values.reconciliation.configmap.BTG_TIMEOUT | default "30s" | quote }}
 
   # CRM API Configuration
-  PLUGIN_CRM_BASE_URL: {{ .Values.reconciliation.configmap.PLUGIN_CRM_BASE_URL | default "http://plugin-crm.midaz-plugins.svc.cluster.local:4003" | quote }}
+  PLUGIN_CRM_BASE_URL: {{ .Values.reconciliation.configmap.PLUGIN_CRM_BASE_URL | default (printf "http://plugin-crm.%s.svc.cluster.local:4003" .Release.Namespace) | quote }}
   PLUGIN_CRM_TIMEOUT: {{ .Values.reconciliation.configmap.PLUGIN_CRM_TIMEOUT | default "30s" | quote }}
-  PLUGIN_AUTH_URL: {{ .Values.reconciliation.configmap.PLUGIN_AUTH_URL | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000/v1/login/oauth/access_token" | quote }}
+  PLUGIN_AUTH_URL: {{ .Values.reconciliation.configmap.PLUGIN_AUTH_URL | default (printf "http://plugin-access-manager-auth.%s.svc.cluster.local:4000/v1/login/oauth/access_token" .Release.Namespace) | quote }}
 
   # Midaz Organization ID
   MIDAZ_ORGANIZATION_ID: {{ .Values.reconciliation.configmap.MIDAZ_ORGANIZATION_ID | default "" | quote }}
 
   # PIX BTG API Configuration
-  PLUGIN_PIX_BTG_BASE_URL: {{ .Values.reconciliation.configmap.PLUGIN_PIX_BTG_BASE_URL | default "http://plugin-br-pix-indirect-btg.midaz-plugins.svc.cluster.local:4014" | quote }}
+  PLUGIN_PIX_BTG_BASE_URL: {{ .Values.reconciliation.configmap.PLUGIN_PIX_BTG_BASE_URL | default (printf "http://plugin-br-pix-indirect-btg.%s.svc.cluster.local:4014" .Release.Namespace) | quote }}
   PLUGIN_PIX_BTG_TIMEOUT: {{ .Values.reconciliation.configmap.PLUGIN_PIX_BTG_TIMEOUT | default "30s" | quote }}
 
   # Circuit Breaker Configuration

--- a/charts/plugin-br-pix-indirect-btg/values-template.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values-template.yaml
@@ -24,16 +24,16 @@ pix:
     tls: []
 
   configmap:
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
-    MONGO_HOST: "plugin-br-pix-indirect-btg-mongodb.midaz-plugins.svc.cluster.local"
+    MONGO_HOST: ""
     MONGO_NAME: "plugin-br-pix-indirect-btg-db"
     MONGO_USER: "pix_btg"
-    REDIS_HOST: "plugin-br-pix-indirect-btg-valkey-master.midaz-plugins.svc.cluster.local"
+    REDIS_HOST: ""
     BTG_BASE_URL: ""
     PIX_ISPB: ""
     MIDAZ_ORGANIZATION_ID: ""
@@ -100,13 +100,13 @@ inbound:
     tls: []
 
   configmap:
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
-    MONGO_HOST: "plugin-br-pix-indirect-btg-mongodb.midaz-plugins.svc.cluster.local"
+    MONGO_HOST: ""
     MONGO_NAME: "plugin-br-pix-indirect-btg-db"
     MONGO_USER: "pix_btg"
 
@@ -145,16 +145,16 @@ outbound:
     tls: []
 
   configmap:
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
-    MONGO_HOST: "plugin-br-pix-indirect-btg-mongodb.midaz-plugins.svc.cluster.local"
+    MONGO_HOST: ""
     MONGO_NAME: "plugin-br-pix-indirect-btg-db"
     MONGO_USER: "pix_btg"
-    REDIS_HOST: "plugin-br-pix-indirect-btg-valkey-master.midaz-plugins.svc.cluster.local"
+    REDIS_HOST: ""
     WEBHOOK_CLIENT_URL: ""
     WEBHOOK_DICT_CLAIM_URL: ""
     WEBHOOK_DICT_INFRACTION_REPORT_URL: ""
@@ -201,13 +201,13 @@ reconciliation:
     tls: []
 
   configmap:
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
-    REDIS_HOST: "plugin-br-pix-indirect-btg-valkey-master.midaz-plugins.svc.cluster.local"
+    REDIS_HOST: ""
     MIDAZ_ORGANIZATION_ID: ""
     BTG_BASE_URL: ""
     RECONCILIATION_START_TIME: ""

--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -110,18 +110,18 @@ pix:
   # @default -- templates/configmap.yaml
   configmap:
     # Database Configuration
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
     # MongoDB Configuration
-    MONGO_HOST: "plugin-br-pix-indirect-btg-mongodb.midaz-plugins.svc.cluster.local"
+    MONGO_HOST: ""
     MONGO_NAME: "plugin-br-pix-indirect-btg-db"
     MONGO_USER: "pix_btg"
     # Redis Configuration
-    REDIS_HOST: "plugin-br-pix-indirect-btg-valkey-master.midaz-plugins.svc.cluster.local"
+    REDIS_HOST: ""
     # External Services
     BTG_BASE_URL: ""
     # Midaz Configuration
@@ -280,14 +280,14 @@ inbound:
   # @default -- templates/configmap.yaml
   configmap:
     # Database Configuration
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
     # MongoDB Configuration
-    MONGO_HOST: "plugin-br-pix-indirect-btg-mongodb.midaz-plugins.svc.cluster.local"
+    MONGO_HOST: ""
     MONGO_NAME: "plugin-br-pix-indirect-btg-db"
     MONGO_USER: "pix_btg"
   # -- Secrets for storing sensitive data
@@ -414,18 +414,18 @@ outbound:
     # Environment
     ENV_NAME: "staging"
     # Database Configuration
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
     # MongoDB Configuration
-    MONGO_HOST: "plugin-br-pix-indirect-btg-mongodb.midaz-plugins.svc.cluster.local"
+    MONGO_HOST: ""
     MONGO_NAME: "plugin-br-pix-indirect-btg-db"
     MONGO_USER: "pix_btg"
     # Redis Configuration
-    REDIS_HOST: "plugin-br-pix-indirect-btg-valkey-master.midaz-plugins.svc.cluster.local"
+    REDIS_HOST: ""
     # Webhook URLs (Client-specific)
     WEBHOOK_DEFAULT_URL: ""
     WEBHOOK_CLIENT_URL: ""
@@ -560,14 +560,14 @@ reconciliation:
   # @default -- templates/configmap.yaml
   configmap:
     # Database Configuration
-    DB_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_HOST: ""
     DB_USER: "pix_btg"
     DB_NAME: "pix_btg"
-    DB_REPLICA_HOST: "plugin-br-pix-indirect-btg-postgresql.midaz-plugins.svc.cluster.local"
+    DB_REPLICA_HOST: ""
     DB_REPLICA_USER: "pix_btg"
     DB_REPLICA_NAME: "pix_btg"
     # Redis Configuration
-    REDIS_HOST: "plugin-br-pix-indirect-btg-valkey-master.midaz-plugins.svc.cluster.local"
+    REDIS_HOST: ""
     # Midaz Configuration
     MIDAZ_ORGANIZATION_ID: ""
     # BTG API Configuration

--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
 
   # Auth Plugin (Access Manager)
   PLUGIN_AUTH_ENABLED: {{ .Values.tracer.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
-  PLUGIN_AUTH_HOST: {{ .Values.tracer.configmap.PLUGIN_AUTH_HOST | default "http://plugin-auth:4000" | quote }}
+  PLUGIN_AUTH_HOST: {{ .Values.tracer.configmap.PLUGIN_AUTH_HOST | default (printf "http://plugin-access-manager-auth.%s.svc.cluster.local:4000" .Release.Namespace) | quote }}
 
   # PostgreSQL Database
   DB_HOST: {{ .Values.tracer.configmap.DB_HOST | default "tracer-postgresql" | quote }}

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -175,7 +175,7 @@ tracer:
 
     # Auth Plugin (Access Manager)
     PLUGIN_AUTH_ENABLED: "false"
-    PLUGIN_AUTH_HOST: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000"
+    PLUGIN_AUTH_HOST: ""
 
     # PostgreSQL Database
     DB_HOST: "tracer-postgresql.tracer.svc.cluster.local."


### PR DESCRIPTION
## What

Replaces all hardcoded `midaz-plugins` and `jd-mock` namespace references in configmap templates with `.Release.Namespace`, and clears stale values.yaml defaults so the template defaults take effect.

### Charts affected

| Chart | Templates | Values |
|-------|-----------|--------|
| plugin-br-pix-direct-jd | 2 configmaps (pix + job): DATABASE_HOST, PLUGIN_AUTH_HOST, CRM_URL, JD_BASE_URL | — |
| plugin-br-pix-indirect-btg | 3 configmaps (pix, reconciliation, inbound): PLUGIN_AUTH_ADDRESS, PLUGIN_CRM_BASE_URL, FEE_SERVICE_URL, WEBHOOK_INBOUND_BASE_URL, PLUGIN_PIX_BTG_BASE_URL, PLUGIN_AUTH_URL | values.yaml + values-template.yaml: cleared DB_HOST, MONGO_HOST, REDIS_HOST (14 refs each) |
| tracer | 1 configmap: PLUGIN_AUTH_HOST (`plugin-auth` → `plugin-access-manager-auth`) | values.yaml: cleared hardcoded namespace |

### Why

The namespace `midaz-plugins` (without env suffix) does not exist in either cluster. All deployed namespaces use the pattern `midaz-plugins-{dev,sandbox,stg,prd}`. Template defaults now resolve correctly via `.Release.Namespace`.

### Context

Part of DSINT-1009 — GitOps Cross-Reference Audit (items 3, 4, 6).