### PR TITLE
hotfix(fetcher): align secrets pattern with reporter chart

### DIFF
--- a/charts/fetcher/Chart.yaml
+++ b/charts/fetcher/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/LerianStudio/fetcher
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 2.1.1
+version: 2.1.2
 appVersion: "1.3.0"
 keywords:
   - midaz

--- a/charts/fetcher/templates/manager/secrets.yaml
+++ b/charts/fetcher/templates/manager/secrets.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "fetcher-manager.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- range $key, $value := .Values.manager.secrets }}
+  {{- range $key, $value := .Values.secrets }}
   {{ $key }}: {{ $value | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/fetcher/templates/worker/secrets.yaml
+++ b/charts/fetcher/templates/worker/secrets.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "fetcher-worker.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- range $key, $value := .Values.worker.secrets }}
+  {{- range $key, $value := .Values.secrets }}
   {{ $key }}: {{ $value | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/fetcher/values-template.yaml
+++ b/charts/fetcher/values-template.yaml
@@ -47,10 +47,6 @@ manager:
     ALLOW_RATELIMIT_DISABLED: ""
     ALLOW_RATELIMIT_FAIL_OPEN: ""
 
-  secrets:
-    APP_ENC_KEY: ""  # REQUIRED - Base64 encoded 32-byte key (generate with: openssl rand -base64 32)
-    APP_ENC_KEY_VERSION: "1"
-
   useExistingSecret: false
   existingSecretName: ""
 
@@ -84,12 +80,6 @@ worker:
     RATE_LIMIT_REDIS_TIMEOUT_MS: "500"
     ALLOW_RATELIMIT_DISABLED: ""
     ALLOW_RATELIMIT_FAIL_OPEN: ""
-
-  secrets:
-    APP_ENC_KEY: ""  # REQUIRED - Base64 encoded 32-byte key (generate with: openssl rand -base64 32)
-    APP_ENC_KEY_VERSION: "1"
-    CRYPTO_ENCRYPT_SECRET_KEY_SEAWEEDFS: ""
-    CRYPTO_HASH_SECRET_KEY_SEAWEEDFS: ""
 
   useExistingSecret: false
   existingSecretName: ""
@@ -134,6 +124,7 @@ common:
     ENABLE_TELEMETRY: "false"
     OTEL_INSECURE_EXPORTER: "false"
 
+# Shared secrets (used by both manager and worker)
 secrets:
   MONGO_USER: ""  # REQUIRED - MongoDB username
   MONGO_PASSWORD: ""  # REQUIRED - MongoDB password
@@ -143,6 +134,17 @@ secrets:
   REDIS_PASSWORD: ""
   LICENSE_KEY: ""  # REQUIRED - Lerian license key
   ORGANIZATION_IDS: ""
+  APP_ENC_KEY: ""  # REQUIRED - Base64 encoded 32-byte key (generate with: openssl rand -base64 32)
+  APP_ENC_KEY_VERSION: "1"
+  # Storage Encryption Keys
+  CRYPTO_ENCRYPT_FILE_STORAGE: ""
+  CRYPTO_HASH_SECRET_KEY_FILE_STORAGE: ""
+  # CRM Plugin Encryption Keys
+  CRYPTO_ENCRYPT_SECRET_KEY_PLUGIN_CRM: ""
+  CRYPTO_HASH_SECRET_KEY_PLUGIN_CRM: ""
+  # S3 Object Storage Credentials
+  OBJECT_STORAGE_ACCESS_KEY_ID: ""
+  OBJECT_STORAGE_SECRET_KEY: ""
 
 # External RabbitMQ Bootstrap - Apply definitions to external RabbitMQ
 externalRabbitmqDefinitions:

--- a/charts/fetcher/values.yaml
+++ b/charts/fetcher/values.yaml
@@ -146,10 +146,6 @@ manager:
     RATE_LIMIT_REDIS_TIMEOUT_MS: "500"
     ALLOW_RATELIMIT_DISABLED: ""
     ALLOW_RATELIMIT_FAIL_OPEN: ""
-  # Manager-specific Secrets
-  secrets:
-    APP_ENC_KEY: "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=" # Base64 encoded 32-byte key
-    APP_ENC_KEY_VERSION: "1"
   extraEnvVars: {}
   useExistingSecret: false
   existingSecretName: ""
@@ -216,19 +212,6 @@ worker:
     RATE_LIMIT_REDIS_TIMEOUT_MS: "500"
     ALLOW_RATELIMIT_DISABLED: ""
     ALLOW_RATELIMIT_FAIL_OPEN: ""
-  # Worker-specific Secrets
-  secrets:
-    APP_ENC_KEY: "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=" # Base64 encoded 32-byte key
-    APP_ENC_KEY_VERSION: "1"
-    # Storage Encryption Keys
-    CRYPTO_ENCRYPT_FILE_STORAGE: ""
-    CRYPTO_HASH_SECRET_KEY_FILE_STORAGE: ""
-    # CRM Plugin Encryption Keys
-    CRYPTO_ENCRYPT_SECRET_KEY_PLUGIN_CRM: ""
-    CRYPTO_HASH_SECRET_KEY_PLUGIN_CRM: ""
-    # S3 Object Storage Credentials
-    OBJECT_STORAGE_ACCESS_KEY_ID: ""
-    OBJECT_STORAGE_SECRET_KEY: ""
   extraEnvVars: {}
   useExistingSecret: false
   existingSecretName: ""
@@ -274,7 +257,7 @@ common:
     MULTI_TENANT_IDLE_TIMEOUT_SEC: "300"
     MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
     MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
-# Shared secrets
+# Shared secrets (used by both manager and worker)
 secrets:
   MONGO_USER: "fetcher"
   MONGO_PASSWORD: "lerian"
@@ -284,6 +267,17 @@ secrets:
   REDIS_PASSWORD: ""
   LICENSE_KEY: ""
   ORGANIZATION_IDS: ""
+  APP_ENC_KEY: "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="
+  APP_ENC_KEY_VERSION: "1"
+  # Storage Encryption Keys
+  CRYPTO_ENCRYPT_FILE_STORAGE: ""
+  CRYPTO_HASH_SECRET_KEY_FILE_STORAGE: ""
+  # CRM Plugin Encryption Keys
+  CRYPTO_ENCRYPT_SECRET_KEY_PLUGIN_CRM: ""
+  CRYPTO_HASH_SECRET_KEY_PLUGIN_CRM: ""
+  # S3 Object Storage Credentials
+  OBJECT_STORAGE_ACCESS_KEY_ID: ""
+  OBJECT_STORAGE_SECRET_KEY: ""
 # =============================================================================
 # Optional Dependencies - Enable to deploy components in Kubernetes
 # =============================================================================


### PR DESCRIPTION
## Summary
This hotfix aligns the fetcher chart secrets pattern with the reporter chart for consistency.

## Problem
- Fetcher chart templates used `.Values.manager.secrets` and `.Values.worker.secrets`
- Reporter chart templates use shared `.Values.secrets` for both manager and worker
- This inconsistency caused confusion and issues with ExternalSecrets configuration

## Changes
- **templates/manager/secrets.yaml**: Changed from `.Values.manager.secrets` to `.Values.secrets`
- **templates/worker/secrets.yaml**: Changed from `.Values.worker.secrets` to `.Values.secrets`
- **values.yaml**: Moved all secrets to shared `secrets:` section
- **values-template.yaml**: Same as values.yaml
- **Chart.yaml**: Bumped version to 2.1.2

## Result
Both `fetcher-manager` and `fetcher-worker` secrets now contain the same keys from the shared `secrets:` section, matching the reporter chart pattern.

## Testing
- `helm lint` passes
- `helm template` generates correct secrets for both manager and worker