### PR TITLE
feat(reporter,fetcher): auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag

### DIFF
--- a/charts/fetcher/templates/manager/configmap.yaml
+++ b/charts/fetcher/templates/manager/configmap.yaml
@@ -8,10 +8,20 @@ data:
   {{- range $key, $value := .Values.manager.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
+  {{- if not .Values.manager.configmap.VERSION }}
   {{- if .Values.manager.image.tag }}
   VERSION: {{ .Values.manager.image.tag | quote }}
   {{- else }}
   VERSION: {{ .Chart.AppVersion | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if not .Values.manager.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
+  {{- if .Values.manager.image.tag }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.manager.image.tag | quote }}
+  {{- else }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- end }}
   {{- end }}
   {{- with .Values.manager.extraEnvVars }}
   {{- range $key, $value := . }}

--- a/charts/fetcher/templates/manager/configmap.yaml
+++ b/charts/fetcher/templates/manager/configmap.yaml
@@ -8,21 +8,9 @@ data:
   {{- range $key, $value := .Values.manager.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
-  {{- if not .Values.manager.configmap.VERSION }}
-  {{- if .Values.manager.image.tag }}
-  VERSION: {{ .Values.manager.image.tag | quote }}
-  {{- else }}
-  VERSION: {{ .Chart.AppVersion | quote }}
-  {{- end }}
-  {{- end }}
-  {{- if not .Values.manager.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
-  {{- if .Values.manager.image.tag }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.manager.image.tag | quote }}
-  {{- else }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Chart.AppVersion | quote }}
-  {{- end }}
-  {{- end }}
+  # Always set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag
+  VERSION: {{ .Values.manager.image.tag | default .Chart.AppVersion | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.manager.image.tag | default .Chart.AppVersion | quote }}
   {{- with .Values.manager.extraEnvVars }}
   {{- range $key, $value := . }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/fetcher/templates/worker/configmap.yaml
+++ b/charts/fetcher/templates/worker/configmap.yaml
@@ -8,21 +8,9 @@ data:
   {{- range $key, $value := .Values.worker.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
-  {{- if not .Values.worker.configmap.VERSION }}
-  {{- if .Values.worker.image.tag }}
-  VERSION: {{ .Values.worker.image.tag | quote }}
-  {{- else }}
-  VERSION: {{ .Chart.AppVersion | quote }}
-  {{- end }}
-  {{- end }}
-  {{- if not .Values.worker.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
-  {{- if .Values.worker.image.tag }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.worker.image.tag | quote }}
-  {{- else }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Chart.AppVersion | quote }}
-  {{- end }}
-  {{- end }}
+  # Always set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag
+  VERSION: {{ .Values.worker.image.tag | default .Chart.AppVersion | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.worker.image.tag | default .Chart.AppVersion | quote }}
   {{- with .Values.worker.extraEnvVars }}
   {{- range $key, $value := . }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/fetcher/templates/worker/configmap.yaml
+++ b/charts/fetcher/templates/worker/configmap.yaml
@@ -8,10 +8,20 @@ data:
   {{- range $key, $value := .Values.worker.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
+  {{- if not .Values.worker.configmap.VERSION }}
   {{- if .Values.worker.image.tag }}
   VERSION: {{ .Values.worker.image.tag | quote }}
   {{- else }}
   VERSION: {{ .Chart.AppVersion | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if not .Values.worker.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
+  {{- if .Values.worker.image.tag }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.worker.image.tag | quote }}
+  {{- else }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- end }}
   {{- end }}
   {{- with .Values.worker.extraEnvVars }}
   {{- range $key, $value := . }}

--- a/charts/flowker/templates/configmap.yaml
+++ b/charts/flowker/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
   # Swagger
   SWAGGER_TITLE: {{ .Values.flowker.configmap.SWAGGER_TITLE | default "Flowker API" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.flowker.configmap.SWAGGER_DESCRIPTION | default "Workflow orchestration platform for financial validation" | quote }}
-  SWAGGER_VERSION: {{ .Values.flowker.configmap.SWAGGER_VERSION | default "v1.0.0" | quote }}
+  SWAGGER_VERSION: {{ .Values.flowker.image.tag | default .Chart.AppVersion | quote }}
   SWAGGER_HOST: {{ .Values.flowker.configmap.SWAGGER_HOST | default ":4000" | quote }}
   SWAGGER_BASE_PATH: {{ .Values.flowker.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
   SWAGGER_SCHEMES: {{ .Values.flowker.configmap.SWAGGER_SCHEMES | default "http" | quote }}

--- a/charts/flowker/templates/configmap.yaml
+++ b/charts/flowker/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   # Server
   ENV_NAME: {{ .Values.flowker.configmap.ENV_NAME | default "development" | quote }}
-  VERSION: {{ .Values.flowker.configmap.VERSION | default "v1.0.0" | quote }}
+  VERSION: {{ .Values.flowker.image.tag | default .Chart.AppVersion | quote }}
   SERVER_PORT: {{ .Values.flowker.configmap.SERVER_PORT | default "4000" | quote }}
   SERVER_ADDRESS: {{ .Values.flowker.configmap.SERVER_ADDRESS | default ":4000" | quote }}
 
@@ -48,7 +48,7 @@ data:
   ENABLE_TELEMETRY: {{ .Values.flowker.configmap.ENABLE_TELEMETRY | default "false" | quote }}
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.flowker.configmap.OTEL_RESOURCE_SERVICE_NAME | default "flowker" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.flowker.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/flowker" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.flowker.configmap.OTEL_RESOURCE_SERVICE_VERSION | default "v1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.flowker.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.flowker.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.flowker.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.flowker.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}

--- a/charts/matcher/templates/configmap.yaml
+++ b/charts/matcher/templates/configmap.yaml
@@ -159,11 +159,7 @@ data:
   {{- end }}
 
   # Application Version (for logs/telemetry)
-  {{- if .Values.matcher.image.tag }}
-  VERSION: {{ .Values.matcher.image.tag | quote }}
-  {{- else }}
-  VERSION: {{ .Chart.AppVersion | quote }}
-  {{- end }}
+  VERSION: {{ .Values.matcher.image.tag | default .Chart.AppVersion | quote }}
 
   # Extra Env Vars
   {{- with .Values.matcher.extraEnvVars }}

--- a/charts/midaz/templates/crm/configmap.yaml
+++ b/charts/midaz/templates/crm/configmap.yaml
@@ -12,7 +12,7 @@ data:
   # APP
   SERVER_PORT: {{ .Values.crm.configmap.SERVER_PORT | default "4003" | quote }}
   SERVER_ADDRESS: {{ .Values.crm.configmap.SERVER_ADDRESS | default ":4003" | quote }}
-  VERSION: "v{{ .Values.crm.image.tag | default .Chart.AppVersion }}"
+  VERSION: {{ .Values.crm.image.tag | default .Chart.AppVersion | quote }}
 
   # Mongo DB
   MONGO_URI: {{ .Values.crm.configmap.MONGO_URI | default "mongodb" | quote }}
@@ -26,7 +26,7 @@ data:
   # SWAGGER
   SWAGGER_TITLE: {{ .Values.crm.configmap.SWAGGER_TITLE | default "CRM" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.crm.configmap.SWAGGER_DESCRIPTION | default "The CRM API provides a set of endpoints for managing holder data, including information related to their ledger accounts." | quote }}
-  SWAGGER_VERSION: "v{{ .Values.crm.image.tag | default .Chart.AppVersion }}"
+  SWAGGER_VERSION: {{ .Values.crm.image.tag | default .Chart.AppVersion | quote }}
   SWAGGER_HOST: {{ .Values.crm.configmap.SWAGGER_HOST | default ":4003" | quote }}
   SWAGGER_BASE_PATH: {{ .Values.crm.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
   SWAGGER_SCHEMES: {{ .Values.crm.configmap.SWAGGER_SCHEMES | default "http" | quote }}

--- a/charts/midaz/templates/crm/configmap.yaml
+++ b/charts/midaz/templates/crm/configmap.yaml
@@ -39,7 +39,7 @@ data:
   # OPEN TELEMETRY
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.crm.configmap.OTEL_RESOURCE_SERVICE_NAME | default "midaz-crm" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.crm.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-crm" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: "v{{ .Values.crm.image.tag | default .Chart.AppVersion }}"
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.crm.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.crm.configmap.ENV_NAME | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.crm.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.crm.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "midaz-grafana:4317" | quote }}

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -240,11 +240,7 @@ data:
   TRANSFER_OPERATING_TIMEZONE: {{ .Values.bankTransfer.configmap.TRANSFER_OPERATING_TIMEZONE | default "America/Sao_Paulo" | quote }}
 
   # Application Version (for logs/telemetry)
-  {{- if .Values.bankTransfer.image.tag }}
-  VERSION: {{ .Values.bankTransfer.image.tag | quote }}
-  {{- else }}
-  VERSION: {{ .Chart.AppVersion | quote }}
-  {{- end }}
+  VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
 
   # Extra Env Vars (must be a map of key: value pairs)
   {{- range $key, $value := .Values.bankTransfer.extraEnvVars }}

--- a/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd-job/configmap.yaml
+++ b/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd-job/configmap.yaml
@@ -12,7 +12,7 @@ data:
   # APP
   APPLICATION_NAME: {{ .Values.job.configmap.APPLICATION_NAME | default "plugin-br-pix-direct-jd" | quote }}
   APPLICATION_BASE_URL: {{ .Values.job.configmap.APPLICATION_BASE_URL | default "http://plugin-br-pix-direct-jd:4011" | quote }}
-  API_VERSION: {{ .Values.job.configmap.API_VERSION | default "1.0.0" | quote }}
+  API_VERSION: {{ .Values.job.image.tag | default .Chart.AppVersion | quote }}
   API_PORT: {{ .Values.job.configmap.API_PORT | default "4011" | quote }}
   API_RATE_CRITICAL_MAX: {{ .Values.job.configmap.API_RATE_CRITICAL_MAX | default "5" | quote }}
   API_RATE_CRITICAL_WINDOW: {{ .Values.job.configmap.API_RATE_CRITICAL_WINDOW | default "1" | quote }}
@@ -71,7 +71,7 @@ data:
 
   # OpenTelemetry - Shared Midaz LGTM Infrastructure
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.job.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-pix-direct-jd" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.job.configmap.OTEL_RESOURCE_SERVICE_VERSION | default "1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.job.image.tag | default .Chart.AppVersion | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.job.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.job.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "midaz-otel-lgtm:4317" | quote }}
   ENABLE_TELEMETRY: {{ .Values.job.configmap.ENABLE_TELEMETRY | default "true" | quote }}

--- a/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd-qr-code/configmap.yaml
+++ b/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd-qr-code/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "plugin-br-pix-direct-jd-qr-code.labels" (dict "context" . "name" .Values.qrcode.name ) | nindent 4 }}
 data:
   # APP
-  VERSION: "v1.0.0"
+  VERSION: {{ .Values.qrcode.image.tag | default .Chart.AppVersion | quote }}
   SERVER_PORT: "4009"
   SERVER_ADDRESS: ":4009"
 

--- a/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/configmap.yaml
+++ b/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/configmap.yaml
@@ -12,7 +12,7 @@ data:
   # APP
   APPLICATION_NAME: {{ .Values.pix.configmap.APPLICATION_NAME | default "plugin-br-pix-direct-jd" | quote }}
   APPLICATION_BASE_URL: {{ .Values.pix.configmap.APPLICATION_BASE_URL | default "http://plugin-br-pix-direct-jd:4011" | quote }}
-  API_VERSION: {{ .Values.pix.configmap.API_VERSION | default "1.0.0" | quote }}
+  API_VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}
   API_PORT: {{ .Values.pix.configmap.API_PORT | default "4011" | quote }}
   API_RATE_CRITICAL_MAX: {{ .Values.pix.configmap.API_RATE_CRITICAL_MAX | default "5" | quote }}
   API_RATE_CRITICAL_WINDOW: {{ .Values.pix.configmap.API_RATE_CRITICAL_WINDOW | default "1" | quote }}
@@ -65,7 +65,7 @@ data:
 
   # OpenTelemetry - Shared Midaz LGTM Infrastructure
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.pix.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-pix-direct-jd" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.pix.configmap.OTEL_RESOURCE_SERVICE_VERSION | default "1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.pix.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.pix.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "midaz-otel-lgtm:4317" | quote }}
   ENABLE_TELEMETRY: {{ .Values.pix.configmap.ENABLE_TELEMETRY | default "true" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/templates/inbound/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/inbound/configmap.yaml
@@ -9,7 +9,7 @@ data:
   ENV_NAME: {{ .Values.inbound.configmap.ENV_NAME | default "development" | quote }}
 
   # APP
-  VERSION: {{ .Values.inbound.image.tag | default "v1.0.0" | quote }}
+  VERSION: {{ .Values.inbound.image.tag | default .Chart.AppVersion | quote }}
   WORKER_PORT: {{ .Values.inbound.configmap.WORKER_PORT | default "4016" | quote }}
 
   # AUTH PLUGIN
@@ -44,7 +44,7 @@ data:
   # OPEN TELEMETRY (WITH MIDAZ LGTM SERVICE)
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.inbound.configmap.OTEL_RESOURCE_SERVICE_NAME | default "webhook-inbound-worker" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.inbound.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-pix-indirect-btg/components/worker/webhook/inbound" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.inbound.image.tag | default "v1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.inbound.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.inbound.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.inbound.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.inbound.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "http://midaz-otel-lgtm" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/templates/outbound/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/outbound/configmap.yaml
@@ -9,7 +9,7 @@ data:
   ENV_NAME: {{ .Values.outbound.configmap.ENV_NAME | default "development" | quote }}
 
   # APP
-  VERSION: {{ .Values.outbound.image.tag | default "v1.0.0" | quote }}
+  VERSION: {{ .Values.outbound.image.tag | default .Chart.AppVersion | quote }}
   WORKER_PORT: {{ .Values.outbound.configmap.WORKER_PORT | default "4015" | quote }}
 
 
@@ -79,7 +79,7 @@ data:
   # OPEN TELEMETRY (WITH MIDAZ LGTM SERVICE)
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.outbound.configmap.OTEL_RESOURCE_SERVICE_NAME | default "webhook-outbound-worker" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.outbound.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-pix-indirect-btg/components/worker/webhook/outbound" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.outbound.image.tag | default "v1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.outbound.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.outbound.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.outbound.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "http://midaz-otel-lgtm:4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.outbound.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
@@ -91,7 +91,7 @@ data:
   # OPEN TELEMETRY (WITH MIDAZ LGTM SERVICE)
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.pix.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-pix-indirect-btg" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.pix.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-pix-indirect-btg" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.pix.configmap.OTEL_RESOURCE_SERVICE_VERSION | default "v1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.pix.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.pix.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.pix.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "http://midaz-otel-lgtm:4317" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
@@ -9,7 +9,7 @@ data:
   ENV_NAME: {{ .Values.pix.configmap.ENV_NAME | default "development" | quote }}
 
   # APP
-  VERSION: {{ .Values.pix.image.tag | quote }}
+  VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}
   SERVER_PORT: {{ .Values.pix.configmap.SERVER_PORT | default "4014" | quote }}
   SERVER_ADDRESS: {{ .Values.pix.configmap.SERVER_ADDRESS | default ":4014" | quote }}
 
@@ -78,7 +78,7 @@ data:
   # SWAGGER
   SWAGGER_TITLE: {{ .Values.pix.configmap.SWAGGER_TITLE | default "Plugin BR Pix Indirect BTG" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.pix.configmap.SWAGGER_DESCRIPTION | default "Documentation Plugin PIX BTG" | quote }}
-  SWAGGER_VERSION: {{ .Values.pix.image.tag | default "v1.0.0" | quote }}
+  SWAGGER_VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}
   SWAGGER_HOST: {{ .Values.pix.configmap.SWAGGER_HOST | default ":4000" | quote }}
   SWAGGER_BASE_PATH: {{ .Values.pix.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
   SWAGGER_SCHEMES: {{ .Values.pix.configmap.SWAGGER_SCHEMES | default "http" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/templates/reconciliation/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/reconciliation/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "reconciliation.labels" (dict "context" . "name" .Values.reconciliation.name ) | nindent 4 }}
 data:
   ENV_NAME: {{ .Values.reconciliation.configmap.ENV_NAME | default "development" | quote }}
-  VERSION: {{ .Values.reconciliation.image.tag | default "v1.0.0" | quote }}
+  VERSION: {{ .Values.reconciliation.image.tag | default .Chart.AppVersion | quote }}
   LOG_LEVEL: {{ .Values.reconciliation.configmap.LOG_LEVEL | default "info" | quote }}
   WORKER_PORT: {{ .Values.reconciliation.configmap.WORKER_PORT | default "4017" | quote }}
 
@@ -109,7 +109,7 @@ data:
   # Observability Configuration
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.reconciliation.configmap.OTEL_RESOURCE_SERVICE_NAME | default "reconciliation-worker" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.reconciliation.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-pix-indirect-btg/components/worker/reconciliation" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.reconciliation.image.tag | default "1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.reconciliation.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.reconciliation.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.reconciliation.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.reconciliation.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "http://midaz-otel-lgtm:4317" | quote }}

--- a/charts/plugin-crm/templates/crm/configmap.yaml
+++ b/charts/plugin-crm/templates/crm/configmap.yaml
@@ -37,7 +37,7 @@ data:
   # OPEN TELEMETRY
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.crm.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-crm" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.crm.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-crm" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: "v{{ include "plugin.version" . }}"
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.crm.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.crm.configmap.ENV_NAME | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.crm.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.crm.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "midaz-grafana.midaz.svc.cluster.local:4317" | quote }}

--- a/charts/plugin-crm/templates/crm/configmap.yaml
+++ b/charts/plugin-crm/templates/crm/configmap.yaml
@@ -11,7 +11,7 @@ data:
   # APP 
   SERVER_PORT: {{ .Values.crm.configmap.SERVER_PORT | default "4003" | quote }}
   SERVER_ADDRESS: {{ .Values.crm.configmap.SERVER_ADDRESS | default ":4003" | quote }}
-  VERSION: "v{{ include "plugin.version" . }}"
+  VERSION: {{ .Values.crm.image.tag | default .Chart.AppVersion | quote }}
 
   # Mongo DB
   MONGO_URI: {{ .Values.crm.configmap.MONGO_URI | default "mongodb" | quote }}
@@ -24,7 +24,7 @@ data:
   # SWAGGER
   SWAGGER_TITLE: {{ .Values.crm.configmap.SWAGGER_TITLE | default "Plugin CRM" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.crm.configmap.SWAGGER_DESCRIPTION | default "The CRM API provides a set of endpoints for managing holder data, including information related to their ledger accounts." | quote }}
-  SWAGGER_VERSION: "v{{ include "plugin.version" . }}"
+  SWAGGER_VERSION: {{ .Values.crm.image.tag | default .Chart.AppVersion | quote }}
   SWAGGER_HOST: {{ .Values.crm.configmap.SWAGGER_HOST | default ":4003" | quote }}
   SWAGGER_BASE_PATH: {{ .Values.crm.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
   SWAGGER_SCHEMES: {{ .Values.crm.configmap.SWAGGER_SCHEMES | default "http" | quote }}

--- a/charts/plugin-fees/templates/fees/configmap.yaml
+++ b/charts/plugin-fees/templates/fees/configmap.yaml
@@ -11,7 +11,7 @@ data:
   # APP 
   SERVER_PORT: {{ .Values.fees.configmap.SERVER_PORT | default "4002" | quote }}
   SERVER_ADDRESS: {{ .Values.fees.configmap.SERVER_ADDRESS | default ":4002" | quote }}
-  VERSION: "v{{ include "plugin.version" . }}"
+  VERSION: {{ .Values.fees.image.tag | default .Chart.AppVersion | quote }}
 
   # Mongo DB
   MONGO_URI: {{ .Values.fees.configmap.MONGO_URI | default "mongodb" | quote }}
@@ -31,7 +31,7 @@ data:
   # SWAGGER
   SWAGGER_TITLE: {{ .Values.fees.configmap.SWAGGER_TITLE | default "Plugin Fees" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.fees.configmap.SWAGGER_DESCRIPTION | default "Documentation for the plugins fees" | quote }}
-  SWAGGER_VERSION: "v{{ include "plugin.version" . }}"
+  SWAGGER_VERSION: {{ .Values.fees.image.tag | default .Chart.AppVersion | quote }}
   SWAGGER_HOST: {{ .Values.fees.configmap.SWAGGER_HOST | default ":4002" | quote }}
   SWAGGER_BASE_PATH: {{ .Values.fees.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
   SWAGGER_SCHEMES: {{ .Values.fees.configmap.SWAGGER_SCHEMES | default "http" | quote }}

--- a/charts/plugin-fees/templates/fees/configmap.yaml
+++ b/charts/plugin-fees/templates/fees/configmap.yaml
@@ -44,7 +44,7 @@ data:
   # OPEN TELEMETRY
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.fees.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-fees" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.fees.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-fees" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: "v{{ include "plugin.version" . }}"
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.fees.image.tag | default .Chart.AppVersion | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.fees.configmap.ENV_NAME | default "development" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.fees.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.fees.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}

--- a/charts/product-console/templates/configmap.yaml
+++ b/charts/product-console/templates/configmap.yaml
@@ -8,11 +8,7 @@ data:
   {{- range $key, $value := .Values.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  {{- if .Values.image.tag }}
-  VERSION: {{ .Values.image.tag | quote }}
-  {{- else }}
-  VERSION: {{ .Chart.AppVersion | quote }}
-  {{- end }}
+  VERSION: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
   {{- with .Values.extraEnvVars }}
   {{- range $key, $value := . }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/reporter/templates/manager/configmap.yaml
+++ b/charts/reporter/templates/manager/configmap.yaml
@@ -19,6 +19,13 @@ data:
   {{- range $key, $value := .Values.manager.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
+  {{- if not .Values.manager.configmap.VERSION }}
+  VERSION: {{ .Values.manager.image.tag | quote }}
+  {{- end }}
+  {{- if not .Values.manager.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.manager.image.tag | quote }}
+  {{- end }}
   # Extra Env Vars
   {{- with .Values.manager.extraEnvVars }}
   {{- toYaml . | nindent 2 }}

--- a/charts/reporter/templates/manager/configmap.yaml
+++ b/charts/reporter/templates/manager/configmap.yaml
@@ -19,13 +19,9 @@ data:
   {{- range $key, $value := .Values.manager.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
-  {{- if not .Values.manager.configmap.VERSION }}
+  # Always set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag
   VERSION: {{ .Values.manager.image.tag | quote }}
-  {{- end }}
-  {{- if not .Values.manager.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.manager.image.tag | quote }}
-  {{- end }}
   # Extra Env Vars
   {{- with .Values.manager.extraEnvVars }}
   {{- toYaml . | nindent 2 }}

--- a/charts/reporter/templates/worker/configmap.yaml
+++ b/charts/reporter/templates/worker/configmap.yaml
@@ -19,13 +19,9 @@ data:
   {{- range $key, $value := .Values.worker.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
-  {{- if not .Values.worker.configmap.VERSION }}
+  # Always set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag
   VERSION: {{ .Values.worker.image.tag | quote }}
-  {{- end }}
-  {{- if not .Values.worker.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.worker.image.tag | quote }}
-  {{- end }}
   # Extra Env Vars
   {{- with .Values.worker.extraEnvVars }}
   {{- toYaml . | nindent 2 }}

--- a/charts/reporter/templates/worker/configmap.yaml
+++ b/charts/reporter/templates/worker/configmap.yaml
@@ -19,6 +19,13 @@ data:
   {{- range $key, $value := .Values.worker.configmap }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+  # Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION from image tag if not explicitly set
+  {{- if not .Values.worker.configmap.VERSION }}
+  VERSION: {{ .Values.worker.image.tag | quote }}
+  {{- end }}
+  {{- if not .Values.worker.configmap.OTEL_RESOURCE_SERVICE_VERSION }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.worker.image.tag | quote }}
+  {{- end }}
   # Extra Env Vars
   {{- with .Values.worker.extraEnvVars }}
   {{- toYaml . | nindent 2 }}

--- a/charts/underwriter/templates/configmap.yaml
+++ b/charts/underwriter/templates/configmap.yaml
@@ -64,7 +64,7 @@ data:
   ENABLE_TELEMETRY: {{ .Values.underwriter.configmap.ENABLE_TELEMETRY | default "false" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.underwriter.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/underwriter" | quote }}
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.underwriter.configmap.OTEL_RESOURCE_SERVICE_NAME | default "underwriter" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.underwriter.configmap.OTEL_RESOURCE_SERVICE_VERSION | default "1.0.0" | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.underwriter.image.tag | default .Chart.AppVersion | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.underwriter.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.underwriter.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "production" | quote }}
 


### PR DESCRIPTION
## Summary
Both reporter and fetcher charts now automatically set `VERSION` and `OTEL_RESOURCE_SERVICE_VERSION` environment variables from the image tag if not explicitly configured in the configmap.

## Changes
- **reporter/templates/manager/configmap.yaml**: Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION
- **reporter/templates/worker/configmap.yaml**: Auto-set VERSION and OTEL_RESOURCE_SERVICE_VERSION
- **fetcher/templates/manager/configmap.yaml**: Auto-set OTEL_RESOURCE_SERVICE_VERSION (VERSION already existed)
- **fetcher/templates/worker/configmap.yaml**: Auto-set OTEL_RESOURCE_SERVICE_VERSION (VERSION already existed)

## Behavior
- If `configmap.VERSION` is explicitly set, use that value
- If `configmap.OTEL_RESOURCE_SERVICE_VERSION` is explicitly set, use that value
- Otherwise, auto-set from `image.tag` (or `Chart.AppVersion` as fallback for fetcher)

## Why
This ensures telemetry data always reflects the actual deployed version without requiring manual synchronization in values.yaml. Previously, users had to manually update `OTEL_RESOURCE_SERVICE_VERSION` every time they changed the image tag.