### PR TITLE
fix(plugins): separate RABBITMQ_HOST from RABBITMQ_URL in bc-correios chart

### DIFF
--- a/charts/plugin-bc-correios/templates/configmap.yaml
+++ b/charts/plugin-bc-correios/templates/configmap.yaml
@@ -30,10 +30,11 @@ data:
   POSTGRES_MIN_CONNS: {{ $component.configmap.POSTGRES_MIN_CONNS | default "5" | quote }}
 
   # RabbitMQ
-  # NOTE: When using external RabbitMQ, RABBITMQ_URL must be set explicitly in configmap overrides
-  # to match the actual user and host. The default URL below is only valid for bundled RabbitMQ.
   RABBITMQ_USER: {{ $component.configmap.RABBITMQ_USER | default "plugin-bc-correios" | quote }}
-  RABBITMQ_URL: {{ $component.configmap.RABBITMQ_URL | default (printf "amqp://%s:$(RABBITMQ_PASS)@%s-rabbitmq:5672/" ($component.configmap.RABBITMQ_USER | default "plugin-bc-correios") .Release.Name) | quote }}
+  # RABBITMQ_HOST is used by the init container to wait for RabbitMQ (no credentials needed).
+  # For bundled RabbitMQ, defaults to the subchart service name.
+  # For external RabbitMQ, set configmap.RABBITMQ_HOST to the external hostname.
+  RABBITMQ_HOST: {{ $component.configmap.RABBITMQ_HOST | default (printf "%s-rabbitmq" .Release.Name) | quote }}
 
   # Cache (Valkey)
   CACHE_ADDR: {{ $component.configmap.CACHE_ADDR | default (printf "%s-valkey-master:6379" .Release.Name) | quote }}

--- a/charts/plugin-bc-correios/templates/deployment.yaml
+++ b/charts/plugin-bc-correios/templates/deployment.yaml
@@ -73,8 +73,7 @@ spec:
               wait_for_service "$POSTGRES_HOST" "$POSTGRES_PORT"
 
               # Wait for RabbitMQ (AMQP port)
-              # Handles both amqp://user:pass@host:port/ and amqp://user@host:port/ formats
-              RABBITMQ_HOST=$(echo "$RABBITMQ_URL" | sed 's|amqp://[^@]*@||' | cut -d: -f1 | cut -d/ -f1)
+              # Uses RABBITMQ_HOST from configmap — no credentials required for TCP check
               wait_for_service "$RABBITMQ_HOST" "5672"
 
               # Wait for Valkey/Cache

--- a/charts/plugin-bc-correios/templates/secrets.yaml
+++ b/charts/plugin-bc-correios/templates/secrets.yaml
@@ -16,6 +16,7 @@ stringData:
 
   # RabbitMQ credentials
   RABBITMQ_PASS: {{ required "bc-correios.secrets.RABBITMQ_PASS is required" $component.secrets.RABBITMQ_PASS | quote }}
+  RABBITMQ_URL: {{ required "bc-correios.secrets.RABBITMQ_URL is required" $component.secrets.RABBITMQ_URL | quote }}
 
   # AES-256 encryption key (32 bytes)
   ENCRYPTION_KEY: {{ required "bc-correios.secrets.ENCRYPTION_KEY is required" $component.secrets.ENCRYPTION_KEY | quote }}

--- a/charts/plugin-bc-correios/values.yaml
+++ b/charts/plugin-bc-correios/values.yaml
@@ -197,7 +197,7 @@ bc-correios:
     POSTGRES_MIN_CONNS: "5"
     # RabbitMQ
     RABBITMQ_USER: "plugin-bc-correios"
-    RABBITMQ_URL: "amqp://plugin-bc-correios:$(RABBITMQ_PASS)@plugin-bc-correios-rabbitmq:5672/"
+    RABBITMQ_HOST: "plugin-bc-correios-rabbitmq"
     # Cache (Valkey)
     CACHE_ADDR: "plugin-bc-correios-valkey-master:6379"
     CACHE_TTL_SEC: "60"
@@ -238,6 +238,7 @@ bc-correios:
     POSTGRES_PASSWORD: "lerian"
     # RabbitMQ credentials
     RABBITMQ_PASS: "lerian"
+    RABBITMQ_URL: "amqp://plugin-bc-correios:lerian@plugin-bc-correios-rabbitmq:5672/"
     # AES-256 encryption key (32 bytes — override with a real key in production)
     ENCRYPTION_KEY: "01234567890123456789012345678901"
     # Cache (Valkey) credentials


### PR DESCRIPTION
## Summary

- Add `RABBITMQ_HOST` to configmap (hostname only, no credentials)
- Move `RABBITMQ_URL` (full URL with password) to secrets
- Update init container to use `RABBITMQ_HOST` directly instead of parsing `RABBITMQ_URL`

## Why

The init container does a TCP check (`nc -z $host 5672`) to wait for RabbitMQ. It only needs the hostname — not the full URL with embedded password. Previously, it parsed `RABBITMQ_URL` from the configmap, which forced the URL (with password) to live in a ConfigMap rather than a Secret.

## Test plan

- [ ] Init container resolves external RabbitMQ host correctly
- [ ] App connects to RabbitMQ using `RABBITMQ_URL` from Secret
- [ ] `helm lint` passes
- [ ] Gitops values updated: `configmap.RABBITMQ_HOST` + `secrets.RABBITMQ_URL`