### PR TITLE
fix(product-console): remove inconsistent artifacthub image annotation

### DIFF
--- a/charts/product-console/Chart.yaml
+++ b/charts/product-console/Chart.yaml
@@ -33,11 +33,6 @@ keywords:
 # The URL to an icon file for this chart. Or the icon data.
 icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
 
-annotations:
-  artifacthub.io/images: |
-    - name: product-console
-      image: ghcr.io/lerianstudio/product-console:1.6.0
-
 dependencies:
   - name: mongodb
     version: "16.4.0"


### PR DESCRIPTION
## Changes

Remove the `artifacthub.io/images` annotation from `Chart.yaml`.

The annotation referenced `ghcr.io/lerianstudio/product-console:1.6.0` which is inconsistent with `values.yaml` (`image.repository: lerianstudio/product-console`) and the deployment template. It was only added to trigger a release and should not be kept.