### PR TITLE
feat(templates): add bootstrap-mongodb Jobs for idempotent MongoDB provisioning

### DIFF
--- a/charts/fetcher/templates/bootstrap-mongodb.yaml
+++ b/charts/fetcher/templates/bootstrap-mongodb.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.global.externalMongoDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "fetcher.fullname" . }}-bootstrap-mongodb
+  namespace: {{ include "fetcher.namespace" . }}
+  labels:
+    {{- include "fetcher.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bootstrap
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: mongosh
+        image: mongo:8
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        - name: MONGO_ROOT_USER
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_USER
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.username | quote }}
+          {{- end }}
+        - name: MONGO_ROOT_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.fetcherCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.fetcherCredentials.useExistingSecret.name | quote }}
+              key: MONGO_APP_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.fetcherCredentials.password | quote }}
+          {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Fetcher MongoDB Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          echo "Checking existing MongoDB objects..."
+          USER_EXISTS=0
+
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('fetcher'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+            USER_EXISTS=1
+          fi
+
+          if [ "$USER_EXISTS" = "1" ]; then
+            echo "User 'fetcher' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('fetcher', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('fetcher', [{role: 'readWrite', db: 'fetcher-db'}])"
+          else
+            echo "Creating user 'fetcher'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'fetcher', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'fetcher-db'}]})"
+          fi
+
+          echo ""
+          echo "=== Fetcher MongoDB Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/fetcher/templates/bootstrap-mongodb.yaml
+++ b/charts/fetcher/templates/bootstrap-mongodb.yaml
@@ -76,7 +76,7 @@ spec:
           value: {{ .Values.global.externalMongoDefinitions.fetcherCredentials.password | quote }}
           {{- end }}
         command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - |
           set -euo pipefail

--- a/charts/fetcher/values.yaml
+++ b/charts/fetcher/values.yaml
@@ -4,6 +4,35 @@
 nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: "fetcher"
+
+global:
+  # -- Bootstrap job for external MongoDB: creates users and grants privileges
+  externalMongoDefinitions:
+    # -- Enable or disable the MongoDB bootstrap job
+    enabled: false
+    # -- MongoDB connection settings
+    connection:
+      # -- MongoDB host
+      host: "fetcher-mongodb"
+      # -- MongoDB port
+      port: "27017"
+    # -- Admin credentials for MongoDB (rootUser from bitnami subchart)
+    mongoAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_ROOT_USER and MONGO_ROOT_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "fetcher"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for fetcher user created by the job
+    fetcherCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        name: ""
+      # -- Password for fetcher user (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
 # Manager component - REST API service
 manager:
   name: "fetcher-manager"

--- a/charts/flowker/templates/bootstrap-mongodb.yaml
+++ b/charts/flowker/templates/bootstrap-mongodb.yaml
@@ -75,7 +75,7 @@ spec:
           value: {{ .Values.global.externalMongoDefinitions.flowkerCredentials.password | quote }}
           {{- end }}
         command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - |
           set -euo pipefail

--- a/charts/flowker/templates/bootstrap-mongodb.yaml
+++ b/charts/flowker/templates/bootstrap-mongodb.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.global.externalMongoDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "flowker.fullname" . }}-bootstrap-mongodb
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "flowker.labels" (dict "context" . "component" "bootstrap" "name" "mongodb") | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: mongosh
+        image: mongo:8
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        - name: MONGO_ROOT_USER
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_USER
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.username | quote }}
+          {{- end }}
+        - name: MONGO_ROOT_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.flowkerCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.flowkerCredentials.useExistingSecret.name | quote }}
+              key: MONGO_APP_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.flowkerCredentials.password | quote }}
+          {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Flowker MongoDB Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          echo "Checking existing MongoDB objects..."
+          USER_EXISTS=0
+
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('flowker'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+            USER_EXISTS=1
+          fi
+
+          if [ "$USER_EXISTS" = "1" ]; then
+            echo "User 'flowker' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('flowker', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('flowker', [{role: 'readWrite', db: 'flowker'}])"
+          else
+            echo "Creating user 'flowker'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'flowker', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'flowker'}]})"
+          fi
+
+          echo ""
+          echo "=== Flowker MongoDB Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -5,6 +5,34 @@ nameOverride: "flowker"
 fullnameOverride: ""
 namespaceOverride: "flowker"
 
+global:
+  # -- Bootstrap job for external MongoDB: creates users and grants privileges
+  externalMongoDefinitions:
+    # -- Enable or disable the MongoDB bootstrap job
+    enabled: false
+    # -- MongoDB connection settings
+    connection:
+      # -- MongoDB host
+      host: "flowker-mongodb"
+      # -- MongoDB port
+      port: "27017"
+    # -- Admin credentials for MongoDB (rootUser from bitnami subchart)
+    mongoAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_ROOT_USER and MONGO_ROOT_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "flowker"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for flowker user created by the job
+    flowkerCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        name: ""
+      # -- Password for flowker user (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
 flowker:
   # -- Service name
   name: flowker

--- a/charts/midaz/templates/bootstrap-mongodb.yaml
+++ b/charts/midaz/templates/bootstrap-mongodb.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.global.externalMongoDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: midaz-bootstrap-mongodb
+  namespace: {{ .Release.Namespace }}
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: mongosh
+        image: mongo:8
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        - name: MONGO_ROOT_USER
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_USER
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.username | quote }}
+          {{- end }}
+        - name: MONGO_ROOT_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.midazCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.midazCredentials.useExistingSecret.name | quote }}
+              key: MONGO_APP_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.midazCredentials.password | quote }}
+          {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Midaz MongoDB Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          echo "Checking existing MongoDB objects..."
+          USER_EXISTS=0
+
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('midaz'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+            USER_EXISTS=1
+          fi
+
+          if [ "$USER_EXISTS" = "1" ]; then
+            echo "User 'midaz' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('midaz', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('midaz', [{role: 'readWrite', db: 'onboarding'}, {role: 'readWrite', db: 'transaction'}, {role: 'readWrite', db: 'crm'}])"
+          else
+            echo "Creating user 'midaz'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'midaz', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'onboarding'}, {role: 'readWrite', db: 'transaction'}, {role: 'readWrite', db: 'crm'}]})"
+          fi
+
+          echo ""
+          echo "=== Midaz MongoDB Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/midaz/templates/bootstrap-mongodb.yaml
+++ b/charts/midaz/templates/bootstrap-mongodb.yaml
@@ -73,7 +73,7 @@ spec:
           value: {{ .Values.global.externalMongoDefinitions.midazCredentials.password | quote }}
           {{- end }}
         command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - |
           set -euo pipefail

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -67,6 +67,33 @@ global:
       # -- Password for midaz role (ignored if useExistingSecret.name is set)
       password: "lerian"
 
+  # -- Bootstrap job for external MongoDB: creates users and grants privileges
+  externalMongoDefinitions:
+    # -- Enable or disable the MongoDB bootstrap job
+    enabled: false
+    # -- MongoDB connection settings
+    connection:
+      # -- MongoDB host
+      host: "midaz-mongodb"
+      # -- MongoDB port
+      port: "27017"
+    # -- Admin credentials for MongoDB (rootUser from bitnami subchart)
+    mongoAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_ROOT_USER and MONGO_ROOT_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "midaz"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for midaz user created by the job
+    midazCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        name: ""
+      # -- Password for midaz user (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
 onboarding:
   # -- Service name
   name: onboarding

--- a/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.global.externalMongoDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "plugin-br-pix-indirect-btg.fullname" . }}-bootstrap-mongodb
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-indirect-btg.labels" (dict "context" . "name" "bootstrap-mongodb") | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: mongosh
+        image: mongo:8
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        - name: MONGO_ROOT_USER
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_USER
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.username | quote }}
+          {{- end }}
+        - name: MONGO_ROOT_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.pixBtgCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.pixBtgCredentials.useExistingSecret.name | quote }}
+              key: MONGO_APP_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.pixBtgCredentials.password | quote }}
+          {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Plugin BR PIX Indirect BTG MongoDB Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          echo "Checking existing MongoDB objects..."
+          USER_EXISTS=0
+
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('pix_btg'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+            USER_EXISTS=1
+          fi
+
+          if [ "$USER_EXISTS" = "1" ]; then
+            echo "User 'pix_btg' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('pix_btg', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('pix_btg', [{role: 'readWrite', db: 'plugin-br-pix-indirect-btg-db'}])"
+          else
+            echo "Creating user 'pix_btg'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'pix_btg', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'plugin-br-pix-indirect-btg-db'}]})"
+          fi
+
+          echo ""
+          echo "=== Plugin BR PIX Indirect BTG MongoDB Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
@@ -75,7 +75,7 @@ spec:
           value: {{ .Values.global.externalMongoDefinitions.pixBtgCredentials.password | quote }}
           {{- end }}
         command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - |
           set -euo pipefail

--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -2,6 +2,34 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # -- Bootstrap job for external MongoDB: creates users and grants privileges
+  externalMongoDefinitions:
+    # -- Enable or disable the MongoDB bootstrap job
+    enabled: false
+    # -- MongoDB connection settings
+    connection:
+      # -- MongoDB host
+      host: "plugin-br-pix-indirect-btg-mongodb"
+      # -- MongoDB port
+      port: "27017"
+    # -- Admin credentials for MongoDB (rootUser from bitnami subchart)
+    mongoAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_ROOT_USER and MONGO_ROOT_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "pix_btg"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for pix_btg user created by the job
+    pixBtgCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        name: ""
+      # -- Password for pix_btg user (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
 pix:
   replicaCount: 1
   name: "plugin-br-pix-indirect-btg"

--- a/charts/plugin-fees/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-fees/templates/bootstrap-mongodb.yaml
@@ -75,7 +75,7 @@ spec:
           value: {{ .Values.global.externalMongoDefinitions.pluginFeesCredentials.password | quote }}
           {{- end }}
         command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - |
           set -euo pipefail

--- a/charts/plugin-fees/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-fees/templates/bootstrap-mongodb.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.global.externalMongoDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "plugin-fees.fullname" . }}-bootstrap-mongodb
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-fees.labels" (dict "context" . "name" "bootstrap-mongodb") | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: mongosh
+        image: mongo:8
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        - name: MONGO_ROOT_USER
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_USER
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.username | quote }}
+          {{- end }}
+        - name: MONGO_ROOT_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.pluginFeesCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.pluginFeesCredentials.useExistingSecret.name | quote }}
+              key: MONGO_APP_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.pluginFeesCredentials.password | quote }}
+          {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Plugin Fees MongoDB Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          echo "Checking existing MongoDB objects..."
+          USER_EXISTS=0
+
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('plugin-fees'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+            USER_EXISTS=1
+          fi
+
+          if [ "$USER_EXISTS" = "1" ]; then
+            echo "User 'plugin-fees' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('plugin-fees', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('plugin-fees', [{role: 'readWrite', db: 'plugin-fees-db'}])"
+          else
+            echo "Creating user 'plugin-fees'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'plugin-fees', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'plugin-fees-db'}]})"
+          fi
+
+          echo ""
+          echo "=== Plugin Fees MongoDB Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -1,6 +1,35 @@
 # Default values
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+global:
+  # -- Bootstrap job for external MongoDB: creates users and grants privileges
+  externalMongoDefinitions:
+    # -- Enable or disable the MongoDB bootstrap job
+    enabled: false
+    # -- MongoDB connection settings
+    connection:
+      # -- MongoDB host
+      host: "plugin-fees-mongodb"
+      # -- MongoDB port
+      port: "27017"
+    # -- Admin credentials for MongoDB (rootUser from bitnami subchart)
+    mongoAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_ROOT_USER and MONGO_ROOT_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "plugin-fees"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for plugin-fees user created by the job
+    pluginFeesCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        name: ""
+      # -- Password for plugin-fees user (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
 fees:
   replicaCount: 1
   name: "plugin-fees"

--- a/charts/product-console/templates/bootstrap-mongodb.yaml
+++ b/charts/product-console/templates/bootstrap-mongodb.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.global.externalMongoDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "product-console.fullname" . }}-bootstrap-mongodb
+  namespace: {{ include "product-console.namespace" . }}
+  labels:
+    {{- include "product-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bootstrap
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: mongosh
+        image: mongo:8
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        - name: MONGO_ROOT_USER
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_USER
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.username | quote }}
+          {{- end }}
+        - name: MONGO_ROOT_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.consoleCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.consoleCredentials.useExistingSecret.name | quote }}
+              key: MONGO_APP_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.consoleCredentials.password | quote }}
+          {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Product Console MongoDB Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          echo "Checking existing MongoDB objects..."
+          USER_EXISTS=0
+
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('midaz'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+            USER_EXISTS=1
+          fi
+
+          if [ "$USER_EXISTS" = "1" ]; then
+            echo "User 'midaz' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('midaz', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('midaz', [{role: 'readWrite', db: 'midaz-console'}])"
+          else
+            echo "Creating user 'midaz'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'midaz', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'midaz-console'}]})"
+          fi
+
+          echo ""
+          echo "=== Product Console MongoDB Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/product-console/templates/bootstrap-mongodb.yaml
+++ b/charts/product-console/templates/bootstrap-mongodb.yaml
@@ -76,7 +76,7 @@ spec:
           value: {{ .Values.global.externalMongoDefinitions.consoleCredentials.password | quote }}
           {{- end }}
         command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - |
           set -euo pipefail

--- a/charts/product-console/values.yaml
+++ b/charts/product-console/values.yaml
@@ -27,6 +27,34 @@ fullnameOverride: ""
 # -- Override the namespace
 namespaceOverride: "product-console"
 
+global:
+  # -- Bootstrap job for external MongoDB: creates users and grants privileges
+  externalMongoDefinitions:
+    # -- Enable or disable the MongoDB bootstrap job
+    enabled: false
+    # -- MongoDB connection settings
+    connection:
+      # -- MongoDB host
+      host: "product-console-mongodb"
+      # -- MongoDB port
+      port: "27017"
+    # -- Admin credentials for MongoDB (rootUser from bitnami subchart)
+    mongoAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_ROOT_USER and MONGO_ROOT_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "midaz"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for midaz user (product-console) created by the job
+    consoleCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        name: ""
+      # -- Password for midaz user (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
 # -- Annotations to be added to the Pod
 podAnnotations: {}
 

--- a/charts/reporter/templates/bootstrap-mongodb.yaml
+++ b/charts/reporter/templates/bootstrap-mongodb.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.global.externalMongoDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: reporter-bootstrap-mongodb
+  namespace: {{ include "global.namespace" . }}
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: mongosh
+        image: mongo:8
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalMongoDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalMongoDefinitions.connection.port | quote }}
+        - name: MONGO_ROOT_USER
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_USER
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.username | quote }}
+          {{- end }}
+        - name: MONGO_ROOT_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.useExistingSecret.name | quote }}
+              key: MONGO_ROOT_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if .Values.global.externalMongoDefinitions.reporterCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalMongoDefinitions.reporterCredentials.useExistingSecret.name | quote }}
+              key: MONGO_APP_PASSWORD
+          {{- else }}
+          value: {{ .Values.global.externalMongoDefinitions.reporterCredentials.password | quote }}
+          {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Reporter MongoDB Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          echo "Checking existing MongoDB objects..."
+          USER_EXISTS=0
+
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('reporter'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+            USER_EXISTS=1
+          fi
+
+          if [ "$USER_EXISTS" = "1" ]; then
+            echo "User 'reporter' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('reporter', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('reporter', [{role: 'readWrite', db: 'reporter-db'}])"
+          else
+            echo "Creating user 'reporter'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'reporter', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'reporter-db'}]})"
+          fi
+
+          echo ""
+          echo "=== Reporter MongoDB Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/reporter/templates/bootstrap-mongodb.yaml
+++ b/charts/reporter/templates/bootstrap-mongodb.yaml
@@ -73,7 +73,7 @@ spec:
           value: {{ .Values.global.externalMongoDefinitions.reporterCredentials.password | quote }}
           {{- end }}
         command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - |
           set -euo pipefail

--- a/charts/reporter/values.yaml
+++ b/charts/reporter/values.yaml
@@ -2,6 +2,34 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # -- Bootstrap job for external MongoDB: creates users and grants privileges
+  externalMongoDefinitions:
+    # -- Enable or disable the MongoDB bootstrap job
+    enabled: false
+    # -- MongoDB connection settings
+    connection:
+      # -- MongoDB host
+      host: "reporter-mongodb"
+      # -- MongoDB port
+      port: "27017"
+    # -- Admin credentials for MongoDB (rootUser from bitnami subchart)
+    mongoAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_ROOT_USER and MONGO_ROOT_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "reporter"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for reporter user created by the job
+    reporterCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        name: ""
+      # -- Password for reporter user (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
 manager:
   name: "reporter-manager"
   # -- Number of old ReplicaSets to retain for deployment rollback


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Midaz
- [x] Reporter
- [x] Plugin Fees
- [x] Plugin BR PIX Indirect BTG
- [x] Fetcher
- [x] Flowker

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Add `bootstrap-mongodb.yaml` Job templates to 7 charts (midaz, fetcher, flowker, plugin-br-pix-indirect-btg, plugin-fees, product-console, reporter) following the same pattern as existing `bootstrap-postgres.yaml` Jobs.

Each Job uses `mongosh` (image `mongo:8`) to idempotently create app users with `readWrite` roles on the chart's databases, running on every ArgoCD sync. Controlled by `global.externalMongoDefinitions.enabled` (default: `false`). Supports `useExistingSecret` for Vault-managed credentials.

| Chart | Database(s) | App User |
|---|---|---|
| midaz | onboarding, transaction, crm | midaz |
| fetcher | fetcher-db | fetcher |
| flowker | flowker | flowker |
| plugin-br-pix-indirect-btg | plugin-br-pix-indirect-btg-db | pix_btg |
| plugin-fees | plugin-fees-db | plugin-fees |
| product-console | midaz-console | midaz |
| reporter | reporter-db | reporter |