### PR TITLE
feat(reporter): add ServiceAccount annotations support for IRSA

### DIFF
--- a/charts/reporter/templates/manager/sa.yaml
+++ b/charts/reporter/templates/manager/sa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.manager.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "plugin-manager.labels" (dict "context" . "name" .Values.manager.name ) | nindent 4 }}
+  {{- with .Values.manager.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/reporter/templates/worker/deployment.yaml
+++ b/charts/reporter/templates/worker/deployment.yaml
@@ -38,6 +38,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.worker.serviceAccount.create }}
+      serviceAccountName: {{ include "plugin-worker.fullname" . }}
+      {{- end }}
       {{- if and $.Values.aws $.Values.aws.rolesAnywhere $.Values.aws.rolesAnywhere.enabled }}
       securityContext:
         fsGroup: 65532

--- a/charts/reporter/templates/worker/keda-scaled-job.yaml
+++ b/charts/reporter/templates/worker/keda-scaled-job.yaml
@@ -25,6 +25,9 @@ spec:
         imagePullSecrets:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if .Values.worker.serviceAccount.create }}
+        serviceAccountName: {{ include "plugin-worker.fullname" . }}
+        {{- end }}
         {{- if and $.Values.aws $.Values.aws.rolesAnywhere $.Values.aws.rolesAnywhere.enabled }}
         securityContext:
           fsGroup: 65532

--- a/charts/reporter/templates/worker/sa.yaml
+++ b/charts/reporter/templates/worker/sa.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.worker.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "plugin-worker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "plugin-worker.labels" (dict "context" . "name" .Values.worker.name ) | nindent 4 }}
+  {{- with .Values.worker.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/reporter/values.yaml
+++ b/charts/reporter/values.yaml
@@ -144,6 +144,15 @@ manager:
   clusterRole:
     # -- Enable or disable ClusterRole and ClusterRoleBinding creation
     create: true
+  # -- ServiceAccount configuration for manager
+  serviceAccount:
+    # -- Enable or disable ServiceAccount creation
+    create: true
+    # -- Annotations to add to the ServiceAccount (e.g., for IRSA)
+    annotations: {}
+    # Example for AWS IRSA:
+    # annotations:
+    #   eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/my-role"
   configmap:
     # -- Annotations for the configmap
     annotations: {}
@@ -257,6 +266,15 @@ worker:
 
   useExistingSecret: false
   existingSecretName: ""
+  # -- ServiceAccount configuration for worker
+  serviceAccount:
+    # -- Enable or disable ServiceAccount creation
+    create: true
+    # -- Annotations to add to the ServiceAccount (e.g., for IRSA)
+    annotations: {}
+    # Example for AWS IRSA:
+    # annotations:
+    #   eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/my-role"
   configmap:
     # -- Annotations for the configmap
     annotations: {}


### PR DESCRIPTION
## Summary
Add support for ServiceAccount annotations in reporter chart to enable AWS IRSA (IAM Roles for Service Accounts) authentication.

## Changes
- Add `serviceAccount.create` and `serviceAccount.annotations` to manager values
- Add `serviceAccount.create` and `serviceAccount.annotations` to worker values
- Update `manager/sa.yaml` to include annotations and conditional creation
- Create `worker/sa.yaml` with annotations support
- Update `worker/deployment.yaml` to use `serviceAccountName`
- Update `worker/keda-scaled-job.yaml` to use `serviceAccountName`

## Usage Example
```yaml
manager:
  serviceAccount:
    create: true
    annotations:
      eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/my-role"

worker:
  serviceAccount:
    create: true
    annotations:
      eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/my-role"
```

## Why
This enables AWS EKS deployments to use IRSA for IAM authentication instead of node-level IAM roles, providing better security isolation and least-privilege access.