### PR TITLE
fix(midaz): use name helpers instead of hardcoded Job names

### DIFF
--- a/charts/midaz/templates/bootstrap-mongodb.yaml
+++ b/charts/midaz/templates/bootstrap-mongodb.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: midaz-bootstrap-mongodb
+  name: {{ include "midaz.name" . }}-bootstrap-mongodb
   namespace: {{ .Release.Namespace }}
 spec:
   ttlSecondsAfterFinished: 300

--- a/charts/reporter/templates/bootstrap-mongodb.yaml
+++ b/charts/reporter/templates/bootstrap-mongodb.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: reporter-bootstrap-mongodb
+  name: {{ include "reporter.name" . }}-bootstrap-mongodb
   namespace: {{ include "global.namespace" . }}
 spec:
   ttlSecondsAfterFinished: 300

--- a/charts/reporter/templates/helpers.tpl
+++ b/charts/reporter/templates/helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "reporter.name" -}}
+{{- default "reporter" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Expand the name of the chart and plugin manager.
 */}}
 {{- define "plugin-manager.name" -}}


### PR DESCRIPTION
## What

Replace hardcoded Job names in midaz and reporter MongoDB bootstrap templates with Helm name helpers, matching the pattern already used by fetcher, flowker, matcher, plugin-br-pix-indirect-btg, plugin-fees, and product-console.

## Changes

- **midaz:** `midaz-bootstrap-mongodb` → `{{ include "midaz.name" . }}-bootstrap-mongodb` (uses existing helper)
- **reporter:** `reporter-bootstrap-mongodb` → `{{ include "reporter.name" . }}-bootstrap-mongodb` (new helper added to `helpers.tpl`, following the standard pattern with `nameOverride` support)

## Why

Hardcoded names can collide when multiple releases exist in the same namespace or when `nameOverride` is used. The other 5 MongoDB bootstrap templates already use fullname/name helpers.

Ref: PR #1192 review discussion