### PR TITLE
feat(templates): make app user and roles configurable

### DIFF
--- a/charts/fetcher/templates/bootstrap-mongodb.yaml
+++ b/charts/fetcher/templates/bootstrap-mongodb.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
 {{- $creds := .Values.global.externalMongoDefinitions.fetcherCredentials -}}
-{{- $rolesList := list -}}
-{{- range $creds.roles -}}
-{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
-{{- end -}}
-{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
+{{- $rolesJSON := toJson $creds.roles -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -90,6 +86,8 @@ spec:
           {{- else }}
           value: {{ $creds.password | quote }}
           {{- end }}
+        - name: ROLES_JSON
+          value: {{ $rolesJSON | quote }}
         command:
         - /bin/bash
         - -c
@@ -100,22 +98,19 @@ spec:
           echo "App user: $MONGO_APP_USER"
           echo ""
 
-          ROLES={{ $rolesJSON | quote }}
-
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'if (db.getSiblingDB("admin").getUser(process.env.MONGO_APP_USER) !== null) { print("EXISTS"); }' | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and replacing roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").updateUser(process.env.MONGO_APP_USER, {pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           else
             echo "Creating user '$MONGO_APP_USER'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").createUser({user: process.env.MONGO_APP_USER, pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           fi
 
           echo ""

--- a/charts/fetcher/templates/bootstrap-mongodb.yaml
+++ b/charts/fetcher/templates/bootstrap-mongodb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
+{{- $creds := .Values.global.externalMongoDefinitions.fetcherCredentials -}}
+{{- $rolesList := list -}}
+{{- range $creds.roles -}}
+{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
+{{- end -}}
+{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -66,14 +72,23 @@ spec:
           {{- else }}
           value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
           {{- end }}
-        - name: MONGO_APP_PASSWORD
-          {{- if .Values.global.externalMongoDefinitions.fetcherCredentials.useExistingSecret.name }}
+        - name: MONGO_APP_USER
+          {{- if $creds.useExistingSecret.name }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.externalMongoDefinitions.fetcherCredentials.useExistingSecret.name | quote }}
+              name: {{ $creds.useExistingSecret.name | quote }}
+              key: MONGO_APP_USER
+          {{- else }}
+          value: {{ $creds.username | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if $creds.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $creds.useExistingSecret.name | quote }}
               key: MONGO_APP_PASSWORD
           {{- else }}
-          value: {{ .Values.global.externalMongoDefinitions.fetcherCredentials.password | quote }}
+          value: {{ $creds.password | quote }}
           {{- end }}
         command:
         - /bin/bash
@@ -82,22 +97,25 @@ spec:
           set -euo pipefail
           echo "=== Fetcher MongoDB Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT"
+          echo "App user: $MONGO_APP_USER"
           echo ""
+
+          ROLES={{ $rolesJSON | quote }}
 
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('fetcher'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User 'fetcher' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('fetcher', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('fetcher', [{role: 'readWrite', db: 'fetcher-db'}])"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
           else
-            echo "Creating user 'fetcher'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'fetcher', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'fetcher-db'}]})"
+            echo "Creating user '$MONGO_APP_USER'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
           fi
 
           echo ""

--- a/charts/fetcher/values.yaml
+++ b/charts/fetcher/values.yaml
@@ -28,10 +28,16 @@ global:
     # -- Credentials for fetcher user created by the job
     fetcherCredentials:
       useExistingSecret:
-        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        # -- Name of existing secret containing MONGO_APP_USER and MONGO_APP_PASSWORD keys
         name: ""
+      # -- App username (ignored if useExistingSecret.name is set)
+      username: "fetcher"
       # -- Password for fetcher user (ignored if useExistingSecret.name is set)
       password: "lerian"
+      # -- List of roles to grant to the user. Each item is a {role, db} pair.
+      roles:
+        - role: "readWrite"
+          db: "fetcher-db"
 
 # Manager component - REST API service
 manager:

--- a/charts/flowker/templates/bootstrap-mongodb.yaml
+++ b/charts/flowker/templates/bootstrap-mongodb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
+{{- $creds := .Values.global.externalMongoDefinitions.flowkerCredentials -}}
+{{- $rolesList := list -}}
+{{- range $creds.roles -}}
+{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
+{{- end -}}
+{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -65,14 +71,23 @@ spec:
           {{- else }}
           value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
           {{- end }}
-        - name: MONGO_APP_PASSWORD
-          {{- if .Values.global.externalMongoDefinitions.flowkerCredentials.useExistingSecret.name }}
+        - name: MONGO_APP_USER
+          {{- if $creds.useExistingSecret.name }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.externalMongoDefinitions.flowkerCredentials.useExistingSecret.name | quote }}
+              name: {{ $creds.useExistingSecret.name | quote }}
+              key: MONGO_APP_USER
+          {{- else }}
+          value: {{ $creds.username | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if $creds.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $creds.useExistingSecret.name | quote }}
               key: MONGO_APP_PASSWORD
           {{- else }}
-          value: {{ .Values.global.externalMongoDefinitions.flowkerCredentials.password | quote }}
+          value: {{ $creds.password | quote }}
           {{- end }}
         command:
         - /bin/bash
@@ -81,22 +96,25 @@ spec:
           set -euo pipefail
           echo "=== Flowker MongoDB Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT"
+          echo "App user: $MONGO_APP_USER"
           echo ""
+
+          ROLES={{ $rolesJSON | quote }}
 
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('flowker'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User 'flowker' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('flowker', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('flowker', [{role: 'readWrite', db: 'flowker'}])"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
           else
-            echo "Creating user 'flowker'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'flowker', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'flowker'}]})"
+            echo "Creating user '$MONGO_APP_USER'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
           fi
 
           echo ""

--- a/charts/flowker/templates/bootstrap-mongodb.yaml
+++ b/charts/flowker/templates/bootstrap-mongodb.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
 {{- $creds := .Values.global.externalMongoDefinitions.flowkerCredentials -}}
-{{- $rolesList := list -}}
-{{- range $creds.roles -}}
-{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
-{{- end -}}
-{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
+{{- $rolesJSON := toJson $creds.roles -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -89,6 +85,8 @@ spec:
           {{- else }}
           value: {{ $creds.password | quote }}
           {{- end }}
+        - name: ROLES_JSON
+          value: {{ $rolesJSON | quote }}
         command:
         - /bin/bash
         - -c
@@ -99,22 +97,19 @@ spec:
           echo "App user: $MONGO_APP_USER"
           echo ""
 
-          ROLES={{ $rolesJSON | quote }}
-
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'if (db.getSiblingDB("admin").getUser(process.env.MONGO_APP_USER) !== null) { print("EXISTS"); }' | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and replacing roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").updateUser(process.env.MONGO_APP_USER, {pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           else
             echo "Creating user '$MONGO_APP_USER'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").createUser({user: process.env.MONGO_APP_USER, pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           fi
 
           echo ""

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -28,10 +28,16 @@ global:
     # -- Credentials for flowker user created by the job
     flowkerCredentials:
       useExistingSecret:
-        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        # -- Name of existing secret containing MONGO_APP_USER and MONGO_APP_PASSWORD keys
         name: ""
+      # -- App username (ignored if useExistingSecret.name is set)
+      username: "flowker"
       # -- Password for flowker user (ignored if useExistingSecret.name is set)
       password: "lerian"
+      # -- List of roles to grant to the user. Each item is a {role, db} pair.
+      roles:
+        - role: "readWrite"
+          db: "flowker"
 
 flowker:
   # -- Service name

--- a/charts/midaz/templates/bootstrap-mongodb.yaml
+++ b/charts/midaz/templates/bootstrap-mongodb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
+{{- $creds := .Values.global.externalMongoDefinitions.midazCredentials -}}
+{{- $rolesList := list -}}
+{{- range $creds.roles -}}
+{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
+{{- end -}}
+{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -63,14 +69,23 @@ spec:
           {{- else }}
           value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
           {{- end }}
-        - name: MONGO_APP_PASSWORD
-          {{- if .Values.global.externalMongoDefinitions.midazCredentials.useExistingSecret.name }}
+        - name: MONGO_APP_USER
+          {{- if $creds.useExistingSecret.name }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.externalMongoDefinitions.midazCredentials.useExistingSecret.name | quote }}
+              name: {{ $creds.useExistingSecret.name | quote }}
+              key: MONGO_APP_USER
+          {{- else }}
+          value: {{ $creds.username | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if $creds.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $creds.useExistingSecret.name | quote }}
               key: MONGO_APP_PASSWORD
           {{- else }}
-          value: {{ .Values.global.externalMongoDefinitions.midazCredentials.password | quote }}
+          value: {{ $creds.password | quote }}
           {{- end }}
         command:
         - /bin/bash
@@ -79,22 +94,25 @@ spec:
           set -euo pipefail
           echo "=== Midaz MongoDB Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT"
+          echo "App user: $MONGO_APP_USER"
           echo ""
+
+          ROLES={{ $rolesJSON | quote }}
 
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('midaz'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User 'midaz' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('midaz', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('midaz', [{role: 'readWrite', db: 'onboarding'}, {role: 'readWrite', db: 'transaction'}, {role: 'readWrite', db: 'crm'}])"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
           else
-            echo "Creating user 'midaz'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'midaz', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'onboarding'}, {role: 'readWrite', db: 'transaction'}, {role: 'readWrite', db: 'crm'}]})"
+            echo "Creating user '$MONGO_APP_USER'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
           fi
 
           echo ""

--- a/charts/midaz/templates/bootstrap-mongodb.yaml
+++ b/charts/midaz/templates/bootstrap-mongodb.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
 {{- $creds := .Values.global.externalMongoDefinitions.midazCredentials -}}
-{{- $rolesList := list -}}
-{{- range $creds.roles -}}
-{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
-{{- end -}}
-{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
+{{- $rolesJSON := toJson $creds.roles -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -87,6 +83,8 @@ spec:
           {{- else }}
           value: {{ $creds.password | quote }}
           {{- end }}
+        - name: ROLES_JSON
+          value: {{ $rolesJSON | quote }}
         command:
         - /bin/bash
         - -c
@@ -97,22 +95,19 @@ spec:
           echo "App user: $MONGO_APP_USER"
           echo ""
 
-          ROLES={{ $rolesJSON | quote }}
-
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'if (db.getSiblingDB("admin").getUser(process.env.MONGO_APP_USER) !== null) { print("EXISTS"); }' | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and replacing roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").updateUser(process.env.MONGO_APP_USER, {pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           else
             echo "Creating user '$MONGO_APP_USER'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").createUser({user: process.env.MONGO_APP_USER, pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           fi
 
           echo ""

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -89,10 +89,20 @@ global:
     # -- Credentials for midaz user created by the job
     midazCredentials:
       useExistingSecret:
-        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        # -- Name of existing secret containing MONGO_APP_USER and MONGO_APP_PASSWORD keys
         name: ""
+      # -- App username (ignored if useExistingSecret.name is set)
+      username: "midaz"
       # -- Password for midaz user (ignored if useExistingSecret.name is set)
       password: "lerian"
+      # -- List of roles to grant to the user. Each item is a {role, db} pair.
+      roles:
+        - role: "readWrite"
+          db: "onboarding"
+        - role: "readWrite"
+          db: "transaction"
+        - role: "readWrite"
+          db: "crm"
 
 onboarding:
   # -- Service name

--- a/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
 {{- $creds := .Values.global.externalMongoDefinitions.pixBtgCredentials -}}
-{{- $rolesList := list -}}
-{{- range $creds.roles -}}
-{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
-{{- end -}}
-{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
+{{- $rolesJSON := toJson $creds.roles -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -89,6 +85,8 @@ spec:
           {{- else }}
           value: {{ $creds.password | quote }}
           {{- end }}
+        - name: ROLES_JSON
+          value: {{ $rolesJSON | quote }}
         command:
         - /bin/bash
         - -c
@@ -99,22 +97,19 @@ spec:
           echo "App user: $MONGO_APP_USER"
           echo ""
 
-          ROLES={{ $rolesJSON | quote }}
-
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'if (db.getSiblingDB("admin").getUser(process.env.MONGO_APP_USER) !== null) { print("EXISTS"); }' | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and replacing roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").updateUser(process.env.MONGO_APP_USER, {pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           else
             echo "Creating user '$MONGO_APP_USER'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").createUser({user: process.env.MONGO_APP_USER, pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           fi
 
           echo ""

--- a/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/bootstrap-mongodb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
+{{- $creds := .Values.global.externalMongoDefinitions.pixBtgCredentials -}}
+{{- $rolesList := list -}}
+{{- range $creds.roles -}}
+{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
+{{- end -}}
+{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -65,14 +71,23 @@ spec:
           {{- else }}
           value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
           {{- end }}
-        - name: MONGO_APP_PASSWORD
-          {{- if .Values.global.externalMongoDefinitions.pixBtgCredentials.useExistingSecret.name }}
+        - name: MONGO_APP_USER
+          {{- if $creds.useExistingSecret.name }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.externalMongoDefinitions.pixBtgCredentials.useExistingSecret.name | quote }}
+              name: {{ $creds.useExistingSecret.name | quote }}
+              key: MONGO_APP_USER
+          {{- else }}
+          value: {{ $creds.username | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if $creds.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $creds.useExistingSecret.name | quote }}
               key: MONGO_APP_PASSWORD
           {{- else }}
-          value: {{ .Values.global.externalMongoDefinitions.pixBtgCredentials.password | quote }}
+          value: {{ $creds.password | quote }}
           {{- end }}
         command:
         - /bin/bash
@@ -81,22 +96,25 @@ spec:
           set -euo pipefail
           echo "=== Plugin BR PIX Indirect BTG MongoDB Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT"
+          echo "App user: $MONGO_APP_USER"
           echo ""
+
+          ROLES={{ $rolesJSON | quote }}
 
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('pix_btg'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User 'pix_btg' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('pix_btg', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('pix_btg', [{role: 'readWrite', db: 'plugin-br-pix-indirect-btg-db'}])"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
           else
-            echo "Creating user 'pix_btg'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'pix_btg', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'plugin-br-pix-indirect-btg-db'}]})"
+            echo "Creating user '$MONGO_APP_USER'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
           fi
 
           echo ""

--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -25,10 +25,16 @@ global:
     # -- Credentials for pix_btg user created by the job
     pixBtgCredentials:
       useExistingSecret:
-        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        # -- Name of existing secret containing MONGO_APP_USER and MONGO_APP_PASSWORD keys
         name: ""
+      # -- App username (ignored if useExistingSecret.name is set)
+      username: "pix_btg"
       # -- Password for pix_btg user (ignored if useExistingSecret.name is set)
       password: "lerian"
+      # -- List of roles to grant to the user. Each item is a {role, db} pair.
+      roles:
+        - role: "readWrite"
+          db: "plugin-br-pix-indirect-btg-db"
 
 pix:
   replicaCount: 1

--- a/charts/plugin-fees/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-fees/templates/bootstrap-mongodb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
+{{- $creds := .Values.global.externalMongoDefinitions.pluginFeesCredentials -}}
+{{- $rolesList := list -}}
+{{- range $creds.roles -}}
+{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
+{{- end -}}
+{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -65,14 +71,23 @@ spec:
           {{- else }}
           value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
           {{- end }}
-        - name: MONGO_APP_PASSWORD
-          {{- if .Values.global.externalMongoDefinitions.pluginFeesCredentials.useExistingSecret.name }}
+        - name: MONGO_APP_USER
+          {{- if $creds.useExistingSecret.name }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.externalMongoDefinitions.pluginFeesCredentials.useExistingSecret.name | quote }}
+              name: {{ $creds.useExistingSecret.name | quote }}
+              key: MONGO_APP_USER
+          {{- else }}
+          value: {{ $creds.username | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if $creds.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $creds.useExistingSecret.name | quote }}
               key: MONGO_APP_PASSWORD
           {{- else }}
-          value: {{ .Values.global.externalMongoDefinitions.pluginFeesCredentials.password | quote }}
+          value: {{ $creds.password | quote }}
           {{- end }}
         command:
         - /bin/bash
@@ -81,22 +96,25 @@ spec:
           set -euo pipefail
           echo "=== Plugin Fees MongoDB Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT"
+          echo "App user: $MONGO_APP_USER"
           echo ""
+
+          ROLES={{ $rolesJSON | quote }}
 
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('plugin-fees'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User 'plugin-fees' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('plugin-fees', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('plugin-fees', [{role: 'readWrite', db: 'plugin-fees-db'}])"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
           else
-            echo "Creating user 'plugin-fees'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'plugin-fees', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'plugin-fees-db'}]})"
+            echo "Creating user '$MONGO_APP_USER'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
           fi
 
           echo ""

--- a/charts/plugin-fees/templates/bootstrap-mongodb.yaml
+++ b/charts/plugin-fees/templates/bootstrap-mongodb.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
 {{- $creds := .Values.global.externalMongoDefinitions.pluginFeesCredentials -}}
-{{- $rolesList := list -}}
-{{- range $creds.roles -}}
-{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
-{{- end -}}
-{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
+{{- $rolesJSON := toJson $creds.roles -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -89,6 +85,8 @@ spec:
           {{- else }}
           value: {{ $creds.password | quote }}
           {{- end }}
+        - name: ROLES_JSON
+          value: {{ $rolesJSON | quote }}
         command:
         - /bin/bash
         - -c
@@ -99,22 +97,19 @@ spec:
           echo "App user: $MONGO_APP_USER"
           echo ""
 
-          ROLES={{ $rolesJSON | quote }}
-
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'if (db.getSiblingDB("admin").getUser(process.env.MONGO_APP_USER) !== null) { print("EXISTS"); }' | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and replacing roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").updateUser(process.env.MONGO_APP_USER, {pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           else
             echo "Creating user '$MONGO_APP_USER'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").createUser({user: process.env.MONGO_APP_USER, pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           fi
 
           echo ""

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -25,10 +25,16 @@ global:
     # -- Credentials for plugin-fees user created by the job
     pluginFeesCredentials:
       useExistingSecret:
-        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        # -- Name of existing secret containing MONGO_APP_USER and MONGO_APP_PASSWORD keys
         name: ""
+      # -- App username (ignored if useExistingSecret.name is set)
+      username: "plugin-fees"
       # -- Password for plugin-fees user (ignored if useExistingSecret.name is set)
       password: "lerian"
+      # -- List of roles to grant to the user. Each item is a {role, db} pair.
+      roles:
+        - role: "readWrite"
+          db: "plugin-fees-db"
 
 fees:
   replicaCount: 1

--- a/charts/product-console/templates/bootstrap-mongodb.yaml
+++ b/charts/product-console/templates/bootstrap-mongodb.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
 {{- $creds := .Values.global.externalMongoDefinitions.consoleCredentials -}}
-{{- $rolesList := list -}}
-{{- range $creds.roles -}}
-{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
-{{- end -}}
-{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
+{{- $rolesJSON := toJson $creds.roles -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -90,6 +86,8 @@ spec:
           {{- else }}
           value: {{ $creds.password | quote }}
           {{- end }}
+        - name: ROLES_JSON
+          value: {{ $rolesJSON | quote }}
         command:
         - /bin/bash
         - -c
@@ -100,22 +98,19 @@ spec:
           echo "App user: $MONGO_APP_USER"
           echo ""
 
-          ROLES={{ $rolesJSON | quote }}
-
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'if (db.getSiblingDB("admin").getUser(process.env.MONGO_APP_USER) !== null) { print("EXISTS"); }' | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and replacing roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").updateUser(process.env.MONGO_APP_USER, {pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           else
             echo "Creating user '$MONGO_APP_USER'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").createUser({user: process.env.MONGO_APP_USER, pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           fi
 
           echo ""

--- a/charts/product-console/templates/bootstrap-mongodb.yaml
+++ b/charts/product-console/templates/bootstrap-mongodb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
+{{- $creds := .Values.global.externalMongoDefinitions.consoleCredentials -}}
+{{- $rolesList := list -}}
+{{- range $creds.roles -}}
+{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
+{{- end -}}
+{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -66,14 +72,23 @@ spec:
           {{- else }}
           value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
           {{- end }}
-        - name: MONGO_APP_PASSWORD
-          {{- if .Values.global.externalMongoDefinitions.consoleCredentials.useExistingSecret.name }}
+        - name: MONGO_APP_USER
+          {{- if $creds.useExistingSecret.name }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.externalMongoDefinitions.consoleCredentials.useExistingSecret.name | quote }}
+              name: {{ $creds.useExistingSecret.name | quote }}
+              key: MONGO_APP_USER
+          {{- else }}
+          value: {{ $creds.username | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if $creds.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $creds.useExistingSecret.name | quote }}
               key: MONGO_APP_PASSWORD
           {{- else }}
-          value: {{ .Values.global.externalMongoDefinitions.consoleCredentials.password | quote }}
+          value: {{ $creds.password | quote }}
           {{- end }}
         command:
         - /bin/bash
@@ -82,22 +97,25 @@ spec:
           set -euo pipefail
           echo "=== Product Console MongoDB Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT"
+          echo "App user: $MONGO_APP_USER"
           echo ""
+
+          ROLES={{ $rolesJSON | quote }}
 
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('midaz'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User 'midaz' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('midaz', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('midaz', [{role: 'readWrite', db: 'midaz-console'}])"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
           else
-            echo "Creating user 'midaz'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'midaz', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'midaz-console'}]})"
+            echo "Creating user '$MONGO_APP_USER'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
           fi
 
           echo ""

--- a/charts/product-console/values.yaml
+++ b/charts/product-console/values.yaml
@@ -50,10 +50,16 @@ global:
     # -- Credentials for midaz user (product-console) created by the job
     consoleCredentials:
       useExistingSecret:
-        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        # -- Name of existing secret containing MONGO_APP_USER and MONGO_APP_PASSWORD keys
         name: ""
+      # -- App username (ignored if useExistingSecret.name is set)
+      username: "midaz"
       # -- Password for midaz user (ignored if useExistingSecret.name is set)
       password: "lerian"
+      # -- List of roles to grant to the user. Each item is a {role, db} pair.
+      roles:
+        - role: "readWrite"
+          db: "midaz-console"
 
 # -- Annotations to be added to the Pod
 podAnnotations: {}

--- a/charts/reporter/templates/bootstrap-mongodb.yaml
+++ b/charts/reporter/templates/bootstrap-mongodb.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
 {{- $creds := .Values.global.externalMongoDefinitions.reporterCredentials -}}
-{{- $rolesList := list -}}
-{{- range $creds.roles -}}
-{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
-{{- end -}}
-{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
+{{- $rolesJSON := toJson $creds.roles -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -87,6 +83,8 @@ spec:
           {{- else }}
           value: {{ $creds.password | quote }}
           {{- end }}
+        - name: ROLES_JSON
+          value: {{ $rolesJSON | quote }}
         command:
         - /bin/bash
         - -c
@@ -97,22 +95,19 @@ spec:
           echo "App user: $MONGO_APP_USER"
           echo ""
 
-          ROLES={{ $rolesJSON | quote }}
-
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'if (db.getSiblingDB("admin").getUser(process.env.MONGO_APP_USER) !== null) { print("EXISTS"); }' | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and replacing roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").updateUser(process.env.MONGO_APP_USER, {pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           else
             echo "Creating user '$MONGO_APP_USER'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval 'db.getSiblingDB("admin").createUser({user: process.env.MONGO_APP_USER, pwd: process.env.MONGO_APP_PASSWORD, roles: JSON.parse(process.env.ROLES_JSON)})'
           fi
 
           echo ""

--- a/charts/reporter/templates/bootstrap-mongodb.yaml
+++ b/charts/reporter/templates/bootstrap-mongodb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.global.externalMongoDefinitions.enabled }}
+{{- $creds := .Values.global.externalMongoDefinitions.reporterCredentials -}}
+{{- $rolesList := list -}}
+{{- range $creds.roles -}}
+{{- $rolesList = append $rolesList (printf "{role: '%s', db: '%s'}" .role .db) -}}
+{{- end -}}
+{{- $rolesJSON := printf "[%s]" (join ", " $rolesList) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -63,14 +69,23 @@ spec:
           {{- else }}
           value: {{ .Values.global.externalMongoDefinitions.mongoAdminLogin.password | quote }}
           {{- end }}
-        - name: MONGO_APP_PASSWORD
-          {{- if .Values.global.externalMongoDefinitions.reporterCredentials.useExistingSecret.name }}
+        - name: MONGO_APP_USER
+          {{- if $creds.useExistingSecret.name }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.global.externalMongoDefinitions.reporterCredentials.useExistingSecret.name | quote }}
+              name: {{ $creds.useExistingSecret.name | quote }}
+              key: MONGO_APP_USER
+          {{- else }}
+          value: {{ $creds.username | quote }}
+          {{- end }}
+        - name: MONGO_APP_PASSWORD
+          {{- if $creds.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $creds.useExistingSecret.name | quote }}
               key: MONGO_APP_PASSWORD
           {{- else }}
-          value: {{ .Values.global.externalMongoDefinitions.reporterCredentials.password | quote }}
+          value: {{ $creds.password | quote }}
           {{- end }}
         command:
         - /bin/bash
@@ -79,22 +94,25 @@ spec:
           set -euo pipefail
           echo "=== Reporter MongoDB Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT"
+          echo "App user: $MONGO_APP_USER"
           echo ""
+
+          ROLES={{ $rolesJSON | quote }}
 
           echo "Checking existing MongoDB objects..."
           USER_EXISTS=0
 
-          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('reporter'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
+          if mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "var u = db.getSiblingDB('admin').getUser('$MONGO_APP_USER'); if (u !== null) { print('EXISTS'); }" | grep -q "EXISTS"; then
             USER_EXISTS=1
           fi
 
           if [ "$USER_EXISTS" = "1" ]; then
-            echo "User 'reporter' already exists. Updating password and ensuring roles..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('reporter', '$MONGO_APP_PASSWORD')"
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('reporter', [{role: 'readWrite', db: 'reporter-db'}])"
+            echo "User '$MONGO_APP_USER' already exists. Updating password and ensuring roles..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').changeUserPassword('$MONGO_APP_USER', '$MONGO_APP_PASSWORD')"
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').grantRolesToUser('$MONGO_APP_USER', $ROLES)"
           else
-            echo "Creating user 'reporter'..."
-            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: 'reporter', pwd: '$MONGO_APP_PASSWORD', roles: [{role: 'readWrite', db: 'reporter-db'}]})"
+            echo "Creating user '$MONGO_APP_USER'..."
+            mongosh --host "$DB_HOST" --port "$DB_PORT" -u "$MONGO_ROOT_USER" -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.getSiblingDB('admin').createUser({user: '$MONGO_APP_USER', pwd: '$MONGO_APP_PASSWORD', roles: $ROLES})"
           fi
 
           echo ""

--- a/charts/reporter/values.yaml
+++ b/charts/reporter/values.yaml
@@ -25,10 +25,16 @@ global:
     # -- Credentials for reporter user created by the job
     reporterCredentials:
       useExistingSecret:
-        # -- Name of existing secret containing MONGO_APP_PASSWORD key
+        # -- Name of existing secret containing MONGO_APP_USER and MONGO_APP_PASSWORD keys
         name: ""
+      # -- App username (ignored if useExistingSecret.name is set)
+      username: "reporter"
       # -- Password for reporter user (ignored if useExistingSecret.name is set)
       password: "lerian"
+      # -- List of roles to grant to the user. Each item is a {role, db} pair.
+      roles:
+        - role: "readWrite"
+          db: "reporter-db"
 
 manager:
   name: "reporter-manager"


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Midaz
- [x] Reporter
- [x] Plugin Fees
- [x] Plugin BR PIX Indirect BTG
- [x] Fetcher
- [x] Flowker

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Refactor of the bootstrap-mongodb templates introduced in #1181 to make the app username and roles list configurable via values.yaml instead of hardcoded in the mongosh script.

### What changed

Each chart's `<chart>Credentials` block (under `global.externalMongoDefinitions`) now accepts:
- `username` — app user to create (was hardcoded in the script)
- `roles` — list of `{role, db}` objects to grant (was hardcoded)

The bootstrap script reads `MONGO_APP_USER` from env and renders the roles JSON at template time from the values list.

Defaults preserve the previous hardcoded behavior for all 7 charts. Existing deployments are unaffected.

### Why

This unblocks gitops environments that need different users/roles than the chart defaults. Specific case: plugin-br-pix-indirect-btg in anacleto needs user `plugin-br-pix-indirect-btg` (not `pix_btg`) with both `readWrite` and `dbAdmin` roles across 3 databases (`plugin-br-pix-indirect-btg-db`, `plugin_pix`, `pix_btg`).

### Testing

End-to-end validated on minikube with plugin-br-pix-indirect-btg using the gitops config (6 roles in 3 databases):
- User `plugin-br-pix-indirect-btg` created with all 6 roles
- Idempotent re-run with rotated password — roles preserved, password updated
- Authentication with new password succeeded across all 3 databases

`helm lint` passes on all 7 charts.