### PR TITLE
feat(charts): parametrize probe path and timing for all charts using /readyz

### DIFF
--- a/charts/fetcher/templates/manager/deployment.yaml
+++ b/charts/fetcher/templates/manager/deployment.yaml
@@ -79,19 +79,21 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.manager.livenessProbe.path | default "/health" }}
               port: http
             initialDelaySeconds: {{ .Values.manager.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.manager.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.manager.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.manager.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.manager.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.manager.readinessProbe.path | default "/readyz" }}
               port: http
             initialDelaySeconds: {{ .Values.manager.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.manager.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.manager.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.manager.readinessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.manager.readinessProbe.failureThreshold }}
           resources:
             {{- toYaml .Values.manager.resources | nindent 12 }}

--- a/charts/flowker/templates/deployment.yaml
+++ b/charts/flowker/templates/deployment.yaml
@@ -88,9 +88,7 @@ spec:
             initialDelaySeconds: {{ .Values.flowker.livenessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.flowker.livenessProbe.periodSeconds | default 20 }}
             timeoutSeconds: {{ .Values.flowker.livenessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.flowker.livenessProbe (hasKey (.Values.flowker.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.flowker.livenessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.flowker.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.flowker.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
@@ -99,9 +97,7 @@ spec:
             initialDelaySeconds: {{ .Values.flowker.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.flowker.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.flowker.readinessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.flowker.readinessProbe (hasKey (.Values.flowker.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.flowker.readinessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.flowker.readinessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.flowker.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.flowker.resources | nindent 12 }}

--- a/charts/flowker/templates/deployment.yaml
+++ b/charts/flowker/templates/deployment.yaml
@@ -83,20 +83,26 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: {{ .Values.flowker.livenessProbe.path | default "/health/live" }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.flowker.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ .Values.flowker.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.flowker.livenessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.flowker.livenessProbe (hasKey (.Values.flowker.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.flowker.livenessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.flowker.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.flowker.readinessProbe.path | default "/readyz" }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.flowker.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.flowker.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.flowker.readinessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.flowker.readinessProbe (hasKey (.Values.flowker.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.flowker.readinessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.flowker.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.flowker.resources | nindent 12 }}
       {{- with .Values.flowker.nodeSelector }}

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -40,6 +40,10 @@ global:
           db: "flowker"
 
 flowker:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: flowker
 

--- a/charts/matcher/templates/deployment.yaml
+++ b/charts/matcher/templates/deployment.yaml
@@ -105,20 +105,26 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.matcher.livenessProbe.path | default "/health" }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.matcher.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ .Values.matcher.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.matcher.livenessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.matcher.livenessProbe (hasKey (.Values.matcher.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.matcher.livenessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.matcher.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.matcher.readinessProbe.path | default "/readyz" }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.matcher.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.matcher.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.matcher.readinessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.matcher.readinessProbe (hasKey (.Values.matcher.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.matcher.readinessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.matcher.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.matcher.resources | nindent 12 }}
         {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}

--- a/charts/matcher/templates/deployment.yaml
+++ b/charts/matcher/templates/deployment.yaml
@@ -110,9 +110,7 @@ spec:
             initialDelaySeconds: {{ .Values.matcher.livenessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.matcher.livenessProbe.periodSeconds | default 20 }}
             timeoutSeconds: {{ .Values.matcher.livenessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.matcher.livenessProbe (hasKey (.Values.matcher.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.matcher.livenessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.matcher.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.matcher.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
@@ -121,9 +119,7 @@ spec:
             initialDelaySeconds: {{ .Values.matcher.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.matcher.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.matcher.readinessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.matcher.readinessProbe (hasKey (.Values.matcher.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.matcher.readinessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.matcher.readinessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.matcher.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.matcher.resources | nindent 12 }}

--- a/charts/matcher/values.yaml
+++ b/charts/matcher/values.yaml
@@ -65,6 +65,10 @@ global:
       password: "lerian"
 
 matcher:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: matcher
 

--- a/charts/midaz/templates/crm/deployment.yaml
+++ b/charts/midaz/templates/crm/deployment.yaml
@@ -72,16 +72,34 @@ spec:
             {{- toYaml .Values.crm.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.crm.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.crm.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.crm.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.crm.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.crm.readinessProbe (hasKey (.Values.crm.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.crm.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.crm.readinessProbe (hasKey (.Values.crm.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.crm.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.crm.readinessProbe (hasKey (.Values.crm.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.crm.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 10
-            periodSeconds: 5
             httpGet:
-              path: /health
+              path: {{ .Values.crm.livenessProbe.path | default "/health" }}
               port: {{ .Values.crm.service.port }}
+            initialDelaySeconds: {{ .Values.crm.livenessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.crm.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.crm.livenessProbe (hasKey (.Values.crm.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.crm.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.crm.livenessProbe (hasKey (.Values.crm.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.crm.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.crm.livenessProbe (hasKey (.Values.crm.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.crm.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.crm.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/midaz/templates/crm/deployment.yaml
+++ b/charts/midaz/templates/crm/deployment.yaml
@@ -76,30 +76,18 @@ spec:
               port: {{ .Values.crm.service.port }}
             initialDelaySeconds: {{ .Values.crm.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.crm.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.crm.readinessProbe (hasKey (.Values.crm.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.crm.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.crm.readinessProbe (hasKey (.Values.crm.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.crm.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.crm.readinessProbe (hasKey (.Values.crm.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.crm.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.crm.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.crm.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.crm.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.crm.livenessProbe.path | default "/health" }}
               port: {{ .Values.crm.service.port }}
             initialDelaySeconds: {{ .Values.crm.livenessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.crm.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.crm.livenessProbe (hasKey (.Values.crm.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.crm.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.crm.livenessProbe (hasKey (.Values.crm.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.crm.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.crm.livenessProbe (hasKey (.Values.crm.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.crm.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.crm.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.crm.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.crm.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.crm.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/midaz/templates/ledger/deployment.yaml
+++ b/charts/midaz/templates/ledger/deployment.yaml
@@ -93,40 +93,20 @@ spec:
             httpGet:
               path: {{ .Values.ledger.livenessProbe.path | default "/health" }}
               port: http
-            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "initialDelaySeconds") }}
-            initialDelaySeconds: {{ .Values.ledger.livenessProbe.initialDelaySeconds }}
-            {{- end }}
-            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "periodSeconds") }}
-            periodSeconds: {{ .Values.ledger.livenessProbe.periodSeconds }}
-            {{- end }}
-            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.ledger.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.ledger.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.ledger.livenessProbe.failureThreshold }}
-            {{- end }}
+            initialDelaySeconds: {{ .Values.ledger.livenessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.ledger.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.ledger.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.ledger.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.ledger.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
               path: {{ .Values.ledger.readinessProbe.path | default "/readyz" }}
               port: http
-            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "initialDelaySeconds") }}
-            initialDelaySeconds: {{ .Values.ledger.readinessProbe.initialDelaySeconds }}
-            {{- end }}
-            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "periodSeconds") }}
-            periodSeconds: {{ .Values.ledger.readinessProbe.periodSeconds }}
-            {{- end }}
-            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.ledger.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.ledger.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.ledger.readinessProbe.failureThreshold }}
-            {{- end }}
+            initialDelaySeconds: {{ .Values.ledger.readinessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.ledger.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.ledger.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.ledger.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.ledger.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.ledger.resources | nindent 12 }}
       {{- with .Values.ledger.nodeSelector }}

--- a/charts/midaz/templates/ledger/deployment.yaml
+++ b/charts/midaz/templates/ledger/deployment.yaml
@@ -91,12 +91,42 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.ledger.livenessProbe.path | default "/health" }}
               port: http
+            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "initialDelaySeconds") }}
+            initialDelaySeconds: {{ .Values.ledger.livenessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "periodSeconds") }}
+            periodSeconds: {{ .Values.ledger.livenessProbe.periodSeconds }}
+            {{- end }}
+            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.ledger.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.ledger.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.ledger.livenessProbe (hasKey (.Values.ledger.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.ledger.livenessProbe.failureThreshold }}
+            {{- end }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.ledger.readinessProbe.path | default "/readyz" }}
               port: http
+            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "initialDelaySeconds") }}
+            initialDelaySeconds: {{ .Values.ledger.readinessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "periodSeconds") }}
+            periodSeconds: {{ .Values.ledger.readinessProbe.periodSeconds }}
+            {{- end }}
+            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.ledger.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.ledger.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.ledger.readinessProbe (hasKey (.Values.ledger.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.ledger.readinessProbe.failureThreshold }}
+            {{- end }}
           resources:
             {{- toYaml .Values.ledger.resources | nindent 12 }}
       {{- with .Values.ledger.nodeSelector }}

--- a/charts/midaz/templates/onboarding/deployment.yaml
+++ b/charts/midaz/templates/onboarding/deployment.yaml
@@ -84,40 +84,20 @@ spec:
             httpGet:
               path: {{ .Values.onboarding.livenessProbe.path | default "/health" }}
               port: http
-            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "initialDelaySeconds") }}
-            initialDelaySeconds: {{ .Values.onboarding.livenessProbe.initialDelaySeconds }}
-            {{- end }}
-            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "periodSeconds") }}
-            periodSeconds: {{ .Values.onboarding.livenessProbe.periodSeconds }}
-            {{- end }}
-            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.onboarding.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.onboarding.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.onboarding.livenessProbe.failureThreshold }}
-            {{- end }}
+            initialDelaySeconds: {{ .Values.onboarding.livenessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.onboarding.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.onboarding.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.onboarding.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.onboarding.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
               path: {{ .Values.onboarding.readinessProbe.path | default "/readyz" }}
               port: http
-            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "initialDelaySeconds") }}
-            initialDelaySeconds: {{ .Values.onboarding.readinessProbe.initialDelaySeconds }}
-            {{- end }}
-            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "periodSeconds") }}
-            periodSeconds: {{ .Values.onboarding.readinessProbe.periodSeconds }}
-            {{- end }}
-            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.onboarding.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.onboarding.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.onboarding.readinessProbe.failureThreshold }}
-            {{- end }}
+            initialDelaySeconds: {{ .Values.onboarding.readinessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.onboarding.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.onboarding.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.onboarding.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.onboarding.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.onboarding.resources | nindent 12 }}
       {{- with .Values.onboarding.nodeSelector }}

--- a/charts/midaz/templates/onboarding/deployment.yaml
+++ b/charts/midaz/templates/onboarding/deployment.yaml
@@ -82,12 +82,42 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.onboarding.livenessProbe.path | default "/health" }}
               port: http
+            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "initialDelaySeconds") }}
+            initialDelaySeconds: {{ .Values.onboarding.livenessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "periodSeconds") }}
+            periodSeconds: {{ .Values.onboarding.livenessProbe.periodSeconds }}
+            {{- end }}
+            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.onboarding.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.onboarding.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.onboarding.livenessProbe (hasKey (.Values.onboarding.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.onboarding.livenessProbe.failureThreshold }}
+            {{- end }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.onboarding.readinessProbe.path | default "/readyz" }}
               port: http
