### PR TITLE
feat(plugin-fees): add multi-tenant support and fix AVP secret rendering

### DIFF
--- a/charts/plugin-fees/CHANGELOG.md
+++ b/charts/plugin-fees/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Plugin-fees Changelog
 
+## [5.1.0](https://github.com/LerianStudio/helm/releases/tag/plugin-fees-v5.1.0)
+
+- Features:
+  - Added multi-tenant support via tenant-manager. New configmap fields (rendered when `MULTI_TENANT_ENABLED=true`): `MULTI_TENANT_URL`, `MULTI_TENANT_ENVIRONMENT`, `MULTI_TENANT_MAX_TENANT_POOLS`, `MULTI_TENANT_IDLE_TIMEOUT_SEC`, `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD`, `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC`, `MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC`, `MULTI_TENANT_REDIS_HOST`, `MULTI_TENANT_REDIS_PORT`, `MULTI_TENANT_REDIS_TLS`. New secret fields: `MULTI_TENANT_SERVICE_API_KEY` (required when enabled), `MULTI_TENANT_REDIS_PASSWORD` (optional).
+  - Added `useExistingSecret` guard on the in-tree Secret manifest to avoid creating a default Secret when an external one is provided.
+  - Added `checksum/config` and `checksum/secret` pod annotations so ConfigMap/Secret changes automatically trigger pod rollouts.
+
+- Fixes:
+  - Migrated `fees` Secret from `data:` + `b64enc` to `stringData:`. The previous pattern silently broke argocd-vault-plugin (AVP) substitution because Helm encoded the `<path:...>` placeholder before AVP could resolve it. Existing deployments that relied on AVP for `MONGO_PASSWORD`, `CLIENT_SECRET`, `LICENSE_KEY`, or `ORGANIZATION_IDS` will now receive the actual Vault values on the next sync (was previously falling back to chart defaults).
+
+- Breaking notes:
+  - **Behavior change for AVP users:** Secret values that were silently falling back to chart defaults (e.g. `MONGO_PASSWORD: lerian`) will now be replaced by the real Vault values on first sync. Operators must verify that downstream services (MongoDB user, OAuth client) are provisioned with the credentials stored in Vault before upgrading.
+  - **Pre-encoded secrets in Vault are no longer supported:** if any consumer was storing base64-pre-encoded values in Vault, switch them to plaintext.
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/plugin-fees-v5.0.0...plugin-fees-v5.1.0)
+
+---
+
 ## [4.1.2](https://github.com/LerianStudio/helm/releases/tag/plugin-fees-v4.1.2)
 
 - Fixes:

--- a/charts/plugin-fees/Chart.yaml
+++ b/charts/plugin-fees/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.0.0
+version: 5.1.0
 # This is the version number of the application being deployed.
 appVersion: "3.1.0"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/plugin-fees/templates/fees/configmap.yaml
+++ b/charts/plugin-fees/templates/fees/configmap.yaml
@@ -75,6 +75,21 @@ data:
   ACCOUNT_CACHE_ENABLED: {{ .Values.fees.configmap.ACCOUNT_CACHE_ENABLED | default "true" | quote }}
   ACCOUNT_CACHE_TTL_SECONDS: {{ .Values.fees.configmap.ACCOUNT_CACHE_TTL_SECONDS | default "300" | quote }}
 
