### PR TITLE
fix(product-console): add image annotation for product-console 1.6.0

### DIFF
--- a/charts/product-console/Chart.yaml
+++ b/charts/product-console/Chart.yaml
@@ -33,6 +33,11 @@ keywords:
 # The URL to an icon file for this chart. Or the icon data.
 icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
 
+annotations:
+  artifacthub.io/images: |
+    - name: product-console
+      image: ghcr.io/lerianstudio/product-console:1.6.0
+
 dependencies:
   - name: mongodb
     version: "16.4.0"


### PR DESCRIPTION
## Changes

Add `artifacthub.io/images` annotation to `Chart.yaml` to improve artifact traceability.

This also triggers a helm chart release for the `product-console` app version `1.6.0` update that was merged previously but did not produce a release.

**Image:** `ghcr.io/lerianstudio/product-console:1.6.0`