### PR TITLE
feat(charts): add missing NEU app env vars to reporter and fetcher

### DIFF
--- a/charts/fetcher/Chart.yaml
+++ b/charts/fetcher/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/LerianStudio/fetcher
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 2.1.0-beta.7
+version: 2.1.0-beta.8
 appVersion: "1.3.0"
 keywords:
   - midaz

--- a/charts/fetcher/values-template.yaml
+++ b/charts/fetcher/values-template.yaml
@@ -102,6 +102,8 @@ common:
     MONGO_NAME: "fetcher-db"
     MONGO_PORT: "27017"
     MONGO_MAX_POOL_SIZE: "1000"
+    MONGO_PARAMETERS: ""
+    MONGO_TLS_CA_CERT: ""
 
     # RabbitMQ - REQUIRED
     RABBITMQ_URI: "amqp"
@@ -130,6 +132,7 @@ common:
     OTEL_EXPORTER_OTLP_ENDPOINT_PORT: "4317"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
     ENABLE_TELEMETRY: "false"
+    OTEL_INSECURE_EXPORTER: "false"
 
 secrets:
   MONGO_USER: ""  # REQUIRED - MongoDB username

--- a/charts/fetcher/values.yaml
+++ b/charts/fetcher/values.yaml
@@ -241,6 +241,8 @@ common:
     MONGO_NAME: "fetcher-db"
     MONGO_PORT: "27017"
     MONGO_MAX_POOL_SIZE: "1000"
+    MONGO_PARAMETERS: ""
+    MONGO_TLS_CA_CERT: ""
     # RabbitMQ
     RABBITMQ_URI: "amqp"
     RABBITMQ_HOST: "rabbitmq"
@@ -263,6 +265,7 @@ common:
     OTEL_EXPORTER_OTLP_ENDPOINT_PORT: "4317"
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://$(HOST_IP):4317"
     ENABLE_TELEMETRY: "false"
+    OTEL_INSECURE_EXPORTER: "false"
     # Multi-Tenant
     MULTI_TENANT_ENABLED: "false"
     MULTI_TENANT_URL: ""

--- a/charts/reporter/Chart.yaml
+++ b/charts/reporter/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.0-beta.7
+version: 2.1.0-beta.8
 # This is the version number of the application being deployed.
 appVersion: "1.2.0"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/reporter/values-template.yaml
+++ b/charts/reporter/values-template.yaml
@@ -71,6 +71,18 @@ common:
     OTEL_EXPORTER_OTLP_ENDPOINT_PORT: 4317
     OTEL_EXPORTER_OTLP_ENDPOINT: otlp://midaz-otel-lgtm:4317
     ENABLE_TELEMETRY: false
+    OTEL_INSECURE_EXPORTER: "false"
+
+    # MongoDB TLS
+    MONGO_TLS_CA_CERT: ""
+    MONGO_PARAMETERS: ""
+
+    # Fetcher Integration
+    FETCHER_ENABLED: "false"
+    FETCHER_URL: ""
+
+    # Multi-Tenant
+    MULTI_TENANT_ENABLED: "false"
 
     # MIDAZ ONBOARDING
     DATASOURCE_ONBOARDING_CONFIG_NAME: midaz_onboarding
@@ -89,6 +101,8 @@ secrets:
   DATASOURCE_ONBOARDING_PASSWORD: lerian
   OBJECT_STORAGE_ACCESS_KEY_ID: any
   OBJECT_STORAGE_SECRET_KEY: any
+  # Fetcher Integration - Base64 encoded 32-byte encryption key
+  APP_ENC_KEY: ""
 
 seaweedfs:
   enabled: true

--- a/charts/reporter/values.yaml
+++ b/charts/reporter/values.yaml
@@ -411,6 +411,15 @@ common:
     OTEL_EXPORTER_OTLP_ENDPOINT_PORT: 4317
     OTEL_EXPORTER_OTLP_ENDPOINT: otlp://midaz-otel-lgtm:4317
     ENABLE_TELEMETRY: true
+    OTEL_INSECURE_EXPORTER: "false"
+    # MongoDB TLS
+    MONGO_TLS_CA_CERT: ""
+    MONGO_PARAMETERS: ""
+    # Fetcher Integration
+    FETCHER_ENABLED: "false"
+    FETCHER_URL: ""
+    # Multi-Tenant
+    MULTI_TENANT_ENABLED: "false"
     # MIDAZ ONBOARDING
     DATASOURCE_ONBOARDING_CONFIG_NAME: midaz_onboarding
     DATASOURCE_ONBOARDING_HOST: midaz-postgresql-replication.midaz.svc.cluster.local
@@ -442,6 +451,8 @@ secrets:
   #DATASOURCE_EXTERNAL_PASSWORD: db_password
   OBJECT_STORAGE_ACCESS_KEY_ID: "any"
   OBJECT_STORAGE_SECRET_KEY: "any"
+  # Fetcher Integration - Base64 encoded 32-byte encryption key
+  APP_ENC_KEY: ""
 seaweedfs:
   enabled: true
   master:


### PR DESCRIPTION
## Summary

Add missing environment variables required for NEU app support in reporter and fetcher Helm charts.

## Changes

### Reporter Chart (7 new env vars)

| Env Var | Location | Default | Description |
|---------|----------|---------|-------------|
| `APP_ENC_KEY` | `secrets` | `""` | Base64 encoded 32-byte encryption key for fetcher integration |
| `FETCHER_ENABLED` | `common.configmap` | `"false"` | Enable fetcher integration mode |
| `FETCHER_URL` | `common.configmap` | `""` | Fetcher service URL |
| `MONGO_TLS_CA_CERT` | `common.configmap` | `""` | Base64-encoded PEM CA certificate for MongoDB TLS |
| `MULTI_TENANT_ENABLED` | `common.configmap` | `"false"` | Enable multi-tenant mode |
| `OTEL_INSECURE_EXPORTER` | `common.configmap` | `"false"` | Use insecure OTEL exporter connection |
| `MONGO_PARAMETERS` | `common.configmap` | `""` | MongoDB connection string parameters |

### Fetcher Chart (3 new env vars)

| Env Var | Location | Default | Description |
|---------|----------|---------|-------------|
| `MONGO_TLS_CA_CERT` | `common.configmap` | `""` | Base64-encoded PEM CA certificate for MongoDB TLS |
| `OTEL_INSECURE_EXPORTER` | `common.configmap` | `"false"` | Use insecure OTEL exporter connection |
| `MONGO_PARAMETERS` | `common.configmap` | `""` | MongoDB connection string parameters |

## Chart Versions

- reporter-helm: `2.1.0-beta.7` -> `2.1.0-beta.8`
- fetcher-helm: `2.1.0-beta.7` -> `2.1.0-beta.8`

## Testing

- [x] `helm lint charts/reporter` passes
- [x] `helm lint charts/fetcher` passes
