### PR TITLE
feat(plugin-fees): add M2M and AWS_REGION env vars

### DIFF
--- a/charts/plugin-fees/templates/fees/configmap.yaml
+++ b/charts/plugin-fees/templates/fees/configmap.yaml
@@ -75,6 +75,13 @@ data:
   ACCOUNT_CACHE_ENABLED: {{ .Values.fees.configmap.ACCOUNT_CACHE_ENABLED | default "true" | quote }}
   ACCOUNT_CACHE_TTL_SECONDS: {{ .Values.fees.configmap.ACCOUNT_CACHE_TTL_SECONDS | default "300" | quote }}
 
+  # M2M (Machine-to-Machine)
+  M2M_TARGET_SERVICE: {{ .Values.fees.configmap.M2M_TARGET_SERVICE | default "" | quote }}
+  M2M_CREDENTIAL_CACHE_TTL_SEC: {{ .Values.fees.configmap.M2M_CREDENTIAL_CACHE_TTL_SEC | default "30" | quote }}
+
+  # AWS
+  AWS_REGION: {{ .Values.fees.configmap.AWS_REGION | default "" | quote }}
+
   # MULTI TENANT
   MULTI_TENANT_ENABLED: {{ .Values.fees.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
   {{- if eq (.Values.fees.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true" }}

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -174,6 +174,12 @@ fees:
     ACCOUNT_CACHE_ENABLED: "true"
     ACCOUNT_CACHE_TTL_SECONDS: "300"
     TRUSTED_PROXIES: ""
+    # -- Target service name for M2M (machine-to-machine) authentication
+    M2M_TARGET_SERVICE: ""
+    # -- TTL in seconds for cached M2M credentials
+    M2M_CREDENTIAL_CACHE_TTL_SEC: "30"
+    # -- AWS region for IAM Roles Anywhere and other AWS integrations
+    AWS_REGION: ""
     # -- Enable multi-tenant support via tenant-manager
     MULTI_TENANT_ENABLED: "false"
     # -- URL of the tenant-manager service (required when MULTI_TENANT_ENABLED=true)


### PR DESCRIPTION
## What

Add three new environment variables to the plugin-fees Helm chart:

| Variable | Default | Purpose |
|----------|---------|---------|
| `M2M_TARGET_SERVICE` | `""` | Target service name for machine-to-machine authentication |
| `M2M_CREDENTIAL_CACHE_TTL_SEC` | `"30"` | TTL in seconds for cached M2M credentials |
| `AWS_REGION` | `""` | AWS region for IAM Roles Anywhere |

Both configmap template and values.yaml updated.

Requested by: @jeffersongr