### PR TITLE
fix(underwriter): align chart with app config + standardize VERSION

### DIFF
--- a/charts/underwriter/templates/configmap.yaml
+++ b/charts/underwriter/templates/configmap.yaml
@@ -7,82 +7,209 @@ metadata:
   labels:
     {{- include "underwriter.labels" (dict "context" . "component" .Values.underwriter.name "name" .Values.underwriter.name) | nindent 4 }}
 data:
-  # Application Settings
+  # =============================================================================
+  # Application
+  # =============================================================================
   ENV_NAME: {{ .Values.underwriter.configmap.ENV_NAME | default "production" | quote }}
   LOG_LEVEL: {{ .Values.underwriter.configmap.LOG_LEVEL | default "info" | quote }}
+  DEPLOYMENT_MODE: {{ .Values.underwriter.configmap.DEPLOYMENT_MODE | default "local" | quote }}
+  # Auto-generated from image tag (matches OTEL_RESOURCE_SERVICE_VERSION)
+  VERSION: {{ .Values.underwriter.image.tag | default .Chart.AppVersion | quote }}
+
+  # =============================================================================
+  # HTTP server
+  # =============================================================================
   SERVER_ADDRESS: {{ .Values.underwriter.configmap.SERVER_ADDRESS | default ":4017" | quote }}
   HTTP_BODY_LIMIT_BYTES: {{ .Values.underwriter.configmap.HTTP_BODY_LIMIT_BYTES | default "104857600" | quote }}