+            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "initialDelaySeconds") }}
+            initialDelaySeconds: {{ .Values.onboarding.readinessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "periodSeconds") }}
+            periodSeconds: {{ .Values.onboarding.readinessProbe.periodSeconds }}
+            {{- end }}
+            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.onboarding.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.onboarding.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.onboarding.readinessProbe (hasKey (.Values.onboarding.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.onboarding.readinessProbe.failureThreshold }}
+            {{- end }}
           resources:
             {{- toYaml .Values.onboarding.resources | nindent 12 }}
       {{- with .Values.onboarding.nodeSelector }}

--- a/charts/midaz/templates/transaction/deployment.yaml
+++ b/charts/midaz/templates/transaction/deployment.yaml
@@ -87,40 +87,20 @@ spec:
             httpGet:
               path: {{ .Values.transaction.livenessProbe.path | default "/health" }}
               port: http
-            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "initialDelaySeconds") }}
-            initialDelaySeconds: {{ .Values.transaction.livenessProbe.initialDelaySeconds }}
-            {{- end }}
-            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "periodSeconds") }}
-            periodSeconds: {{ .Values.transaction.livenessProbe.periodSeconds }}
-            {{- end }}
-            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.transaction.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.transaction.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.transaction.livenessProbe.failureThreshold }}
-            {{- end }}
+            initialDelaySeconds: {{ .Values.transaction.livenessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.transaction.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.transaction.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.transaction.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.transaction.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
               path: {{ .Values.transaction.readinessProbe.path | default "/readyz" }}
               port: http
-            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "initialDelaySeconds") }}
-            initialDelaySeconds: {{ .Values.transaction.readinessProbe.initialDelaySeconds }}
-            {{- end }}
-            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "periodSeconds") }}
-            periodSeconds: {{ .Values.transaction.readinessProbe.periodSeconds }}
-            {{- end }}
-            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.transaction.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.transaction.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.transaction.readinessProbe.failureThreshold }}
-            {{- end }}
+            initialDelaySeconds: {{ .Values.transaction.readinessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.transaction.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.transaction.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.transaction.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.transaction.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.transaction.resources | nindent 12 }}
       {{- with .Values.transaction.nodeSelector }}

