### PR TITLE
fix(plugin-fees): remove MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC

### DIFF
--- a/charts/plugin-fees/templates/fees/configmap.yaml
+++ b/charts/plugin-fees/templates/fees/configmap.yaml
@@ -85,7 +85,6 @@ data:
   MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.fees.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
   MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.fees.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | default "5" | quote }}
   MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.fees.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
-  MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: {{ .Values.fees.configmap.MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC | default "60" | quote }}
   MULTI_TENANT_REDIS_HOST: {{ required "fees.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.fees.configmap.MULTI_TENANT_REDIS_HOST | quote }}
   MULTI_TENANT_REDIS_PORT: {{ .Values.fees.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.fees.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -189,7 +189,6 @@ fees:
     # -- Seconds the circuit breaker stays open before retrying
     MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
     # -- Interval in seconds to re-check tenant-manager settings
-    MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC: "60"
     # -- Hostname of the Redis/Valkey instance used for tenant cache
     MULTI_TENANT_REDIS_HOST: ""
     # -- Port of the Redis/Valkey instance


### PR DESCRIPTION
Removes `MULTI_TENANT_SETTINGS_CHECK_INTERVAL_SEC` from plugin-fees configmap template and default values.

Requested by: @jeffersonrodrigues-lerian