### PR TITLE
chore(midaz): update appVersion and image tags to 3.6.1

### DIFF
--- a/charts/midaz/Chart.yaml
+++ b/charts/midaz/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 version: 6.0.0-beta.5
 
 # This is the version number of the application being deployed.
-appVersion: "3.5.3"
+appVersion: "3.6.1"
 
 # A list of keywords about the chart. This helps others discover the chart.
 keywords:

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -557,7 +557,7 @@ ledger:
     # -- Image pull policy
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
-    tag: "3.5.3"
+    tag: "3.6.1"
 
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
@@ -792,7 +792,7 @@ crm:
     # -- Image pull policy
     pullPolicy: Always
     # -- Image tag used for deployment
-    tag: "3.5.3"
+    tag: "3.6.0"
 
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []


### PR DESCRIPTION
## Summary

Update midaz chart to use the latest app version 3.6.1.

## Changes

- Updated `appVersion` in Chart.yaml: `3.5.3` → `3.6.1`
- Updated image tags in values.yaml for all 4 components:
  - onboarding: `3.5.3` → `3.6.1`
  - transaction: `3.5.3` → `3.6.1`  
  - ledger: `3.5.3` → `3.6.1`
  - crm: `3.5.3` → `3.6.1`

## Testing

- [x] `helm lint charts/midaz` passes