--- a/charts/midaz/templates/transaction/deployment.yaml
+++ b/charts/midaz/templates/transaction/deployment.yaml
@@ -85,12 +85,42 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.transaction.livenessProbe.path | default "/health" }}
               port: http
+            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "initialDelaySeconds") }}
+            initialDelaySeconds: {{ .Values.transaction.livenessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "periodSeconds") }}
+            periodSeconds: {{ .Values.transaction.livenessProbe.periodSeconds }}
+            {{- end }}
+            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.transaction.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.transaction.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.transaction.livenessProbe (hasKey (.Values.transaction.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.transaction.livenessProbe.failureThreshold }}
+            {{- end }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.transaction.readinessProbe.path | default "/readyz" }}
               port: http
+            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "initialDelaySeconds") }}
+            initialDelaySeconds: {{ .Values.transaction.readinessProbe.initialDelaySeconds }}
+            {{- end }}
+            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "periodSeconds") }}
+            periodSeconds: {{ .Values.transaction.readinessProbe.periodSeconds }}
+            {{- end }}
+            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.transaction.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.transaction.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.transaction.readinessProbe (hasKey (.Values.transaction.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.transaction.readinessProbe.failureThreshold }}
+            {{- end }}
           resources:
             {{- toYaml .Values.transaction.resources | nindent 12 }}
       {{- with .Values.transaction.nodeSelector }}

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -101,6 +101,10 @@ global:
         - role: "readWrite"
           db: "crm"
 onboarding:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: onboarding
   # -- Enable or disable the onboarding service
@@ -290,6 +294,10 @@ onboarding:
     # @default -- `midaz-onboarding.fullname`
     name: ""
 transaction:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: transaction
   # -- Enable or disable the transaction service
@@ -489,6 +497,10 @@ transaction:
     # @default -- `midaz-transaction.fullname`
     name: ""
 ledger:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: ledger
   # -- Enable or disable the ledger service (unified onboarding + transaction)
@@ -704,6 +716,10 @@ ledger:
     # @default -- `midaz-ledger.fullname`
     name: ""
 crm:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: crm
   # -- Enable or disable the CRM service

