### PR TITLE
fix(product-console): release product-console 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,5 +195,5 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | Console Version |
 | :---: | :---: |
-| `2.2.0-beta.1` | 1.6.0 |
+| `2.2.0-beta.2` | 1.6.0 |
 -----------------

--- a/README.md
+++ b/README.md
@@ -195,5 +195,5 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | Console Version |
 | :---: | :---: |
-| `2.1.0` | 1.5.0 |
+| `2.2.0-beta.1` | 1.6.0 |
 -----------------

--- a/charts/product-console/Chart.yaml
+++ b/charts/product-console/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.0-beta.1
+version: 2.2.0-beta.2
 
 # This is the version number of the application being deployed.
 appVersion: "1.6.0"

--- a/charts/product-console/Chart.yaml
+++ b/charts/product-console/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.0
+version: 2.2.0-beta.1
 
 # This is the version number of the application being deployed.
 appVersion: "1.6.0"

--- a/charts/product-console/Chart.yaml
+++ b/charts/product-console/Chart.yaml
@@ -33,11 +33,6 @@ keywords:
 # The URL to an icon file for this chart. Or the icon data.
 icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
 
-annotations:
-  artifacthub.io/images: |
-    - name: product-console
-      image: ghcr.io/lerianstudio/product-console:1.6.0
-
 dependencies:
   - name: mongodb
     version: "16.4.0"

--- a/charts/product-console/Chart.yaml
+++ b/charts/product-console/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 version: 2.1.0
 
 # This is the version number of the application being deployed.
-appVersion: "1.5.0"
+appVersion: "1.6.0"
 
 # A list of keywords about the chart. This helps others discover the chart.
 keywords:

--- a/charts/product-console/Chart.yaml
+++ b/charts/product-console/Chart.yaml
@@ -33,6 +33,11 @@ keywords:
 # The URL to an icon file for this chart. Or the icon data.
 icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
 
+annotations:
+  artifacthub.io/images: |
+    - name: product-console
+      image: ghcr.io/lerianstudio/product-console:1.6.0
+
 dependencies:
   - name: mongodb
     version: "16.4.0"

--- a/charts/product-console/values.yaml
+++ b/charts/product-console/values.yaml
@@ -14,7 +14,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image tag used for deployment (defaults to Chart.AppVersion)
-  tag: "1.5.0"
+  tag: "1.6.0"
 
 # -- Secrets for pulling images from a private registry
 imagePullSecrets: []


### PR DESCRIPTION
## Changes

Promote product-console updates from develop to main for stable release.

### Product Console
- Bump `appVersion` from `1.5.0` to `1.6.0`
- Bump `image.tag` from `1.5.0` to `1.6.0`
- Add `artifacthub.io/images` annotation for artifact traceability

**Image:** `ghcr.io/lerianstudio/product-console:1.6.0`