+  TLS_TERMINATED_UPSTREAM: {{ .Values.underwriter.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
 
-  # CORS Configuration
+  # =============================================================================
+  # CORS
+  # =============================================================================
   CORS_ALLOWED_ORIGINS: {{ .Values.underwriter.configmap.CORS_ALLOWED_ORIGINS | default "*" | quote }}
   CORS_ALLOWED_METHODS: {{ .Values.underwriter.configmap.CORS_ALLOWED_METHODS | default "GET,POST,PUT,PATCH,DELETE,OPTIONS" | quote }}
   CORS_ALLOWED_HEADERS: {{ .Values.underwriter.configmap.CORS_ALLOWED_HEADERS | default "Origin,Content-Type,Accept,Authorization,X-Request-ID" | quote }}
+  CORS_EXPOSE_HEADERS: {{ .Values.underwriter.configmap.CORS_EXPOSE_HEADERS | default "" | quote }}
+  CORS_ALLOW_CREDENTIALS: {{ .Values.underwriter.configmap.CORS_ALLOW_CREDENTIALS | default "false" | quote }}
 
-  # TLS Configuration
-  TLS_TERMINATED_UPSTREAM: {{ .Values.underwriter.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
-
+  # =============================================================================
   # Tenancy
+  # =============================================================================
   DEFAULT_TENANT_ID: {{ .Values.underwriter.configmap.DEFAULT_TENANT_ID | default "11111111-1111-1111-1111-111111111111" | quote }}
-  DEFAULT_TENANT_SLUG: {{ .Values.underwriter.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
 
-  # PostgreSQL Database
+  # =============================================================================
+  # Multi-tenant
+  # =============================================================================
+  MULTI_TENANT_ENABLED: {{ .Values.underwriter.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
+  MULTI_TENANT_URL: {{ .Values.underwriter.configmap.MULTI_TENANT_URL | default "" | quote }}
+  MULTI_TENANT_REDIS_HOST: {{ .Values.underwriter.configmap.MULTI_TENANT_REDIS_HOST | default "" | quote }}
+  MULTI_TENANT_REDIS_PORT: {{ .Values.underwriter.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
+  MULTI_TENANT_REDIS_TLS: {{ .Values.underwriter.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
+  MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.underwriter.configmap.MULTI_TENANT_MAX_TENANT_POOLS | default "100" | quote }}
+  MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.underwriter.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
+  MULTI_TENANT_TIMEOUT: {{ .Values.underwriter.configmap.MULTI_TENANT_TIMEOUT | default "30" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.underwriter.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | default "5" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.underwriter.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
+  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.underwriter.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
+  MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ .Values.underwriter.configmap.MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC | default "30" | quote }}
+
+  # =============================================================================
+  # PostgreSQL primary
+  # =============================================================================
   POSTGRES_HOST: {{ .Values.underwriter.configmap.POSTGRES_HOST | default "underwriter-postgresql-primary" | quote }}
   POSTGRES_PORT: {{ .Values.underwriter.configmap.POSTGRES_PORT | default "5432" | quote }}
-  POSTGRES_DB: {{ .Values.underwriter.configmap.POSTGRES_DB | default "underwriter" | quote }}
+  POSTGRES_NAME: {{ .Values.underwriter.configmap.POSTGRES_NAME | default "underwriter" | quote }}
   POSTGRES_USER: {{ .Values.underwriter.configmap.POSTGRES_USER | default "underwriter" | quote }}
   POSTGRES_SSLMODE: {{ .Values.underwriter.configmap.POSTGRES_SSLMODE | default "disable" | quote }}
   MIGRATIONS_PATH: {{ .Values.underwriter.configmap.MIGRATIONS_PATH | default "migrations" | quote }}
 
-  # PostgreSQL Connection Pool
+  # =============================================================================
+  # PostgreSQL replica (optional; falls back to primary if unset)
+  # =============================================================================
+  POSTGRES_REPLICA_HOST: {{ .Values.underwriter.configmap.POSTGRES_REPLICA_HOST | default "" | quote }}
+  POSTGRES_REPLICA_PORT: {{ .Values.underwriter.configmap.POSTGRES_REPLICA_PORT | default "" | quote }}
+  POSTGRES_REPLICA_NAME: {{ .Values.underwriter.configmap.POSTGRES_REPLICA_NAME | default "" | quote }}
+  POSTGRES_REPLICA_USER: {{ .Values.underwriter.configmap.POSTGRES_REPLICA_USER | default "" | quote }}
+  POSTGRES_REPLICA_SSLMODE: {{ .Values.underwriter.configmap.POSTGRES_REPLICA_SSLMODE | default "" | quote }}
+
+  # =============================================================================
+  # PostgreSQL connection pool
+  # =============================================================================
   POSTGRES_MAX_OPEN_CONNS: {{ .Values.underwriter.configmap.POSTGRES_MAX_OPEN_CONNS | default "25" | quote }}
   POSTGRES_MAX_IDLE_CONNS: {{ .Values.underwriter.configmap.POSTGRES_MAX_IDLE_CONNS | default "5" | quote }}
   POSTGRES_CONN_MAX_LIFETIME_MINS: {{ .Values.underwriter.configmap.POSTGRES_CONN_MAX_LIFETIME_MINS | default "30" | quote }}
   POSTGRES_CONN_MAX_IDLE_TIME_MINS: {{ .Values.underwriter.configmap.POSTGRES_CONN_MAX_IDLE_TIME_MINS | default "5" | quote }}
   POSTGRES_CONNECT_TIMEOUT_SEC: {{ .Values.underwriter.configmap.POSTGRES_CONNECT_TIMEOUT_SEC | default "10" | quote }}
 
-  # Redis
+  # =============================================================================
+  # Redis / Valkey
+  # =============================================================================
   REDIS_HOST: {{ .Values.underwriter.configmap.REDIS_HOST | default "underwriter-valkey-primary:6379" | quote }}
   REDIS_DB: {{ .Values.underwriter.configmap.REDIS_DB | default "0" | quote }}
   REDIS_PROTOCOL: {{ .Values.underwriter.configmap.REDIS_PROTOCOL | default "3" | quote }}
+  REDIS_TLS: {{ .Values.underwriter.configmap.REDIS_TLS | default "false" | quote }}
   REDIS_POOL_SIZE: {{ .Values.underwriter.configmap.REDIS_POOL_SIZE | default "10" | quote }}
   REDIS_MIN_IDLE_CONNS: {{ .Values.underwriter.configmap.REDIS_MIN_IDLE_CONNS | default "2" | quote }}
-  REDIS_READ_TIMEOUT_MS: {{ .Values.underwriter.configmap.REDIS_READ_TIMEOUT_MS | default "3000" | quote }}
-  REDIS_WRITE_TIMEOUT_MS: {{ .Values.underwriter.configmap.REDIS_WRITE_TIMEOUT_MS | default "3000" | quote }}
-  REDIS_DIAL_TIMEOUT_MS: {{ .Values.underwriter.configmap.REDIS_DIAL_TIMEOUT_MS | default "5000" | quote }}
+  REDIS_READ_TIMEOUT: {{ .Values.underwriter.configmap.REDIS_READ_TIMEOUT | default "3s" | quote }}
+  REDIS_WRITE_TIMEOUT: {{ .Values.underwriter.configmap.REDIS_WRITE_TIMEOUT | default "3s" | quote }}
+  REDIS_DIAL_TIMEOUT: {{ .Values.underwriter.configmap.REDIS_DIAL_TIMEOUT | default "5s" | quote }}
+  REDIS_POOL_TIMEOUT: {{ .Values.underwriter.configmap.REDIS_POOL_TIMEOUT | default "4s" | quote }}
+  REDIS_MAX_RETRIES: {{ .Values.underwriter.configmap.REDIS_MAX_RETRIES | default "3" | quote }}
+  REDIS_MIN_RETRY_BACKOFF: {{ .Values.underwriter.configmap.REDIS_MIN_RETRY_BACKOFF | default "8ms" | quote }}
+  REDIS_MAX_RETRY_BACKOFF: {{ .Values.underwriter.configmap.REDIS_MAX_RETRY_BACKOFF | default "512ms" | quote }}
+  REDIS_MASTER_NAME: {{ .Values.underwriter.configmap.REDIS_MASTER_NAME | default "" | quote }}
 
-  # Authentication
-  AUTH_ENABLED: {{ .Values.underwriter.configmap.AUTH_ENABLED | default "false" | quote }}
-  AUTH_SERVICE_ADDRESS: {{ .Values.underwriter.configmap.AUTH_SERVICE_ADDRESS | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000" | quote }}
+  # =============================================================================
+  # RabbitMQ
+  # =============================================================================
+  RABBITMQ_ENABLED: {{ .Values.underwriter.configmap.RABBITMQ_ENABLED | default "false" | quote }}
+  RABBITMQ_HOST: {{ .Values.underwriter.configmap.RABBITMQ_HOST | default "" | quote }}
+  RABBITMQ_PORT_AMQP: {{ .Values.underwriter.configmap.RABBITMQ_PORT_AMQP | default "5672" | quote }}
+  RABBITMQ_PORT_HOST: {{ .Values.underwriter.configmap.RABBITMQ_PORT_HOST | default "15672" | quote }}
+  RABBITMQ_VHOST: {{ .Values.underwriter.configmap.RABBITMQ_VHOST | default "/" | quote }}
+  RABBITMQ_DEFAULT_USER: {{ .Values.underwriter.configmap.RABBITMQ_DEFAULT_USER | default "" | quote }}
+  RABBITMQ_EXCHANGE: {{ .Values.underwriter.configmap.RABBITMQ_EXCHANGE | default "underwriter.events" | quote }}
+  RABBITMQ_QUEUE: {{ .Values.underwriter.configmap.RABBITMQ_QUEUE | default "underwriter.events.queue" | quote }}
+  RABBITMQ_URL: {{ .Values.underwriter.configmap.RABBITMQ_URL | default "" | quote }}
+  RABBITMQ_HEALTH_CHECK_URL: {{ .Values.underwriter.configmap.RABBITMQ_HEALTH_CHECK_URL | default "" | quote }}
+  RABBITMQ_HEALTH_CHECK_ALLOWED_HOSTS: {{ .Values.underwriter.configmap.RABBITMQ_HEALTH_CHECK_ALLOWED_HOSTS | default "" | quote }}
+  RABBITMQ_REQUIRE_HEALTH_ALLOWED_HOSTS: {{ .Values.underwriter.configmap.RABBITMQ_REQUIRE_HEALTH_ALLOWED_HOSTS | default "false" | quote }}
+  RABBITMQ_ALLOW_INSECURE_HEALTH_CHECK: {{ .Values.underwriter.configmap.RABBITMQ_ALLOW_INSECURE_HEALTH_CHECK | default "false" | quote }}
+  RABBITMQ_ALLOW_INSECURE_TLS: {{ .Values.underwriter.configmap.RABBITMQ_ALLOW_INSECURE_TLS | default "false" | quote }}
+  RABBITMQ_PUBLISHER_CONFIRM_TIMEOUT_MS: {{ .Values.underwriter.configmap.RABBITMQ_PUBLISHER_CONFIRM_TIMEOUT_MS | default "5000" | quote }}
+  RABBITMQ_PUBLISHER_MAX_RECOVERIES: {{ .Values.underwriter.configmap.RABBITMQ_PUBLISHER_MAX_RECOVERIES | default "5" | quote }}
+  RABBITMQ_PUBLISHER_RECOVERY_INITIAL_MS: {{ .Values.underwriter.configmap.RABBITMQ_PUBLISHER_RECOVERY_INITIAL_MS | default "100" | quote }}
+  RABBITMQ_PUBLISHER_RECOVERY_MAX_MS: {{ .Values.underwriter.configmap.RABBITMQ_PUBLISHER_RECOVERY_MAX_MS | default "5000" | quote }}
 
-  # Swagger Documentation
+  # =============================================================================
+  # Outbox pattern (transactional event publishing)
+  # =============================================================================
+  OUTBOX_ENABLED: {{ .Values.underwriter.configmap.OUTBOX_ENABLED | default "false" | quote }}
+  OUTBOX_TABLE_NAME: {{ .Values.underwriter.configmap.OUTBOX_TABLE_NAME | default "outbox_events" | quote }}
+  OUTBOX_BATCH_SIZE: {{ .Values.underwriter.configmap.OUTBOX_BATCH_SIZE | default "100" | quote }}
+  OUTBOX_DISPATCH_INTERVAL_SEC: {{ .Values.underwriter.configmap.OUTBOX_DISPATCH_INTERVAL_SEC | default "5" | quote }}
+  OUTBOX_PROCESSING_TIMEOUT_SEC: {{ .Values.underwriter.configmap.OUTBOX_PROCESSING_TIMEOUT_SEC | default "30" | quote }}
+  OUTBOX_MAX_DISPATCH_ATTEMPTS: {{ .Values.underwriter.configmap.OUTBOX_MAX_DISPATCH_ATTEMPTS | default "5" | quote }}
+  OUTBOX_MAX_FAILED_PER_BATCH: {{ .Values.underwriter.configmap.OUTBOX_MAX_FAILED_PER_BATCH | default "10" | quote }}
+  OUTBOX_RETRY_WINDOW_SEC: {{ .Values.underwriter.configmap.OUTBOX_RETRY_WINDOW_SEC | default "60" | quote }}
+  OUTBOX_PUBLISH_BACKOFF_MS: {{ .Values.underwriter.configmap.OUTBOX_PUBLISH_BACKOFF_MS | default "100" | quote }}
+  OUTBOX_PUBLISH_MAX_ATTEMPTS: {{ .Values.underwriter.configmap.OUTBOX_PUBLISH_MAX_ATTEMPTS | default "3" | quote }}
+  OUTBOX_PRIORITY_EVENT_TYPES: {{ .Values.underwriter.configmap.OUTBOX_PRIORITY_EVENT_TYPES | default "" | quote }}
+  OUTBOX_INCLUDE_TENANT_METRICS: {{ .Values.underwriter.configmap.OUTBOX_INCLUDE_TENANT_METRICS | default "false" | quote }}
+  OUTBOX_ALLOW_EMPTY_TENANT: {{ .Values.underwriter.configmap.OUTBOX_ALLOW_EMPTY_TENANT | default "false" | quote }}
+
+  # =============================================================================
+  # Plugin Auth (Access Manager integration)
+  # =============================================================================
+  PLUGIN_AUTH_ENABLED: {{ .Values.underwriter.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
+  PLUGIN_AUTH_HOST: {{ .Values.underwriter.configmap.PLUGIN_AUTH_HOST | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000" | quote }}
+
+  # =============================================================================
+  # Swagger
+  # =============================================================================
   SWAGGER_ENABLED: {{ .Values.underwriter.configmap.SWAGGER_ENABLED | default "false" | quote }}
+  SWAGGER_TITLE: {{ .Values.underwriter.configmap.SWAGGER_TITLE | default "Underwriter API" | quote }}
+  SWAGGER_DESCRIPTION: {{ .Values.underwriter.configmap.SWAGGER_DESCRIPTION | default "Underwriter service" | quote }}
+  SWAGGER_VERSION: {{ .Values.underwriter.image.tag | default .Chart.AppVersion | quote }}
+  SWAGGER_HOST: {{ .Values.underwriter.configmap.SWAGGER_HOST | default "" | quote }}
+  SWAGGER_BASE_PATH: {{ .Values.underwriter.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
+  SWAGGER_SCHEMES: {{ .Values.underwriter.configmap.SWAGGER_SCHEMES | default "https" | quote }}
+  SWAGGER_LEFT_DELIM: {{ .Values.underwriter.configmap.SWAGGER_LEFT_DELIM | default "{{" | quote }}
+  SWAGGER_RIGHT_DELIM: {{ .Values.underwriter.configmap.SWAGGER_RIGHT_DELIM | default "}}" | quote }}
 
-  # Infrastructure Boot Timeout
+  # =============================================================================
+  # Rate limiting
+  # =============================================================================
+  RATE_LIMIT_ENABLED: {{ .Values.underwriter.configmap.RATE_LIMIT_ENABLED | default "true" | quote }}
+  RATE_LIMIT_MAX: {{ .Values.underwriter.configmap.RATE_LIMIT_MAX | default "100" | quote }}
+  RATE_LIMIT_WINDOW_SEC: {{ .Values.underwriter.configmap.RATE_LIMIT_WINDOW_SEC | default "60" | quote }}
+  AGGRESSIVE_RATE_LIMIT_MAX: {{ .Values.underwriter.configmap.AGGRESSIVE_RATE_LIMIT_MAX | default "10" | quote }}
+  AGGRESSIVE_RATE_LIMIT_WINDOW_SEC: {{ .Values.underwriter.configmap.AGGRESSIVE_RATE_LIMIT_WINDOW_SEC | default "60" | quote }}
+  RELAXED_RATE_LIMIT_MAX: {{ .Values.underwriter.configmap.RELAXED_RATE_LIMIT_MAX | default "1000" | quote }}
+  RELAXED_RATE_LIMIT_WINDOW_SEC: {{ .Values.underwriter.configmap.RELAXED_RATE_LIMIT_WINDOW_SEC | default "60" | quote }}
+  CIRCUIT_BREAKER_ENABLED: {{ .Values.underwriter.configmap.CIRCUIT_BREAKER_ENABLED | default "true" | quote }}
+
+  # =============================================================================
+  # Idempotency
+  # =============================================================================
+  IDEMPOTENCY_RETRY_WINDOW_SEC: {{ .Values.underwriter.configmap.IDEMPOTENCY_RETRY_WINDOW_SEC | default "300" | quote }}
+
+  # =============================================================================
+  # Pagination
+  # =============================================================================
+  MAX_PAGINATION_LIMIT: {{ .Values.underwriter.configmap.MAX_PAGINATION_LIMIT | default "100" | quote }}
+  MAX_PAGINATION_MONTH_DATE_RANGE: {{ .Values.underwriter.configmap.MAX_PAGINATION_MONTH_DATE_RANGE | default "12" | quote }}
+
+  # =============================================================================
+  # Infrastructure boot
+  # =============================================================================
   INFRA_CONNECT_TIMEOUT_SEC: {{ .Values.underwriter.configmap.INFRA_CONNECT_TIMEOUT_SEC | default "30" | quote }}
+  DB_METRICS_INTERVAL_SEC: {{ .Values.underwriter.configmap.DB_METRICS_INTERVAL_SEC | default "15" | quote }}
 
-  # OpenTelemetry (Observability)
+  # =============================================================================
+  # AWS
+  # =============================================================================
+  AWS_REGION: {{ .Values.underwriter.configmap.AWS_REGION | default "" | quote }}
+
+  # =============================================================================
+  # Examples / domain features
+  # =============================================================================
+  EXAMPLE_STATUS_PROVIDER_MODE: {{ .Values.underwriter.configmap.EXAMPLE_STATUS_PROVIDER_MODE | default "healthy" | quote }}
+
+  # =============================================================================
+  # OpenTelemetry
+  # =============================================================================
   ENABLE_TELEMETRY: {{ .Values.underwriter.configmap.ENABLE_TELEMETRY | default "false" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.underwriter.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/underwriter" | quote }}
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.underwriter.configmap.OTEL_RESOURCE_SERVICE_NAME | default "underwriter" | quote }}
+  # Auto-generated from image tag
   OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.underwriter.image.tag | default .Chart.AppVersion | quote }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.underwriter.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.underwriter.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "production" | quote }}
 
-  # Rate Limiting
-  RATE_LIMIT_ENABLED: {{ .Values.underwriter.configmap.RATE_LIMIT_ENABLED | default "true" | quote }}
-  RATE_LIMIT_MAX: {{ .Values.underwriter.configmap.RATE_LIMIT_MAX | default "100" | quote }}
-  RATE_LIMIT_EXPIRY_SEC: {{ .Values.underwriter.configmap.RATE_LIMIT_EXPIRY_SEC | default "60" | quote }}
-
-  # Observability & Metrics
-  DB_METRICS_INTERVAL_SEC: {{ .Values.underwriter.configmap.DB_METRICS_INTERVAL_SEC | default "15" | quote }}
-
-  # Idempotency
-  IDEMPOTENCY_RETRY_WINDOW_SEC: {{ .Values.underwriter.configmap.IDEMPOTENCY_RETRY_WINDOW_SEC | default "300" | quote }}
-
-  # Auto-generated version
-  VERSION: {{ .Values.underwriter.image.tag | default .Chart.AppVersion | quote }}
-
-  # Extra Env Vars
+  # =============================================================================
+  # Extra Env Vars (escape hatch for env-specific overrides)
+  # =============================================================================
   {{- with .Values.underwriter.extraEnvVars }}
   {{- range . }}
   {{ .name }}: {{ .value | quote }}

--- a/charts/underwriter/values.yaml
+++ b/charts/underwriter/values.yaml
@@ -163,36 +163,66 @@ underwriter:
   # -- Affinity rules for pod scheduling
   affinity: {}
 
-  # -- ConfigMap for environment variables and configurations
+  # -- ConfigMap for environment variables and configurations.
+  # All keys mirror the env vars consumed by the underwriter app
+  # (see internal/bootstrap/config.go). Only the keys you want to override
+  # need to appear here in consumer values.yaml; defaults are applied by
+  # the chart template.
   # @default -- templates/configmap.yaml
   configmap:
     # Application Settings
     ENV_NAME: "production"
     LOG_LEVEL: "info"
+    DEPLOYMENT_MODE: "local"
+    # NOTE: VERSION and OTEL_RESOURCE_SERVICE_VERSION are auto-derived from
+    #       .Values.underwriter.image.tag in templates/configmap.yaml; do not
+    #       set them here.
+
+    # HTTP server
     SERVER_ADDRESS: ":4017"
     HTTP_BODY_LIMIT_BYTES: "104857600"
+    TLS_TERMINATED_UPSTREAM: "true"
 
-    # CORS Configuration
+    # CORS
     CORS_ALLOWED_ORIGINS: "*"
     CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
     CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
-
-    # TLS Configuration
-    TLS_TERMINATED_UPSTREAM: "true"
+    CORS_EXPOSE_HEADERS: ""
+    CORS_ALLOW_CREDENTIALS: "false"
 
     # Tenancy
     DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"
-    DEFAULT_TENANT_SLUG: "default"
 
-    # PostgreSQL Database
+    # Multi-tenant
+    MULTI_TENANT_ENABLED: "false"
+    MULTI_TENANT_URL: ""
+    MULTI_TENANT_REDIS_HOST: ""
+    MULTI_TENANT_REDIS_PORT: "6379"
+    MULTI_TENANT_REDIS_TLS: "false"
+    MULTI_TENANT_MAX_TENANT_POOLS: "100"
+    MULTI_TENANT_IDLE_TIMEOUT_SEC: "300"
+    MULTI_TENANT_TIMEOUT: "30"
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
+    MULTI_TENANT_CACHE_TTL_SEC: "120"
+    MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: "30"
+
+    # PostgreSQL primary
     POSTGRES_HOST: "underwriter-postgresql-primary"
     POSTGRES_PORT: "5432"
-    POSTGRES_DB: "underwriter"
+    POSTGRES_NAME: "underwriter"
     POSTGRES_USER: "underwriter"
     POSTGRES_SSLMODE: "disable"
     MIGRATIONS_PATH: "migrations"
 
-    # PostgreSQL Connection Pool
+    # PostgreSQL replica (optional; falls back to primary if unset)
+    POSTGRES_REPLICA_HOST: ""
+    POSTGRES_REPLICA_PORT: ""
+    POSTGRES_REPLICA_NAME: ""
+    POSTGRES_REPLICA_USER: ""
+    POSTGRES_REPLICA_SSLMODE: ""
+
+    # PostgreSQL connection pool
     POSTGRES_MAX_OPEN_CONNS: "25"
     POSTGRES_MAX_IDLE_CONNS: "5"
     POSTGRES_CONN_MAX_LIFETIME_MINS: "30"
@@ -203,21 +233,93 @@ underwriter:
     REDIS_HOST: "underwriter-valkey-primary:6379"
     REDIS_DB: "0"
     REDIS_PROTOCOL: "3"
+    REDIS_TLS: "false"
     REDIS_POOL_SIZE: "10"
     REDIS_MIN_IDLE_CONNS: "2"
-    REDIS_READ_TIMEOUT_MS: "3000"
-    REDIS_WRITE_TIMEOUT_MS: "3000"
-    REDIS_DIAL_TIMEOUT_MS: "5000"
+    REDIS_READ_TIMEOUT: "3s"
+    REDIS_WRITE_TIMEOUT: "3s"
+    REDIS_DIAL_TIMEOUT: "5s"
+    REDIS_POOL_TIMEOUT: "4s"
+    REDIS_MAX_RETRIES: "3"
+    REDIS_MIN_RETRY_BACKOFF: "8ms"
+    REDIS_MAX_RETRY_BACKOFF: "512ms"
+    REDIS_MASTER_NAME: ""
 
-    # Authentication
-    AUTH_ENABLED: "false"
-    AUTH_SERVICE_ADDRESS: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000"
+    # RabbitMQ
+    RABBITMQ_ENABLED: "false"
+    RABBITMQ_HOST: ""
+    RABBITMQ_PORT_AMQP: "5672"
+    RABBITMQ_PORT_HOST: "15672"
+    RABBITMQ_VHOST: "/"
+    RABBITMQ_DEFAULT_USER: ""
+    RABBITMQ_EXCHANGE: "underwriter.events"
+    RABBITMQ_QUEUE: "underwriter.events.queue"
+    RABBITMQ_URL: ""
+    RABBITMQ_HEALTH_CHECK_URL: ""
+    RABBITMQ_HEALTH_CHECK_ALLOWED_HOSTS: ""
+    RABBITMQ_REQUIRE_HEALTH_ALLOWED_HOSTS: "false"
+    RABBITMQ_ALLOW_INSECURE_HEALTH_CHECK: "false"
+    RABBITMQ_ALLOW_INSECURE_TLS: "false"
+    RABBITMQ_PUBLISHER_CONFIRM_TIMEOUT_MS: "5000"
+    RABBITMQ_PUBLISHER_MAX_RECOVERIES: "5"
+    RABBITMQ_PUBLISHER_RECOVERY_INITIAL_MS: "100"
+    RABBITMQ_PUBLISHER_RECOVERY_MAX_MS: "5000"
 
-    # Swagger Documentation
+    # Outbox pattern (transactional event publishing)
+    OUTBOX_ENABLED: "false"
+    OUTBOX_TABLE_NAME: "outbox_events"
+    OUTBOX_BATCH_SIZE: "100"
+    OUTBOX_DISPATCH_INTERVAL_SEC: "5"
+    OUTBOX_PROCESSING_TIMEOUT_SEC: "30"
+    OUTBOX_MAX_DISPATCH_ATTEMPTS: "5"
+    OUTBOX_MAX_FAILED_PER_BATCH: "10"
+    OUTBOX_RETRY_WINDOW_SEC: "60"
+    OUTBOX_PUBLISH_BACKOFF_MS: "100"
+    OUTBOX_PUBLISH_MAX_ATTEMPTS: "3"
+    OUTBOX_PRIORITY_EVENT_TYPES: ""
+    OUTBOX_INCLUDE_TENANT_METRICS: "false"
+    OUTBOX_ALLOW_EMPTY_TENANT: "false"
+
+    # Plugin Auth (Access Manager integration)
+    PLUGIN_AUTH_ENABLED: "false"
+    PLUGIN_AUTH_HOST: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000"
+
+    # Swagger
     SWAGGER_ENABLED: "false"
+    SWAGGER_TITLE: "Underwriter API"
+    SWAGGER_DESCRIPTION: "Underwriter service"
+    SWAGGER_HOST: ""
+    SWAGGER_BASE_PATH: "/"
+    SWAGGER_SCHEMES: "https"
+    SWAGGER_LEFT_DELIM: "{{"
+    SWAGGER_RIGHT_DELIM: "}}"
 
-    # Infrastructure Boot Timeout
+    # Rate limiting
+    RATE_LIMIT_ENABLED: "true"
+    RATE_LIMIT_MAX: "100"
+    RATE_LIMIT_WINDOW_SEC: "60"
+    AGGRESSIVE_RATE_LIMIT_MAX: "10"
+    AGGRESSIVE_RATE_LIMIT_WINDOW_SEC: "60"
+    RELAXED_RATE_LIMIT_MAX: "1000"
+    RELAXED_RATE_LIMIT_WINDOW_SEC: "60"
+    CIRCUIT_BREAKER_ENABLED: "true"
+
+    # Idempotency
+    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
+
+    # Pagination
+    MAX_PAGINATION_LIMIT: "100"
+    MAX_PAGINATION_MONTH_DATE_RANGE: "12"
+
+    # Infrastructure boot
     INFRA_CONNECT_TIMEOUT_SEC: "30"
+    DB_METRICS_INTERVAL_SEC: "15"
+
+    # AWS
+    AWS_REGION: ""
+
+    # Examples / domain features
+    EXAMPLE_STATUS_PROVIDER_MODE: "healthy"
 
     # OpenTelemetry
     # -- Enable telemetry collection (when true, OTEL_EXPORTER_OTLP_ENDPOINT is overridden with HOST_IP:4317)
@@ -226,33 +328,32 @@ underwriter:
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/underwriter"
     # -- OTEL resource service name for traces/metrics
     OTEL_RESOURCE_SERVICE_NAME: "underwriter"
-    # -- OTEL resource service version
-    OTEL_RESOURCE_SERVICE_VERSION: "1.0.0"
     # -- OTEL exporter endpoint (empty when disabled; overridden by HOST_IP:4317 when ENABLE_TELEMETRY=true)
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
     # -- OTEL deployment environment
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
 
-    # Rate Limiting
-    RATE_LIMIT_ENABLED: "true"
-    RATE_LIMIT_MAX: "100"
-    RATE_LIMIT_EXPIRY_SEC: "60"
-
-    # Observability & Metrics
-    DB_METRICS_INTERVAL_SEC: "15"
-
-    # Idempotency
-    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
-
   # -- Secrets for storing sensitive data
   # @default -- templates/secrets.yaml
   secrets:
-    # -- PostgreSQL password
+    # -- PostgreSQL primary password
     POSTGRES_PASSWORD: "lerian"
+    # -- PostgreSQL replica password (defaults to PostgreSQL primary password if unset)
+    POSTGRES_REPLICA_PASSWORD: ""
     # -- Redis password (empty if auth disabled)
     REDIS_PASSWORD: ""
-    # -- Auth JWT secret (if AUTH_ENABLED is true)
-    AUTH_JWT_SECRET: ""
+    # -- Redis CA certificate path / contents (when REDIS_TLS=true and a custom CA is required)
+    REDIS_CA_CERT: ""
+    # -- RabbitMQ password (when RABBITMQ_ENABLED=true)
+    RABBITMQ_DEFAULT_PASS: ""
+    # -- Multi-tenant Redis password (when MULTI_TENANT_ENABLED=true and the manager Redis requires auth)
+    MULTI_TENANT_REDIS_PASSWORD: ""
+    # -- Multi-tenant service API key (M2M auth against the tenant-manager)
+    MULTI_TENANT_SERVICE_API_KEY: ""
+    # -- TLS certificate file path (when running TLS at the app layer instead of TLS_TERMINATED_UPSTREAM=true)
+    SERVER_TLS_CERT_FILE: ""
+    # -- TLS key file path
+    SERVER_TLS_KEY_FILE: ""
 
   # -- Existing secrets name
   useExistingSecret: false


### PR DESCRIPTION
## Summary

The underwriter app's env-var contract drifted from the chart in commit [df12273](https://github.com/LerianStudio/underwriter/commit/df12273) (\"refactor(config): align environment variables with canonical specification\"). Image \`1.0.0-beta.7\` is the first release with the new contract; the chart still emitted the old names, breaking pod startup across firmino/dev, firmino/stg, firmino/prd with errors like:

\`\`\`
FATAL: database \"sslmode=disable\" does not exist (SQLSTATE 3D000)
\`\`\`

This PR is an **inventory-and-standards pass**: it brings the chart fully in sync with \`internal/bootstrap/config.go\` and standardizes \`VERSION\` env vars to auto-derive from \`.Values.underwriter.image.tag\` (matching other Lerian charts).

## Renames (chart aligned with app's new env names)

| Old (chart) | New (app expects) |
|-------------|-------------------|
| \`POSTGRES_DB\` | **\`POSTGRES_NAME\`** |
| \`POSTGRES_REPLICA_DB\` | **\`POSTGRES_REPLICA_NAME\`** |
| \`AUTH_ENABLED\` | **\`PLUGIN_AUTH_ENABLED\`** |
| \`AUTH_SERVICE_ADDRESS\` | **\`PLUGIN_AUTH_HOST\`** |
| \`RATE_LIMIT_EXPIRY_SEC\` | **\`RATE_LIMIT_WINDOW_SEC\`** |
| \`REDIS_READ_TIMEOUT_MS\` (ms) | **\`REDIS_READ_TIMEOUT\`** (duration string) |
| \`REDIS_WRITE_TIMEOUT_MS\` (ms) | **\`REDIS_WRITE_TIMEOUT\`** (duration string) |
| \`REDIS_DIAL_TIMEOUT_MS\` (ms) | **\`REDIS_DIAL_TIMEOUT\`** (duration string) |

## Removed (obsolete; not read by the app)

- \`DEFAULT_TENANT_SLUG\`
- \`AUTH_JWT_SECRET\` (secret)

## Added (full app contract mirrored; defaults match \`config.go envDefault\`)

| Group | Vars |
|-------|------|
| Application | \`DEPLOYMENT_MODE\` |
| CORS | \`CORS_EXPOSE_HEADERS\`, \`CORS_ALLOW_CREDENTIALS\` |
| Multi-tenant | \`MULTI_TENANT_ENABLED\`, \`MULTI_TENANT_URL\`, \`MULTI_TENANT_REDIS_*\`, \`MULTI_TENANT_MAX_TENANT_POOLS\`, \`MULTI_TENANT_IDLE_TIMEOUT_SEC\`, \`MULTI_TENANT_TIMEOUT\`, \`MULTI_TENANT_CIRCUIT_BREAKER_*\`, \`MULTI_TENANT_CACHE_TTL_SEC\`, \`MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC\` |
| PostgreSQL replica | \`POSTGRES_REPLICA_HOST\`/\`PORT\`/\`NAME\`/\`USER\`/\`SSLMODE\` |
| Redis | \`REDIS_TLS\`, \`REDIS_POOL_TIMEOUT\`, \`REDIS_MAX_RETRIES\`, \`REDIS_MIN_RETRY_BACKOFF\`, \`REDIS_MAX_RETRY_BACKOFF\`, \`REDIS_MASTER_NAME\` |
| RabbitMQ | full block: 16 vars (\`RABBITMQ_*\`) |
| Outbox | full block: 13 vars (\`OUTBOX_*\`) |
| Swagger | \`SWAGGER_TITLE\`/\`DESCRIPTION\`/\`HOST\`/\`BASE_PATH\`/\`SCHEMES\`/\`LEFT_DELIM\`/\`RIGHT_DELIM\` |
| Rate limiting | \`AGGRESSIVE_RATE_LIMIT_*\`, \`RELAXED_RATE_LIMIT_*\`, \`CIRCUIT_BREAKER_ENABLED\` |
| Pagination | \`MAX_PAGINATION_LIMIT\`, \`MAX_PAGINATION_MONTH_DATE_RANGE\` |
| AWS | \`AWS_REGION\` |
| Domain | \`EXAMPLE_STATUS_PROVIDER_MODE\` |
| Secrets | \`POSTGRES_REPLICA_PASSWORD\`, \`REDIS_CA_CERT\`, \`RABBITMQ_DEFAULT_PASS\`, \`MULTI_TENANT_REDIS_PASSWORD\`, \`MULTI_TENANT_SERVICE_API_KEY\`, \`SERVER_TLS_CERT_FILE\`, \`SERVER_TLS_KEY_FILE\` |

## Standardized (VERSION fields auto-derived from image tag)

| Field | Behavior |
|-------|----------|
| \`VERSION\` | Already auto-derived from \`.Values.underwriter.image.tag\` (no change) |
| \`OTEL_RESOURCE_SERVICE_VERSION\` | Already auto-derived (no change) |
| \`SWAGGER_VERSION\` | **Newly added, auto-derived** to keep parity |

This matches the convention used by other Lerian charts (midaz, fetcher, matcher, etc.) where \`VERSION\` env vars never need manual maintenance in gitops values overrides; they always reflect the deployed image tag. Consumer values.yaml should NOT set \`VERSION\`, \`OTEL_RESOURCE_SERVICE_VERSION\`, or \`SWAGGER_VERSION\` manually.

## Consumer (gitops) impact

Consumer \`values.yaml\` files for underwriter need these renames:

\`\`\`diff
- POSTGRES_DB: \"underwriter\"
+ POSTGRES_NAME: \"underwriter\"

- AUTH_ENABLED: \"true\"
+ PLUGIN_AUTH_ENABLED: \"true\"

- AUTH_SERVICE_ADDRESS: \"...\"
+ PLUGIN_AUTH_HOST: \"...\"

- RATE_LIMIT_EXPIRY_SEC: \"60\"
+ RATE_LIMIT_WINDOW_SEC: \"60\"

- REDIS_READ_TIMEOUT_MS: \"3000\"
+ REDIS_READ_TIMEOUT: \"3s\"
- REDIS_WRITE_TIMEOUT_MS: \"3000\"
+ REDIS_WRITE_TIMEOUT: \"3s\"
- REDIS_DIAL_TIMEOUT_MS: \"5000\"
+ REDIS_DIAL_TIMEOUT: \"5s\"

- DEFAULT_TENANT_SLUG: \"default\"     # remove

- OTEL_RESOURCE_SERVICE_VERSION: \"1.0.0-beta.6\"  # remove (auto-derived)
\`\`\`

A separate gitops PR will follow this once the new chart beta is released.

## Verification

\`helm template t charts/underwriter\` renders cleanly. All 113 \`env:\` definitions in \`config.go\` are now exposed via the chart configmap with appropriate defaults, except the secrets (which go through the secrets section) and the auto-derived VERSION fields.