### PR TITLE
fix(flowker): correct livenessProbe default path from /health/live to /health

### DIFF
--- a/charts/flowker/templates/deployment.yaml
+++ b/charts/flowker/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: {{ .Values.flowker.livenessProbe.path | default "/health/live" }}
+              path: {{ .Values.flowker.livenessProbe.path | default "/health" }}
               port: http
             initialDelaySeconds: {{ .Values.flowker.livenessProbe.initialDelaySeconds | default 15 }}
             periodSeconds: {{ .Values.flowker.livenessProbe.periodSeconds | default 20 }}


### PR DESCRIPTION
## Summary

The flowker chart's default \`livenessProbe.path\` is \`/health/live\`, but the flowker app exposes \`/health\` (per Ring Standards). This causes liveness probes to 404 on every deployment using the chart defaults, resulting in 60-second CrashLoopBackOff cycles.

## Source code evidence

\`LerianStudio/flowker/internal/adapters/http/in/routes.go:154\`:
\`\`\`go
// /health - Combined health check (uptime, version, checks)
// Gates on selfProbeOK: returns 503 if startup self-probe did not pass.
f.Get("/health", healthHandler.Health)

// /readyz - Kubernetes readiness probe (canonical contract)
f.Get("/readyz", readyzHandler.Readyz)
\`\`\`

## Live verification (firmino-stg flowker pod, image 1.0.2)

\`\`\`
curl /health      -> 200 OK  {"status":"healthy","uptime":"...","checks":{...}}
curl /health/live -> 404     {"code":404,"title":"request_failed"}
curl /readyz      -> 200 OK  {"status":"healthy","checks":{...}}
\`\`\`

## Impact

Every flowker pod across firmino dev/stg/prd + clotilde dev/sandbox is currently in CrashLoopBackOff because:

1. Chart default \`livenessProbe.path: /health/live\`
2. App responds 404 to \`/health/live\`
3. \`failureThreshold: 3\` × \`periodSeconds: 20\` = 60 seconds → kubelet kills container
4. Restart loop forever

## Fix

Single-line change: chart default \`/health/live\` → \`/health\`.

\`\`\`diff
- path: {{ .Values.flowker.livenessProbe.path | default "/health/live" }}
+ path: {{ .Values.flowker.livenessProbe.path | default "/health" }}
\`\`\`

## Compatibility

- Users explicitly overriding \`livenessProbe.path\` are unaffected.
- All existing deployments using the chart default will start passing liveness once the new chart version is rolled out.

## Bug history

This bug existed since chart \`1.0.0\` (the original \`/health/live\` template). It was always wrong but surfaced clearly only after the chart bumps to 2.1.0-beta.x triggered fresh deployments across all envs simultaneously.