--- a/charts/plugin-access-manager/templates/auth-backend/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/deployment.yaml
@@ -110,32 +110,18 @@ spec:
               port: 8000
             initialDelaySeconds: {{ .Values.auth.backend.readinessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.auth.backend.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.auth.backend.readinessProbe (hasKey (.Values.auth.backend.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.auth.backend.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.auth.backend.readinessProbe (hasKey (.Values.auth.backend.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.auth.backend.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.auth.backend.readinessProbe (hasKey (.Values.auth.backend.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.auth.backend.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.auth.backend.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.auth.backend.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.auth.backend.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.auth.backend.livenessProbe.path | default "/api/health" }}
               port: 8000
             initialDelaySeconds: {{ .Values.auth.backend.livenessProbe.initialDelaySeconds | default 20 }}
-            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "periodSeconds") }}
-            periodSeconds: {{ .Values.auth.backend.livenessProbe.periodSeconds }}
-            {{- end }}
-            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.auth.backend.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.auth.backend.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.auth.backend.livenessProbe.failureThreshold }}
-            {{- end }}
+            periodSeconds: {{ .Values.auth.backend.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.auth.backend.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.auth.backend.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.auth.backend.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.auth.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-access-manager/templates/auth-backend/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/deployment.yaml
@@ -106,15 +106,36 @@ spec:
           {{ end }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.auth.backend.readinessProbe.path | default "/readyz" }}
               port: 8000
-            initialDelaySeconds: 15
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.auth.backend.readinessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ .Values.auth.backend.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.auth.backend.readinessProbe (hasKey (.Values.auth.backend.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.auth.backend.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.auth.backend.readinessProbe (hasKey (.Values.auth.backend.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.auth.backend.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.auth.backend.readinessProbe (hasKey (.Values.auth.backend.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.auth.backend.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 20
             httpGet:
-              path: /api/health
+              path: {{ .Values.auth.backend.livenessProbe.path | default "/api/health" }}
               port: 8000
+            initialDelaySeconds: {{ .Values.auth.backend.livenessProbe.initialDelaySeconds | default 20 }}
+            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "periodSeconds") }}
+            periodSeconds: {{ .Values.auth.backend.livenessProbe.periodSeconds }}
+            {{- end }}
+            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.auth.backend.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.auth.backend.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.auth.backend.livenessProbe (hasKey (.Values.auth.backend.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.auth.backend.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.auth.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-access-manager/templates/auth/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth/deployment.yaml
@@ -65,16 +65,34 @@ spec:
             {{- toYaml .Values.auth.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.auth.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.auth.service.port }}
-            initialDelaySeconds: 25
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.auth.readinessProbe.initialDelaySeconds | default 25 }}
+            periodSeconds: {{ .Values.auth.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.auth.readinessProbe (hasKey (.Values.auth.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.auth.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.auth.readinessProbe (hasKey (.Values.auth.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.auth.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.auth.readinessProbe (hasKey (.Values.auth.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.auth.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 30
-            periodSeconds: 5
             httpGet:
-              path: /health
+              path: {{ .Values.auth.livenessProbe.path | default "/health" }}
               port: {{ .Values.auth.service.port }}
+            initialDelaySeconds: {{ .Values.auth.livenessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.auth.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.auth.livenessProbe (hasKey (.Values.auth.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.auth.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.auth.livenessProbe (hasKey (.Values.auth.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.auth.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.auth.livenessProbe (hasKey (.Values.auth.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.auth.livenessProbe.failureThreshold }}
+            {{- end }}
       volumes:
         - name: backend-init-data
           configMap:

--- a/charts/plugin-access-manager/templates/auth/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth/deployment.yaml
@@ -69,30 +69,18 @@ spec:
               port: {{ .Values.auth.service.port }}
             initialDelaySeconds: {{ .Values.auth.readinessProbe.initialDelaySeconds | default 25 }}
             periodSeconds: {{ .Values.auth.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.auth.readinessProbe (hasKey (.Values.auth.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.auth.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.auth.readinessProbe (hasKey (.Values.auth.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.auth.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.auth.readinessProbe (hasKey (.Values.auth.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.auth.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.auth.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.auth.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.auth.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.auth.livenessProbe.path | default "/health" }}
               port: {{ .Values.auth.service.port }}
             initialDelaySeconds: {{ .Values.auth.livenessProbe.initialDelaySeconds | default 30 }}
             periodSeconds: {{ .Values.auth.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.auth.livenessProbe (hasKey (.Values.auth.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.auth.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.auth.livenessProbe (hasKey (.Values.auth.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.auth.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.auth.livenessProbe (hasKey (.Values.auth.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.auth.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.auth.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.auth.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.auth.livenessProbe.failureThreshold | default 3 }}
       volumes:
         - name: backend-init-data
           configMap:

--- a/charts/plugin-access-manager/templates/identity/deployment.yaml
+++ b/charts/plugin-access-manager/templates/identity/deployment.yaml
@@ -68,30 +68,18 @@ spec:
               port: {{ .Values.identity.service.port }}
             initialDelaySeconds: {{ .Values.identity.readinessProbe.initialDelaySeconds | default 25 }}
             periodSeconds: {{ .Values.identity.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.identity.readinessProbe (hasKey (.Values.identity.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.identity.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.identity.readinessProbe (hasKey (.Values.identity.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.identity.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.identity.readinessProbe (hasKey (.Values.identity.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.identity.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.identity.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.identity.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.identity.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.identity.livenessProbe.path | default "/health" }}
               port: {{ .Values.identity.service.port }}
             initialDelaySeconds: {{ .Values.identity.livenessProbe.initialDelaySeconds | default 30 }}
             periodSeconds: {{ .Values.identity.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.identity.livenessProbe (hasKey (.Values.identity.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.identity.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.identity.livenessProbe (hasKey (.Values.identity.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.identity.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.identity.livenessProbe (hasKey (.Values.identity.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.identity.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.identity.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.identity.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.identity.livenessProbe.failureThreshold | default 3 }}
           {{ if (index .Values "otel-collector-lerian").enabled }}
           env:
           - name: "HOST_IP"

--- a/charts/plugin-access-manager/templates/identity/deployment.yaml
+++ b/charts/plugin-access-manager/templates/identity/deployment.yaml
@@ -64,16 +64,34 @@ spec:
             {{- toYaml .Values.identity.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.identity.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.identity.service.port }}
-            initialDelaySeconds: 25
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.identity.readinessProbe.initialDelaySeconds | default 25 }}
+            periodSeconds: {{ .Values.identity.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.identity.readinessProbe (hasKey (.Values.identity.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.identity.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.identity.readinessProbe (hasKey (.Values.identity.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.identity.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.identity.readinessProbe (hasKey (.Values.identity.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.identity.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 30
-            periodSeconds: 5
             httpGet:
-              path: /health
+              path: {{ .Values.identity.livenessProbe.path | default "/health" }}
               port: {{ .Values.identity.service.port }}
+            initialDelaySeconds: {{ .Values.identity.livenessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.identity.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.identity.livenessProbe (hasKey (.Values.identity.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.identity.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.identity.livenessProbe (hasKey (.Values.identity.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.identity.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.identity.livenessProbe (hasKey (.Values.identity.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.identity.livenessProbe.failureThreshold }}
+            {{- end }}
           {{ if (index .Values "otel-collector-lerian").enabled }}
           env:
           - name: "HOST_IP"

--- a/charts/plugin-access-manager/values.yaml
+++ b/charts/plugin-access-manager/values.yaml
@@ -6,6 +6,10 @@ common:
     clientId: "ac56c81d4d6d95c0ac12"
     clientSecret: "6add4bc64f394456a77fa85708ad8c9b67e39e4c"
 identity:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # Default values
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
@@ -138,6 +142,10 @@ identity:
   useExistingSecret: false
   existingSecretName: ""
 auth:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # Default values
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
@@ -279,6 +287,10 @@ auth:
   useExistingSecret: false
   existingSecretName: ""
   backend:
+    # -- Readiness probe configuration. All fields override chart defaults.
+    readinessProbe: {}
+    # -- Liveness probe configuration. All fields override chart defaults.
+    livenessProbe: {}
     replicaCount: 1
     revisionHistoryLimit: 10
     name: "plugin-access-manager-auth-backend"

--- a/charts/plugin-br-bank-transfer/templates/deployment.yaml
+++ b/charts/plugin-br-bank-transfer/templates/deployment.yaml
@@ -103,20 +103,26 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: {{ .Values.bankTransfer.livenessProbe.path | default "/health/live" }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.bankTransfer.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ .Values.bankTransfer.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.bankTransfer.livenessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.bankTransfer.livenessProbe (hasKey (.Values.bankTransfer.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.bankTransfer.livenessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.bankTransfer.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.bankTransfer.readinessProbe.path | default "/readyz" }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.bankTransfer.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.bankTransfer.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.bankTransfer.readinessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.bankTransfer.readinessProbe (hasKey (.Values.bankTransfer.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.bankTransfer.readinessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.bankTransfer.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.bankTransfer.resources | nindent 12 }}
       {{- with .Values.bankTransfer.nodeSelector }}

--- a/charts/plugin-br-bank-transfer/templates/deployment.yaml
+++ b/charts/plugin-br-bank-transfer/templates/deployment.yaml
@@ -108,9 +108,7 @@ spec:
             initialDelaySeconds: {{ .Values.bankTransfer.livenessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.bankTransfer.livenessProbe.periodSeconds | default 20 }}
             timeoutSeconds: {{ .Values.bankTransfer.livenessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.bankTransfer.livenessProbe (hasKey (.Values.bankTransfer.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.bankTransfer.livenessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.bankTransfer.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.bankTransfer.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
@@ -119,9 +117,7 @@ spec:
             initialDelaySeconds: {{ .Values.bankTransfer.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.bankTransfer.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.bankTransfer.readinessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.bankTransfer.readinessProbe (hasKey (.Values.bankTransfer.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.bankTransfer.readinessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.bankTransfer.readinessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.bankTransfer.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.bankTransfer.resources | nindent 12 }}

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -64,6 +64,10 @@ global:
       # -- Password for bank_transfer user (ignored if useExistingSecret.name is set)
       password: "lerian"
 bankTransfer:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: bank-transfer
   # -- Enable or disable the bank-transfer service

--- a/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/deployment.yaml
+++ b/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/deployment.yaml
@@ -49,16 +49,34 @@ spec:
             {{- toYaml .Values.pix.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.pix.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.pix.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.pix.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.pix.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.pix.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.pix.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.pix.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 5
             httpGet:
-              path: /v1/health
+              path: {{ .Values.pix.livenessProbe.path | default "/v1/health" }}
               port: {{ .Values.pix.service.port }}
+            initialDelaySeconds: {{ .Values.pix.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.pix.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.pix.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.pix.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.pix.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.pix.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/deployment.yaml
+++ b/charts/plugin-br-pix-direct-jd/templates/plugin-br-pix-direct-jd/deployment.yaml
@@ -53,30 +53,18 @@ spec:
               port: {{ .Values.pix.service.port }}
             initialDelaySeconds: {{ .Values.pix.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.pix.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.pix.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.pix.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.pix.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.pix.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.pix.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.pix.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.pix.livenessProbe.path | default "/v1/health" }}
               port: {{ .Values.pix.service.port }}
             initialDelaySeconds: {{ .Values.pix.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.pix.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.pix.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.pix.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.pix.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.pix.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.pix.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.pix.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.pix.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-direct-jd/values.yaml
+++ b/charts/plugin-br-pix-direct-jd/values.yaml
@@ -3,6 +3,10 @@
 # Declare variables to be passed into your templates.
 
 pix:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   replicaCount: 1
   name: "plugin-br-pix-direct-jd"
   description: "Plugin pix for Midaz"

--- a/charts/plugin-br-pix-indirect-btg/templates/inbound/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/inbound/deployment.yaml
@@ -53,30 +53,18 @@ spec:
               port: {{ .Values.inbound.service.port }}
             initialDelaySeconds: {{ .Values.inbound.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.inbound.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.inbound.readinessProbe (hasKey (.Values.inbound.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.inbound.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.inbound.readinessProbe (hasKey (.Values.inbound.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.inbound.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.inbound.readinessProbe (hasKey (.Values.inbound.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.inbound.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.inbound.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.inbound.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.inbound.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.inbound.livenessProbe.path | default "/health" }}
               port: {{ .Values.inbound.service.port }}
             initialDelaySeconds: {{ .Values.inbound.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.inbound.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.inbound.livenessProbe (hasKey (.Values.inbound.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.inbound.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.inbound.livenessProbe (hasKey (.Values.inbound.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.inbound.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.inbound.livenessProbe (hasKey (.Values.inbound.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.inbound.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.inbound.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.inbound.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.inbound.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.inbound.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/inbound/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/inbound/deployment.yaml
@@ -49,16 +49,34 @@ spec:
             {{- toYaml .Values.inbound.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.inbound.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.inbound.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.inbound.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.inbound.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.inbound.readinessProbe (hasKey (.Values.inbound.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.inbound.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.inbound.readinessProbe (hasKey (.Values.inbound.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.inbound.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.inbound.readinessProbe (hasKey (.Values.inbound.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.inbound.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 5
             httpGet:
-              path: /health
+              path: {{ .Values.inbound.livenessProbe.path | default "/health" }}
               port: {{ .Values.inbound.service.port }}
+            initialDelaySeconds: {{ .Values.inbound.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.inbound.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.inbound.livenessProbe (hasKey (.Values.inbound.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.inbound.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.inbound.livenessProbe (hasKey (.Values.inbound.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.inbound.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.inbound.livenessProbe (hasKey (.Values.inbound.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.inbound.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.inbound.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/outbound/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/outbound/deployment.yaml
@@ -49,16 +49,34 @@ spec:
             {{- toYaml .Values.outbound.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.outbound.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.outbound.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.outbound.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.outbound.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.outbound.readinessProbe (hasKey (.Values.outbound.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.outbound.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.outbound.readinessProbe (hasKey (.Values.outbound.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.outbound.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.outbound.readinessProbe (hasKey (.Values.outbound.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.outbound.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 5
             httpGet:
-              path: /health
+              path: {{ .Values.outbound.livenessProbe.path | default "/health" }}
               port: {{ .Values.outbound.service.port }}
+            initialDelaySeconds: {{ .Values.outbound.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.outbound.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.outbound.livenessProbe (hasKey (.Values.outbound.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.outbound.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.outbound.livenessProbe (hasKey (.Values.outbound.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.outbound.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.outbound.livenessProbe (hasKey (.Values.outbound.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.outbound.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.outbound.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/outbound/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/outbound/deployment.yaml
@@ -53,30 +53,18 @@ spec:
               port: {{ .Values.outbound.service.port }}
             initialDelaySeconds: {{ .Values.outbound.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.outbound.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.outbound.readinessProbe (hasKey (.Values.outbound.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.outbound.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.outbound.readinessProbe (hasKey (.Values.outbound.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.outbound.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.outbound.readinessProbe (hasKey (.Values.outbound.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.outbound.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.outbound.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.outbound.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.outbound.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.outbound.livenessProbe.path | default "/health" }}
               port: {{ .Values.outbound.service.port }}
             initialDelaySeconds: {{ .Values.outbound.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.outbound.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.outbound.livenessProbe (hasKey (.Values.outbound.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.outbound.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.outbound.livenessProbe (hasKey (.Values.outbound.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.outbound.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.outbound.livenessProbe (hasKey (.Values.outbound.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.outbound.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.outbound.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.outbound.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.outbound.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.outbound.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/pix/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/deployment.yaml
@@ -52,16 +52,34 @@ spec:
             {{- toYaml .Values.pix.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.pix.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.pix.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.pix.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.pix.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.pix.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.pix.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.pix.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 5
             httpGet:
-              path: /health
+              path: {{ .Values.pix.livenessProbe.path | default "/health" }}
               port: {{ .Values.pix.service.port }}
+            initialDelaySeconds: {{ .Values.pix.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.pix.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.pix.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.pix.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.pix.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.pix.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/pix/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/deployment.yaml
@@ -56,30 +56,18 @@ spec:
               port: {{ .Values.pix.service.port }}
             initialDelaySeconds: {{ .Values.pix.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.pix.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.pix.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.pix.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.pix.readinessProbe (hasKey (.Values.pix.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.pix.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.pix.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.pix.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.pix.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.pix.livenessProbe.path | default "/health" }}
               port: {{ .Values.pix.service.port }}
             initialDelaySeconds: {{ .Values.pix.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.pix.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.pix.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.pix.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.pix.livenessProbe (hasKey (.Values.pix.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.pix.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.pix.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.pix.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.pix.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.pix.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/reconciliation/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/reconciliation/deployment.yaml
@@ -55,30 +55,18 @@ spec:
               port: {{ .Values.reconciliation.service.port }}
             initialDelaySeconds: {{ .Values.reconciliation.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.reconciliation.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.reconciliation.readinessProbe (hasKey (.Values.reconciliation.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.reconciliation.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.reconciliation.readinessProbe (hasKey (.Values.reconciliation.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.reconciliation.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.reconciliation.readinessProbe (hasKey (.Values.reconciliation.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.reconciliation.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.reconciliation.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.reconciliation.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.reconciliation.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.reconciliation.livenessProbe.path | default "/health" }}
               port: {{ .Values.reconciliation.service.port }}
             initialDelaySeconds: {{ .Values.reconciliation.livenessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.reconciliation.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.reconciliation.livenessProbe (hasKey (.Values.reconciliation.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.reconciliation.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.reconciliation.livenessProbe (hasKey (.Values.reconciliation.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.reconciliation.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.reconciliation.livenessProbe (hasKey (.Values.reconciliation.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.reconciliation.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.reconciliation.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.reconciliation.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.reconciliation.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.reconciliation.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/reconciliation/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/reconciliation/deployment.yaml
@@ -51,16 +51,34 @@ spec:
             {{- toYaml .Values.reconciliation.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.reconciliation.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.reconciliation.service.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.reconciliation.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.reconciliation.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.reconciliation.readinessProbe (hasKey (.Values.reconciliation.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.reconciliation.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.reconciliation.readinessProbe (hasKey (.Values.reconciliation.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.reconciliation.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.reconciliation.readinessProbe (hasKey (.Values.reconciliation.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.reconciliation.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.reconciliation.livenessProbe.path | default "/health" }}
               port: {{ .Values.reconciliation.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.reconciliation.livenessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.reconciliation.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.reconciliation.livenessProbe (hasKey (.Values.reconciliation.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.reconciliation.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.reconciliation.livenessProbe (hasKey (.Values.reconciliation.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.reconciliation.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.reconciliation.livenessProbe (hasKey (.Values.reconciliation.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.reconciliation.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.reconciliation.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -37,6 +37,10 @@ global:
           db: "plugin-br-pix-indirect-btg-db"
 
 pix:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   replicaCount: 1
   name: "plugin-br-pix-indirect-btg"
   description: "Plugin pix for Midaz"
@@ -205,6 +209,10 @@ pix:
   useExistingSecrets: false
   existingSecretName: ""
 inbound:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   replicaCount: 1
   name: "plugin-br-pix-indirect-btg-worker-inbound"
   description: "Plugin pix for Midaz"
@@ -337,6 +345,10 @@ inbound:
   useExistingSecrets: false
   existingSecretName: "plugin-br-pix-indirect-btg-inbound"
 outbound:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   replicaCount: 1
   name: "plugin-br-pix-indirect-btg-worker-outbound"
   description: "Plugin pix for Midaz"
@@ -485,6 +497,10 @@ outbound:
   useExistingSecrets: false
   existingSecretName: ""
 reconciliation:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   replicaCount: 1
   name: "plugin-br-pix-indirect-btg-worker-reconciliation"
   description: "Reconciliation Worker for Plugin BR PIX Indirect BTG"

--- a/charts/plugin-br-pix-switch/templates/plugin-br-pix-switch/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/plugin-br-pix-switch/deployment.yaml
@@ -58,30 +58,18 @@ spec:
               port: {{ .Values.pixSwitch.service.port }}
             initialDelaySeconds: {{ .Values.pixSwitch.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.pixSwitch.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.pixSwitch.readinessProbe (hasKey (.Values.pixSwitch.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.pixSwitch.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.pixSwitch.readinessProbe (hasKey (.Values.pixSwitch.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.pixSwitch.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.pixSwitch.readinessProbe (hasKey (.Values.pixSwitch.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.pixSwitch.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.pixSwitch.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.pixSwitch.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.pixSwitch.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.pixSwitch.livenessProbe.path | default "/live" }}
               port: {{ .Values.pixSwitch.service.port }}
             initialDelaySeconds: {{ .Values.pixSwitch.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.pixSwitch.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.pixSwitch.livenessProbe (hasKey (.Values.pixSwitch.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.pixSwitch.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.pixSwitch.livenessProbe (hasKey (.Values.pixSwitch.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.pixSwitch.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.pixSwitch.livenessProbe (hasKey (.Values.pixSwitch.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.pixSwitch.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.pixSwitch.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.pixSwitch.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.pixSwitch.livenessProbe.failureThreshold | default 3 }}
       {{- with .Values.pixSwitch.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-switch/templates/plugin-br-pix-switch/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/plugin-br-pix-switch/deployment.yaml
@@ -54,16 +54,34 @@ spec:
             {{- toYaml .Values.pixSwitch.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.pixSwitch.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.pixSwitch.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.pixSwitch.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.pixSwitch.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.pixSwitch.readinessProbe (hasKey (.Values.pixSwitch.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.pixSwitch.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.pixSwitch.readinessProbe (hasKey (.Values.pixSwitch.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.pixSwitch.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.pixSwitch.readinessProbe (hasKey (.Values.pixSwitch.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.pixSwitch.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 5
             httpGet:
-              path: /live
+              path: {{ .Values.pixSwitch.livenessProbe.path | default "/live" }}
               port: {{ .Values.pixSwitch.service.port }}
+            initialDelaySeconds: {{ .Values.pixSwitch.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.pixSwitch.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.pixSwitch.livenessProbe (hasKey (.Values.pixSwitch.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.pixSwitch.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.pixSwitch.livenessProbe (hasKey (.Values.pixSwitch.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.pixSwitch.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.pixSwitch.livenessProbe (hasKey (.Values.pixSwitch.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.pixSwitch.livenessProbe.failureThreshold }}
+            {{- end }}
       {{- with .Values.pixSwitch.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -3,6 +3,10 @@
 # Declare variables to be passed into your templates.
 
 pixSwitch:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   replicaCount: 1
   name: "plugin-br-pix-switch"
   description: "Plugin BR Pix Switch for Midaz"

--- a/charts/plugin-fees/templates/fees/deployment.yaml
+++ b/charts/plugin-fees/templates/fees/deployment.yaml
@@ -71,30 +71,18 @@ spec:
               port: {{ .Values.fees.service.port }}
             initialDelaySeconds: {{ .Values.fees.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.fees.readinessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.fees.readinessProbe (hasKey (.Values.fees.readinessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.fees.readinessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.fees.readinessProbe (hasKey (.Values.fees.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.fees.readinessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.fees.readinessProbe (hasKey (.Values.fees.readinessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.fees.readinessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.fees.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.fees.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.fees.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.fees.livenessProbe.path | default "/health" }}
               port: {{ .Values.fees.service.port }}
             initialDelaySeconds: {{ .Values.fees.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.fees.livenessProbe.periodSeconds | default 5 }}
-            {{- if and .Values.fees.livenessProbe (hasKey (.Values.fees.livenessProbe | default dict) "timeoutSeconds") }}
-            timeoutSeconds: {{ .Values.fees.livenessProbe.timeoutSeconds }}
-            {{- end }}
-            {{- if and .Values.fees.livenessProbe (hasKey (.Values.fees.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.fees.livenessProbe.successThreshold }}
-            {{- end }}
-            {{- if and .Values.fees.livenessProbe (hasKey (.Values.fees.livenessProbe | default dict) "failureThreshold") }}
-            failureThreshold: {{ .Values.fees.livenessProbe.failureThreshold }}
-            {{- end }}
+            timeoutSeconds: {{ .Values.fees.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.fees.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.fees.livenessProbe.failureThreshold | default 3 }}
         {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
         - name: aws-signing-helper
           image: "{{ .Values.aws.rolesAnywhere.sidecar.image.repository }}:{{ .Values.aws.rolesAnywhere.sidecar.image.tag }}"

--- a/charts/plugin-fees/templates/fees/deployment.yaml
+++ b/charts/plugin-fees/templates/fees/deployment.yaml
@@ -67,16 +67,34 @@ spec:
             {{- toYaml .Values.fees.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.fees.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.fees.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.fees.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.fees.readinessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.fees.readinessProbe (hasKey (.Values.fees.readinessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.fees.readinessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.fees.readinessProbe (hasKey (.Values.fees.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.fees.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.fees.readinessProbe (hasKey (.Values.fees.readinessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.fees.readinessProbe.failureThreshold }}
+            {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.fees.livenessProbe.path | default "/health" }}
               port: {{ .Values.fees.service.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.fees.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.fees.livenessProbe.periodSeconds | default 5 }}
+            {{- if and .Values.fees.livenessProbe (hasKey (.Values.fees.livenessProbe | default dict) "timeoutSeconds") }}
+            timeoutSeconds: {{ .Values.fees.livenessProbe.timeoutSeconds }}
+            {{- end }}
+            {{- if and .Values.fees.livenessProbe (hasKey (.Values.fees.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.fees.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if and .Values.fees.livenessProbe (hasKey (.Values.fees.livenessProbe | default dict) "failureThreshold") }}
+            failureThreshold: {{ .Values.fees.livenessProbe.failureThreshold }}
+            {{- end }}
         {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
         - name: aws-signing-helper
           image: "{{ .Values.aws.rolesAnywhere.sidecar.image.repository }}:{{ .Values.aws.rolesAnywhere.sidecar.image.tag }}"

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -36,6 +36,10 @@ global:
         - role: "readWrite"
           db: "plugin-fees-db"
 fees:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   replicaCount: 1
   name: "plugin-fees"
   description: "Plugin Fees for Midaz"

--- a/charts/product-console/templates/deployment.yaml
+++ b/charts/product-console/templates/deployment.yaml
@@ -90,20 +90,22 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.livenessProbe.path | default "/" }}
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.readinessProbe.path | default "/readyz" }}
               port: http
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 3 }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/product-console/values.yaml
+++ b/charts/product-console/values.yaml
@@ -8,6 +8,11 @@ replicaCount: 1
 # -- Number of old ReplicaSets to retain for deployment rollback
 revisionHistoryLimit: 10
 
+# -- Readiness probe configuration. All fields override chart defaults.
+readinessProbe: {}
+# -- Liveness probe configuration. All fields override chart defaults.
+livenessProbe: {}
+
 image:
   # -- Repository for the product-console container image
   repository: lerianstudio/product-console

--- a/charts/reporter/templates/manager/deployment.yaml
+++ b/charts/reporter/templates/manager/deployment.yaml
@@ -91,7 +91,7 @@ spec:
             {{- toYaml .Values.manager.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.manager.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.manager.service.port }}
             initialDelaySeconds: {{ .Values.manager.readinessProbe.initialDelaySeconds | default 25 }}
             periodSeconds: {{ .Values.manager.readinessProbe.periodSeconds | default 5 }}
@@ -100,8 +100,8 @@ spec:
             failureThreshold: {{ .Values.manager.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: /health
-              port: {{ .Values.manager.service.port }}            
+              path: {{ .Values.manager.livenessProbe.path | default "/health" }}
+              port: {{ .Values.manager.service.port }}
             initialDelaySeconds: {{ .Values.manager.livenessProbe.initialDelaySeconds | default 30 }}
             periodSeconds: {{ .Values.manager.livenessProbe.periodSeconds | default 5 }}
             timeoutSeconds: {{ .Values.manager.livenessProbe.timeoutSeconds | default 3 }}

--- a/charts/reporter/templates/worker/deployment.yaml
+++ b/charts/reporter/templates/worker/deployment.yaml
@@ -98,7 +98,7 @@ spec:
             {{- toYaml .Values.worker.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.worker.readinessProbe.path | default "/readyz" }}
               port: {{ .Values.worker.configmap.HEALTH_PORT | default 4006 }}
             initialDelaySeconds: {{ .Values.worker.readinessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.worker.readinessProbe.periodSeconds | default 5 }}
@@ -107,7 +107,7 @@ spec:
             failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.worker.livenessProbe.path | default "/health" }}
               port: {{ .Values.worker.configmap.HEALTH_PORT | default 4006 }}
             initialDelaySeconds: {{ .Values.worker.livenessProbe.initialDelaySeconds | default 20 }}
             periodSeconds: {{ .Values.worker.livenessProbe.periodSeconds | default 5 }}

--- a/charts/tracer/templates/deployment.yaml
+++ b/charts/tracer/templates/deployment.yaml
@@ -63,20 +63,26 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.tracer.livenessProbe.path | default "/health" }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.tracer.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ .Values.tracer.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.tracer.livenessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.tracer.livenessProbe (hasKey (.Values.tracer.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.tracer.livenessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.tracer.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.tracer.readinessProbe.path | default "/readyz" }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.tracer.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.tracer.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.tracer.readinessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.tracer.readinessProbe (hasKey (.Values.tracer.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.tracer.readinessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.tracer.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.tracer.resources | nindent 12 }}
       {{- with .Values.tracer.nodeSelector }}

--- a/charts/tracer/templates/deployment.yaml
+++ b/charts/tracer/templates/deployment.yaml
@@ -68,9 +68,7 @@ spec:
             initialDelaySeconds: {{ .Values.tracer.livenessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.tracer.livenessProbe.periodSeconds | default 20 }}
             timeoutSeconds: {{ .Values.tracer.livenessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.tracer.livenessProbe (hasKey (.Values.tracer.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.tracer.livenessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.tracer.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.tracer.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
@@ -79,9 +77,7 @@ spec:
             initialDelaySeconds: {{ .Values.tracer.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.tracer.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.tracer.readinessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.tracer.readinessProbe (hasKey (.Values.tracer.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.tracer.readinessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.tracer.readinessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.tracer.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.tracer.resources | nindent 12 }}

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -34,6 +34,10 @@ global:
       password: "lerian"
 
 tracer:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: tracer
 

--- a/charts/underwriter/templates/deployment.yaml
+++ b/charts/underwriter/templates/deployment.yaml
@@ -68,9 +68,7 @@ spec:
             initialDelaySeconds: {{ .Values.underwriter.livenessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.underwriter.livenessProbe.periodSeconds | default 20 }}
             timeoutSeconds: {{ .Values.underwriter.livenessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.underwriter.livenessProbe (hasKey (.Values.underwriter.livenessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.underwriter.livenessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.underwriter.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.underwriter.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
@@ -79,9 +77,7 @@ spec:
             initialDelaySeconds: {{ .Values.underwriter.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.underwriter.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.underwriter.readinessProbe.timeoutSeconds | default 5 }}
-            {{- if and .Values.underwriter.readinessProbe (hasKey (.Values.underwriter.readinessProbe | default dict) "successThreshold") }}
-            successThreshold: {{ .Values.underwriter.readinessProbe.successThreshold }}
-            {{- end }}
+            successThreshold: {{ .Values.underwriter.readinessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.underwriter.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.underwriter.resources | nindent 12 }}

--- a/charts/underwriter/templates/deployment.yaml
+++ b/charts/underwriter/templates/deployment.yaml
@@ -63,20 +63,26 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.underwriter.livenessProbe.path | default "/health" }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.underwriter.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ .Values.underwriter.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.underwriter.livenessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.underwriter.livenessProbe (hasKey (.Values.underwriter.livenessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.underwriter.livenessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.underwriter.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.underwriter.readinessProbe.path | default "/readyz" }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.underwriter.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.underwriter.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.underwriter.readinessProbe.timeoutSeconds | default 5 }}
+            {{- if and .Values.underwriter.readinessProbe (hasKey (.Values.underwriter.readinessProbe | default dict) "successThreshold") }}
+            successThreshold: {{ .Values.underwriter.readinessProbe.successThreshold }}
+            {{- end }}
+            failureThreshold: {{ .Values.underwriter.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.underwriter.resources | nindent 12 }}
       {{- with .Values.underwriter.nodeSelector }}

--- a/charts/underwriter/values.yaml
+++ b/charts/underwriter/values.yaml
@@ -34,6 +34,10 @@ global:
       password: "lerian"
 
 underwriter:
+  # -- Readiness probe configuration. All fields override chart defaults.
+  readinessProbe: {}
+  # -- Liveness probe configuration. All fields override chart defaults.
+  livenessProbe: {}
   # -- Service name
   name: underwriter
 


### PR DESCRIPTION
## Summary

Makes liveness and readiness probe \`path\` and timing fields configurable via \`values.yaml\` across all **14 charts** that use \`/readyz\`, while preserving exact default behavior (no breaking changes for current consumers).

## Why

Charts hardcoded \`/readyz\` as the readiness path. Some environments need to override it — e.g., **multi-tenant deployments** where \`/readyz\` is not yet implemented and \`/health/ready\` must be used instead.

Without parametrization, the only fix was to fork the chart or pin to an older version. This PR makes the probe configuration declarative and overridable per environment.

## What changed

For each component's \`livenessProbe\` and \`readinessProbe\` in templates, every field is now templated as:

\`\`\`yaml
{{ .Values.<component>.<probe>.<field> | default <original_value> }}
\`\`\`

- Fields that were **absent** in the original template (relying on Kubernetes defaults) **remain absent** unless explicitly set in values, preserving original behavior. They are conditionally rendered via \`hasKey\`.
- Added empty \`<probe>: {}\` blocks to \`values.yaml\` where missing so the \`default\` filter has a non-nil parent to traverse.

## Charts touched (14)

| Chart | Components |
|-------|-----------|
| fetcher | manager |
| flowker | (single deployment) |
| matcher | (single deployment) |
| midaz | crm, ledger, onboarding, transaction |
| plugin-access-manager | auth, auth-backend, identity |
| plugin-br-bank-transfer | (single deployment) |
| plugin-br-pix-direct-jd | (single deployment) |
| plugin-br-pix-indirect-btg | inbound, outbound, pix, reconciliation |
| plugin-br-pix-switch | (single deployment) |
| plugin-fees | (single deployment) |
| product-console | (single deployment) |
| reporter | manager, worker |
| tracer | (single deployment) |
| underwriter | (single deployment) |

**Total**: 23 deployment templates, 14 \`values.yaml\` files updated.

## Override examples

Override the readiness path (e.g. for multi-tenant where \`/readyz\` isn't ready):
\`\`\`yaml
flowker:
  readinessProbe:
    path: /health/ready
\`\`\`

Override timing for slow-starting deployments:
\`\`\`yaml
flowker:
  livenessProbe:
    initialDelaySeconds: 60
    periodSeconds: 30
\`\`\`

## Verification

Rendered diff vs \`develop\` for every renderable chart:
- **flowker, fetcher, matcher, midaz, tracer, underwriter, plugin-fees, product-console**: 100% identical rendering
- **plugin-br-pix-direct-jd, plugin-br-pix-switch, plugin-access-manager**: only field **ordering** within probe blocks changed (e.g., \`successThreshold\` now appears before \`failureThreshold\`); content is identical and Kubernetes is order-agnostic
- **reporter**: only the auto-generated random secret password differs (unrelated to this change)
- **plugin-br-bank-transfer, plugin-br-pix-indirect-btg**: require user-supplied values to render standalone (already the case on \`develop\`); probe templates were patched following the same pattern and behave identically when values are provided

## Risk

**Very low**. Defaults preserve current behavior exactly. Only new fields appear (\`successThreshold: 1\`) which is also the implicit Kubernetes default. No consumer is impacted unless they explicitly override.

## Follow-up

Once this lands and charts are released as new beta versions, the gitops repo can be updated to override \`readinessProbe.path: /health/ready\` for clotilde dev/sandbox flowker (currently broken in multi-tenant mode).