### PR TITLE
feat(fetcher): add ServiceAccount support for worker

### DIFF
--- a/charts/fetcher/templates/_helpers.tpl
+++ b/charts/fetcher/templates/_helpers.tpl
@@ -95,6 +95,17 @@ Create the name of the service account to use for manager
 {{- end }}
 
 {{/*
+Create the name of the service account to use for worker
+*/}}
+{{- define "fetcher-worker.serviceAccountName" -}}
+{{- if .Values.worker.serviceAccount.create }}
+{{- default (include "fetcher-worker.fullname" .) .Values.worker.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.worker.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Expand the namespace of the release.
 */}}
 {{- define "fetcher.namespace" -}}

--- a/charts/fetcher/templates/worker/deployment.yaml
+++ b/charts/fetcher/templates/worker/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.worker.serviceAccount.create }}
+      serviceAccountName: {{ include "fetcher-worker.serviceAccountName" . }}
+      {{- end }}
       {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
       securityContext:
         fsGroup: 65532

--- a/charts/fetcher/templates/worker/serviceaccount.yaml
+++ b/charts/fetcher/templates/worker/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.worker.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fetcher-worker.serviceAccountName" . }}
+  labels:
+    {{- include "fetcher-worker.labels" . | nindent 4 }}
+  {{- with .Values.worker.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/fetcher/values.yaml
+++ b/charts/fetcher/values.yaml
@@ -171,6 +171,10 @@ worker:
   nodeSelector: {}
   tolerations: {}
   affinity: {}
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
   # Worker-specific ConfigMap (VERSION is auto-set from image tag)
   configmap:
     ENV_NAME: "development"


### PR DESCRIPTION
## Summary
Add ServiceAccount configuration for fetcher-worker to enable AWS IRSA authentication.

## Changes
- Add `worker.serviceAccount` config to values.yaml (create, annotations, name)
- Create `templates/worker/serviceaccount.yaml`
- Add `fetcher-worker.serviceAccountName` helper to `_helpers.tpl`
- Update `worker/deployment.yaml` to use `serviceAccountName`

## Usage Example
```yaml
worker:
  serviceAccount:
    create: true
    annotations:
      eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/my-role"
```

## Why
Fetcher worker pods need IRSA to access S3 for storing external data. Currently they fall back to node IAM role which doesn't have S3 permissions.