### PR TITLE
feat(plugin-fees): add APPLICATION_NAME, MULTI_TENANT_TIMEOUT, MULTI_TENANT_CACHE_TTL_SEC

### DIFF
--- a/charts/plugin-fees/templates/fees/configmap.yaml
+++ b/charts/plugin-fees/templates/fees/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   # -- Default Environment variables for the plugin-fees 
   ENV_NAME: {{ .Values.fees.configmap.ENV_NAME | default "development" | quote }}
+  APPLICATION_NAME: {{ .Values.fees.configmap.APPLICATION_NAME | default "plugin-fees" | quote }}
 
   # APP 
   SERVER_PORT: {{ .Values.fees.configmap.SERVER_PORT | default "4002" | quote }}
@@ -95,6 +96,8 @@ data:
   MULTI_TENANT_REDIS_HOST: {{ required "fees.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.fees.configmap.MULTI_TENANT_REDIS_HOST | quote }}
   MULTI_TENANT_REDIS_PORT: {{ .Values.fees.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.fees.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
+  MULTI_TENANT_TIMEOUT: {{ .Values.fees.configmap.MULTI_TENANT_TIMEOUT | default "30" | quote }}
+  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.fees.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
   {{- end }}
 
   # Extra Env Vars

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -151,6 +151,8 @@ fees:
   configmap:
     # -- Default Environment
     ENV_NAME: "development"
+    # -- Application name used for service identification in logs/tracing
+    APPLICATION_NAME: "plugin-fees"
     PLUGIN_AUTH_ENABLED: "false"
     PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth:4000"
     MONGO_HOST: "plugin-fees-mongodb.midaz-plugins.svc.cluster.local"
@@ -201,6 +203,10 @@ fees:
     MULTI_TENANT_REDIS_PORT: "6379"
     # -- Enable TLS for the Redis/Valkey connection
     MULTI_TENANT_REDIS_TLS: "false"
+    # -- HTTP client timeout in seconds for tenant-manager requests
+    MULTI_TENANT_TIMEOUT: "30"
+    # -- TTL in seconds for local tenant config cache (0 = disabled)
+    MULTI_TENANT_CACHE_TTL_SEC: "120"
   extraEnvVars: {}
   # -- Secrets for storing sensitive data
   # -- All secrets are declared in the templates/secrets.yaml


### PR DESCRIPTION
## What

Add three missing env vars to the plugin-fees configmap template + values.yaml:

| Variable | Default | Purpose |
|----------|---------|---------|
| `APPLICATION_NAME` | `plugin-fees` | Service identification for logs/tracing |
| `MULTI_TENANT_TIMEOUT` | `30` | HTTP client timeout (seconds) for tenant-manager requests |
| `MULTI_TENANT_CACHE_TTL_SEC` | `120` | TTL (seconds) for local tenant config cache (0 = disabled) |

Found by comparing the chart against the app's .env reference.

Requested by: @jeffersongr