+  # MULTI TENANT
+  MULTI_TENANT_ENABLED: {{ .Values.fees.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
+  {{- if eq (.Values.fees.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true" }}
+  MULTI_TENANT_URL: {{ required "fees.configmap.MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true" .Values.fees.configmap.MULTI_TENANT_URL | quote }}
+  MULTI_TENANT_ENVIRONMENT: {{ .Values.fees.configmap.MULTI_TENANT_ENVIRONMENT | default "" | quote }}
+  MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.fees.configmap.MULTI_TENANT_MAX_TENANT_POOLS | default "100" | quote }}
+  MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.fees.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.fees.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | default "5" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.fees.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
+  MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: {{ .Values.fees.configmap.MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC | default "60" | quote }}
+  MULTI_TENANT_REDIS_HOST: {{ required "fees.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.fees.configmap.MULTI_TENANT_REDIS_HOST | quote }}
+  MULTI_TENANT_REDIS_PORT: {{ .Values.fees.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
+  MULTI_TENANT_REDIS_TLS: {{ .Values.fees.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
+  {{- end }}
+
   # Extra Env Vars
   {{- with .Values.fees.extraEnvVars }}
   {{- toYaml . | nindent 2 }}

--- a/charts/plugin-fees/templates/fees/deployment.yaml
+++ b/charts/plugin-fees/templates/fees/deployment.yaml
@@ -16,6 +16,11 @@ spec:
     metadata:
       labels:
         {{- include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name ) | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/fees/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.fees.useExistingSecret }}
+        checksum/secret: {{ include (print $.Template.BasePath "/fees/secrets.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       {{- with .Values.fees.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/plugin-fees/templates/fees/secrets.yaml
+++ b/charts/plugin-fees/templates/fees/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.fees.useExistingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,11 +6,19 @@ metadata:
   labels:
     {{- include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name ) | nindent 4 }}
 type: Opaque
-data:
+stringData:
   # -- Default sensitive variables for the plugin-fees
   # MONGO Secrets
-  MONGO_PASSWORD: {{ .Values.fees.secrets.MONGO_PASSWORD | default "lerian" | b64enc| quote }}
-  CLIENT_SECRET: {{ .Values.fees.secrets.CLIENT_SECRET | default "6add4bc64f394456a77fa85708ad8c9b67e39e4c" | b64enc | quote }}
+  MONGO_PASSWORD: {{ .Values.fees.secrets.MONGO_PASSWORD | default "lerian" | quote }}
+  CLIENT_SECRET: {{ .Values.fees.secrets.CLIENT_SECRET | default "6add4bc64f394456a77fa85708ad8c9b67e39e4c" | quote }}
   # LICENSE Secrets
-  LICENSE_KEY: {{ .Values.fees.secrets.LICENSE_KEY | b64enc | quote }}
-  ORGANIZATION_IDS: {{ .Values.fees.secrets.ORGANIZATION_IDS | b64enc | quote }}
+  LICENSE_KEY: {{ .Values.fees.secrets.LICENSE_KEY | quote }}
+  ORGANIZATION_IDS: {{ .Values.fees.secrets.ORGANIZATION_IDS | quote }}
+  # Multi-Tenant Secrets
+  {{- if eq (.Values.fees.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true" }}
+  MULTI_TENANT_SERVICE_API_KEY: {{ required "fees.secrets.MULTI_TENANT_SERVICE_API_KEY is required when MULTI_TENANT_ENABLED=true" .Values.fees.secrets.MULTI_TENANT_SERVICE_API_KEY | quote }}
+  {{- if .Values.fees.secrets.MULTI_TENANT_REDIS_PASSWORD }}
+  MULTI_TENANT_REDIS_PASSWORD: {{ .Values.fees.secrets.MULTI_TENANT_REDIS_PASSWORD | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -174,6 +174,28 @@ fees:
     ACCOUNT_CACHE_ENABLED: "true"
     ACCOUNT_CACHE_TTL_SECONDS: "300"
     TRUSTED_PROXIES: ""
+    # -- Enable multi-tenant support via tenant-manager
+    MULTI_TENANT_ENABLED: "false"
+    # -- URL of the tenant-manager service (required when MULTI_TENANT_ENABLED=true)
+    MULTI_TENANT_URL: ""
+    # -- Environment label sent to tenant-manager for tenant scoping
+    MULTI_TENANT_ENVIRONMENT: ""
+    # -- Maximum number of per-tenant MongoDB connection pools
+    MULTI_TENANT_MAX_TENANT_POOLS: "100"
+    # -- Seconds before an idle tenant connection pool is released
+    MULTI_TENANT_IDLE_TIMEOUT_SEC: "300"
+    # -- Number of failures before the circuit breaker opens
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    # -- Seconds the circuit breaker stays open before retrying
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
+    # -- Interval in seconds to re-check tenant-manager settings
+    MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: "60"
+    # -- Hostname of the Redis/Valkey instance used for tenant cache
+    MULTI_TENANT_REDIS_HOST: ""
+    # -- Port of the Redis/Valkey instance
+    MULTI_TENANT_REDIS_PORT: "6379"
+    # -- Enable TLS for the Redis/Valkey connection
+    MULTI_TENANT_REDIS_TLS: "false"
   extraEnvVars: {}
   # -- Secrets for storing sensitive data
   # -- All secrets are declared in the templates/secrets.yaml
@@ -186,6 +208,10 @@ fees:
     CLIENT_SECRET: "6add4bc64f394456a77fa85708ad8c9b67e39e4c"
     LICENSE_KEY: ""
     ORGANIZATION_IDS: ""
+    # -- API key used to authenticate with the tenant-manager service (required when MULTI_TENANT_ENABLED=true)
+    MULTI_TENANT_SERVICE_API_KEY: ""
+    # -- Password for the Redis/Valkey instance used by the multi-tenant cache (required when MULTI_TENANT_ENABLED=true)
+    MULTI_TENANT_REDIS_PASSWORD: ""
 frontend:
   # -- Service name
   name: plugin-fees-ui


### PR DESCRIPTION
## Summary

- Adds multi-tenant support to the `plugin-fees` chart following the same pattern used by `matcher` and `plugin-br-bank-transfer`
- Fixes silent argocd-vault-plugin (AVP) substitution failure by migrating the `fees` Secret from `data:` + `b64enc` to `stringData:`
- Adds operational hardening: `useExistingSecret` guard, `required` validation, and `checksum/config|secret` pod annotations

## Changes

| File | Change |
|------|--------|
| `Chart.yaml` | Bumped version `5.0.0 → 5.1.0` |
| `templates/fees/configmap.yaml` | Added 11 `MULTI_TENANT_*` env vars (conditional on `MULTI_TENANT_ENABLED=true`); `MULTI_TENANT_URL` and `MULTI_TENANT_REDIS_HOST` use `required` |
| `templates/fees/secrets.yaml` | Migrated to `stringData:`; wrapped in `{{- if not .Values.fees.useExistingSecret }}`; added `MULTI_TENANT_SERVICE_API_KEY` (required when enabled) and `MULTI_TENANT_REDIS_PASSWORD` (optional) |
| `templates/fees/deployment.yaml` | Added `checksum/config` and `checksum/secret` pod annotations |
| `values.yaml` | Added defaults for the new fields with helm-docs annotations |
| `CHANGELOG.md` | Documented the feature, fix, and breaking-behavior notes |

## Why the data → stringData migration

Verified empirically that the existing `data:` + `b64enc` pattern was breaking AVP substitution in production:

```bash
$ kubectl get secret plugin-fees -n midaz-plugins-dev -o jsonpath='{.data.MONGO_PASSWORD}' | base64 -d
lerian   # the chart default — AVP placeholder was being base64-encoded as literal string
```

Helm runs `b64enc` on the literal `<path:secret/data/...#KEY>` placeholder string before AVP gets a chance to substitute it, so the actual Vault value never reaches the rendered manifest. The `plugin-br-bank-transfer` chart already uses `stringData:` correctly for the same reason.

## Breaking notes for consumers

After upgrading, the next ArgoCD sync will rotate `MONGO_PASSWORD`, `CLIENT_SECRET`, `LICENSE_KEY`, and `ORGANIZATION_IDS` from chart defaults to actual Vault values. Operators must verify that downstream services (MongoDB user, OAuth client) are provisioned with the credentials stored in Vault before upgrading.

If any consumer was storing pre-base64-encoded values in Vault, switch them to plaintext.

## Validation

- `helm lint charts/plugin-fees` — passes
- `helm template` (default, multi-tenant off) — renders cleanly, no `MULTI_TENANT_*` keys in ConfigMap
- `helm template --set fees.configmap.MULTI_TENANT_ENABLED=true` — fails fast with clear error: `fees.secrets.MULTI_TENANT_SERVICE_API_KEY is required when MULTI_TENANT_ENABLED=true`
- `helm template` with all required fields — renders all `MULTI_TENANT_*` configmap keys, both Secret keys, and `checksum/config`+`checksum/secret` annotations
- `helm template --set fees.useExistingSecret=true --set fees.existingSecretName=external-secret` — in-tree Secret skipped, deployment references `external-secret`

## Test plan

- [ ] Approve and merge to `develop`
- [ ] CI publishes `plugin-fees-helm:5.1.0` to Docker Hub OCI registry
- [ ] Update `midaz-firmino-gitops` to pin chart version `5.1.0` and verify the multi-tenant rollout in Clotilde dev
- [ ] Verify Vault paths resolve correctly (no more silent fallback to chart defaults)