### PR TITLE
feat(plugin-fees): add IAM Roles Anywhere sidecar support

### DIFF
--- a/charts/plugin-fees/templates/fees/deployment.yaml
+++ b/charts/plugin-fees/templates/fees/deployment.yaml
@@ -26,8 +26,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
+      securityContext:
+        fsGroup: 65532
+      {{- else }}
       securityContext:
         {{- toYaml .Values.fees.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "plugin-fees.fullname" . }}
           image: "{{ .Values.fees.image.repository }}:{{ .Values.fees.image.tag | default (include "plugin.version" .) }}"
@@ -41,15 +46,23 @@ spec:
                 name: {{ if .Values.fees.useExistingSecret }}{{ .Values.fees.existingSecretName }}{{ else }}{{ include "plugin-fees.fullname" . }}{{ end }}
             - configMapRef:
                 name: {{ include "plugin-fees.fullname" . }}
-          {{ if (index .Values "otel-collector-lerian").enabled }}
+          {{- if or (index .Values "otel-collector-lerian").enabled (and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled) }}
           env:
+          {{- if (index .Values "otel-collector-lerian").enabled }}
           - name: "HOST_IP"
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
             value: "$(HOST_IP):4317"
-          {{ end }}              
+          {{- end }}
+          {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
+          - name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+            value: "http://127.0.0.1:{{ .Values.aws.rolesAnywhere.sidecar.port | default 9911 }}"
+          - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
+            value: "IPv4"
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.fees.resources | nindent 12 }}
           readinessProbe:
@@ -64,6 +77,59 @@ spec:
               port: {{ .Values.fees.service.port }}
             initialDelaySeconds: 5
             periodSeconds: 5
+        {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
+        - name: aws-signing-helper
+          image: "{{ .Values.aws.rolesAnywhere.sidecar.image.repository }}:{{ .Values.aws.rolesAnywhere.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.aws.rolesAnywhere.sidecar.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - serve
+            - --certificate
+            - /certs/tls.crt
+            - --private-key
+            - /certs/tls.key
+            - --trust-anchor-arn
+            - "{{ required "aws.rolesAnywhere.trustAnchorArn is required when rolesAnywhere is enabled" .Values.aws.rolesAnywhere.trustAnchorArn }}"
+            - --profile-arn
+            - "{{ required "aws.rolesAnywhere.profileArn is required when rolesAnywhere is enabled" .Values.aws.rolesAnywhere.profileArn }}"
+            - --role-arn
+            - "{{ required "aws.rolesAnywhere.roleArn is required when rolesAnywhere is enabled" .Values.aws.rolesAnywhere.roleArn }}"
+            - --region
+            - "{{ .Values.aws.rolesAnywhere.region | default "us-east-2" }}"
+            - --session-duration
+            - "{{ .Values.aws.rolesAnywhere.sessionDuration | default 3600 }}"
+            - --port
+            - "{{ .Values.aws.rolesAnywhere.sidecar.port | default 9911 }}"
+          ports:
+            - name: imds
+              containerPort: {{ .Values.aws.rolesAnywhere.sidecar.port | default 9911 }}
+              protocol: TCP
+          volumeMounts:
+            - name: iam-certs
+              mountPath: /certs
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          resources:
+            {{- toYaml .Values.aws.rolesAnywhere.sidecar.resources | nindent 12 }}
+        {{- end }}
+      {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
+      volumes:
+        - name: iam-certs
+          secret:
+            secretName: {{ .Values.aws.rolesAnywhere.certificateSecretName | default "plugin-fees-iam-tls" }}
+            defaultMode: 0440
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+      {{- end }}
       {{- with .Values.fees.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -353,3 +353,26 @@ mongodb:
   resourcesPreset: "medium"
 otel-collector-lerian:
   enabled: true
+# AWS Authentication - IAM Roles Anywhere for non-AWS clusters (e.g. Proxmox)
+aws:
+  rolesAnywhere:
+    enabled: false
+    trustAnchorArn: ""
+    profileArn: ""
+    roleArn: ""
+    region: "us-east-2"
+    sessionDuration: 3600
+    certificateSecretName: "plugin-fees-iam-tls"
+    sidecar:
+      image:
+        repository: public.ecr.aws/rolesanywhere/credential-helper
+        tag: "latest-amd64"
+        pullPolicy: IfNotPresent
+      port: 9911
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi


### PR DESCRIPTION
## Summary

Add IAM Roles Anywhere support to the **plugin-fees** Helm chart, matching the existing pattern used by **matcher**, **fetcher**, and **reporter** charts.

## Changes

### `charts/plugin-fees/values.yaml`
- Added `aws.rolesAnywhere` configuration block (disabled by default)
- Includes trust anchor, profile, role ARNs, region, session duration, certificate secret name, and sidecar image/resources

### `charts/plugin-fees/templates/fees/deployment.yaml`
- Conditional `fsGroup: 65532` pod security context when IAM Roles Anywhere is enabled (required for cert volume access)
- `AWS_EC2_METADATA_SERVICE_ENDPOINT` and `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` env vars injected into the main container
- `aws-signing-helper` sidecar container with TLS certificate volume mount
- `iam-certs` volume sourced from the configured TLS secret

## Backward Compatibility
- **No breaking changes** -- `aws.rolesAnywhere.enabled` defaults to `false`
- Existing deployments are unaffected unless explicitly enabled via values override

## Verified
- `helm template` renders correctly with rolesAnywhere **disabled** (no IAM resources in output)
- `helm template` renders correctly with rolesAnywhere **enabled** (sidecar, volumes, env vars all present)