### PR TITLE
fix(tracer): correct readinessProbe default path '/readyz' -> '/ready'

### DIFF
--- a/charts/tracer/templates/deployment.yaml
+++ b/charts/tracer/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             failureThreshold: {{ .Values.tracer.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.tracer.readinessProbe.path | default "/readyz" }}
+              path: {{ .Values.tracer.readinessProbe.path | default "/ready" }}
               port: http
             initialDelaySeconds: {{ .Values.tracer.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.tracer.readinessProbe.periodSeconds | default 10 }}


### PR DESCRIPTION
## Summary

The tracer chart defaults \`readinessProbe.path\` to \`/readyz\`, but the tracer app exposes \`/ready\` (per Ring Standards in \`internal/adapters/http/in/routes.go:124\`). The chart's wrong default causes readiness probes to 404 on every deployment using chart defaults, leaving pods stuck at \`0/1\`.

## Source code evidence

\`LerianStudio/tracer/internal/adapters/http/in/routes.go\`:

\`\`\`go
123: f.Get(\"/health\", Health)
124: f.Get(\"/ready\", hc.ReadinessHandler())
125: f.Get(\"/version\", Version)
\`\`\`

The string \`readyz\` does not appear anywhere in the tracer codebase \u2014 verified with \`grep -RnE 'readyz' .\`.

## Live verification (firmino-dev tracer pod, image \`1.0.0-beta.72\`)

\`\`\`
curl /health -> 200 OK \"healthy\"
curl /ready  -> 200 OK
curl /readyz -> 404 {\"code\":404,\"title\":\"request_failed\"}
\`\`\`

## Impact

Tracer pods stuck at \`0/1\` (kubelet records \`Readiness probe failed: 404\` thousands of times) in:
- firmino/dev, firmino/stg, firmino/prd
- clotilde/sandbox
- (clotilde/dev avoided the bug because it has an explicit \`readinessProbe.path: /health\` override from a prior multi-tenant fix)

The old chart \`1.0.0\` (used by anacleto/dev, benedita/dev, benedita/sandbox) was correctly set, so those envs are unaffected.

## Fix

Single-line change: chart default \`/readyz\` \u2192 \`/ready\`.

\`\`\`diff
- path: {{ .Values.tracer.readinessProbe.path | default \"/readyz\" }}
+ path: {{ .Values.tracer.readinessProbe.path | default \"/ready\" }}
\`\`\`

## Compatibility

- Users explicitly overriding \`readinessProbe.path\` are unaffected.
- All existing deployments using the chart default will start passing readiness once the new chart version is rolled out.