### PR TITLE
feat(tracer): add multi-tenant support to chart (2.1.0-beta.1)

### DIFF
--- a/charts/tracer/Chart.yaml
+++ b/charts/tracer/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.2
+version: 2.1.0-beta.1
 
 appVersion: "1.0.0"
 

--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -54,6 +54,29 @@ data:
   CLEANUP_INTERVAL_HOURS: {{ .Values.tracer.configmap.CLEANUP_INTERVAL_HOURS | default "24" | quote }}
   CLEANUP_RETENTION_DAYS: {{ .Values.tracer.configmap.CLEANUP_RETENTION_DAYS | default "90" | quote }}
 
+  # Multi-Tenant
+  MULTI_TENANT_ENABLED: {{ .Values.tracer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
+  {{- if eq (.Values.tracer.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true" }}
+  MULTI_TENANT_URL: {{ required "tracer.configmap.MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true" .Values.tracer.configmap.MULTI_TENANT_URL | quote }}
+  MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ .Values.tracer.configmap.MULTI_TENANT_ALLOW_INSECURE_HTTP | default "false" | quote }}
+  MULTI_TENANT_REDIS_HOST: {{ required "tracer.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.tracer.configmap.MULTI_TENANT_REDIS_HOST | quote }}
+  MULTI_TENANT_REDIS_PORT: {{ .Values.tracer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
+  MULTI_TENANT_REDIS_TLS: {{ .Values.tracer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
+  MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.tracer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | default "100" | quote }}
+  MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.tracer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
+  MULTI_TENANT_TIMEOUT: {{ .Values.tracer.configmap.MULTI_TENANT_TIMEOUT | default "30" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.tracer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | default "5" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.tracer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
+  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.tracer.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
+  MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ .Values.tracer.configmap.MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC | default "30" | quote }}
+  {{- if .Values.tracer.configmap.MULTI_TENANT_MAX_OPEN_CONNS_PER_TENANT }}
+  MULTI_TENANT_MAX_OPEN_CONNS_PER_TENANT: {{ .Values.tracer.configmap.MULTI_TENANT_MAX_OPEN_CONNS_PER_TENANT | quote }}
+  {{- end }}
+  {{- if .Values.tracer.configmap.MULTI_TENANT_MAX_IDLE_CONNS_PER_TENANT }}
+  MULTI_TENANT_MAX_IDLE_CONNS_PER_TENANT: {{ .Values.tracer.configmap.MULTI_TENANT_MAX_IDLE_CONNS_PER_TENANT | quote }}
+  {{- end }}
+  {{- end }}
+
   # Extra Env Vars
   {{- with .Values.tracer.extraEnvVars }}
   {{- range . }}

--- a/charts/tracer/templates/secrets.yaml
+++ b/charts/tracer/templates/secrets.yaml
@@ -1,4 +1,15 @@
 {{- if and .Values.tracer.enabled (not .Values.tracer.useExistingSecret) }}
+{{- /*
+Multi-tenant validation: when MULTI_TENANT_ENABLED=true the app refuses
+to start without MULTI_TENANT_SERVICE_API_KEY. Fail the helm render with
+a clear message instead of letting the pod crashloop on missing config.
+MULTI_TENANT_REDIS_PASSWORD is optional (Redis without auth is allowed).
+*/ -}}
+{{- if eq (.Values.tracer.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true" }}
+{{- if not .Values.tracer.secrets.MULTI_TENANT_SERVICE_API_KEY }}
+{{- fail "tracer.secrets.MULTI_TENANT_SERVICE_API_KEY is required when MULTI_TENANT_ENABLED=true" }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -215,6 +215,43 @@ tracer:
     CLEANUP_INTERVAL_HOURS: "24"
     CLEANUP_RETENTION_DAYS: "90"
 
+    # Multi-Tenant
+    # -- Enable multi-tenant mode. When true, the following fields are required:
+    #    MULTI_TENANT_URL, MULTI_TENANT_REDIS_HOST, secrets.MULTI_TENANT_SERVICE_API_KEY.
+    #    Also requires PLUGIN_AUTH_ENABLED=true and API_KEY_ENABLED_ONLY_VALIDATION=false
+    #    (enforced by the app at boot for security).
+    MULTI_TENANT_ENABLED: "false"
+    # -- Tenant Manager URL (required when MULTI_TENANT_ENABLED=true).
+    #    Use http://tenant-manager.<ns>.svc.cluster.local:4026 for in-cluster traffic.
+    MULTI_TENANT_URL: ""
+    # -- Allow http:// MULTI_TENANT_URL. lib-commons rejects cleartext HTTP unless
+    #    this is true. Never set true in production.
+    MULTI_TENANT_ALLOW_INSECURE_HTTP: "false"
+    # -- Redis host for tenant connection-pool registry (required when MT enabled).
+    MULTI_TENANT_REDIS_HOST: ""
+    # -- Redis port for tenant registry.
+    MULTI_TENANT_REDIS_PORT: "6379"
+    # -- Use TLS for tenant Redis connection.
+    MULTI_TENANT_REDIS_TLS: "false"
+    # -- Maximum number of tenant connection pools held in memory.
+    MULTI_TENANT_MAX_TENANT_POOLS: "100"
+    # -- Idle timeout (seconds) before evicting unused tenant pool.
+    MULTI_TENANT_IDLE_TIMEOUT_SEC: "300"
+    # -- Tenant manager request timeout (seconds).
+    MULTI_TENANT_TIMEOUT: "30"
+    # -- Circuit breaker failure threshold for tenant manager calls.
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    # -- Circuit breaker open timeout (seconds) before half-open retry.
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
+    # -- Cache TTL (seconds) for tenant manager responses.
+    MULTI_TENANT_CACHE_TTL_SEC: "120"
+    # -- Per-tenant connection liveness check interval (seconds).
+    MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: "30"
+    # -- Optional cap on per-tenant DB connections (only set in MT integration tests
+    #    or environments with very low DB max_connections; leave unset in production).
+    # MULTI_TENANT_MAX_OPEN_CONNS_PER_TENANT: ""
+    # MULTI_TENANT_MAX_IDLE_CONNS_PER_TENANT: ""
+
   # -- Secrets for storing sensitive data
   # @default -- templates/secrets.yaml
   secrets:
@@ -222,6 +259,11 @@ tracer:
     DB_PASSWORD: "lerian"
     # -- API Key secret (if API_KEY_ENABLED is true)
     API_KEY_SECRET: ""
+    # -- Tenant Manager service API key (required when MULTI_TENANT_ENABLED=true).
+    #    Helm render fails fast if MT is enabled and this is empty.
+    # MULTI_TENANT_SERVICE_API_KEY: ""
+    # -- Optional Redis password for the tenant connection-pool registry.
+    # MULTI_TENANT_REDIS_PASSWORD: ""
 
   # -- Existing secrets name
   useExistingSecret: false


### PR DESCRIPTION
## Summary

The tracer Go binary supports multi-tenant mode via **17** `MULTI_TENANT_*` env vars (declared in `internal/bootstrap/config.go:100-127`), but the helm chart currently has **zero** multi-tenant support. None of the MT keys are rendered into the configmap or secret, so any env trying to enable MT via `extraEnvVars` would fail at boot because the source-side required fields can't flow through.

This PR mirrors the canonical pattern from the **plugin-fees** chart (which already has full MT support).

## Changes

### `templates/configmap.yaml`
- Always renders `MULTI_TENANT_ENABLED` (defaults to `"false"`)
- When MT is enabled, renders 14 additional MT keys
- `MULTI_TENANT_URL` and `MULTI_TENANT_REDIS_HOST` use `required` so helm fails fast at render time when MT is enabled without them

### `templates/secrets.yaml`
- Pre-render fail-fast check: if MT is enabled but `tracer.secrets.MULTI_TENANT_SERVICE_API_KEY` is empty, helm refuses to render with a clear error
- The secret value itself flows through the existing `range` loop — no template-level rendering changes needed there
- `MULTI_TENANT_REDIS_PASSWORD` is optional (Redis without auth is allowed by the app)

### `values.yaml`
- Documents 14 default MT configmap keys under `tracer.configmap` (matching lib-commons defaults: `REDIS_PORT=6379`, `MAX_TENANT_POOLS=100`, `IDLE_TIMEOUT_SEC=300`, `TIMEOUT=30`, `CIRCUIT_BREAKER_THRESHOLD=5`, `CIRCUIT_BREAKER_TIMEOUT_SEC=30`, `CACHE_TTL_SEC=120`, `CONNECTIONS_CHECK_INTERVAL_SEC=30`, etc.)
- Documents optional `MULTI_TENANT_SERVICE_API_KEY` and `MULTI_TENANT_REDIS_PASSWORD` under `tracer.secrets` (commented out by default)

### `Chart.yaml`
- Bumps version `2.0.0-beta.2` → `2.1.0-beta.1` (additive, **no breaking changes** for existing single-tenant deployments)

## Validation

`helm template` against four scenarios:

| Test | Input | Expected | Result |
|---|---|---|---|
| 1. Defaults | no overrides | `MULTI_TENANT_ENABLED=false`, no other MT keys | ✅ PASS |
| 2. MT enabled with all required | URL + REDIS_HOST + SERVICE_API_KEY | All 14 MT keys + API key in secret | ✅ PASS |
| 3. MT enabled, no values | only `MULTI_TENANT_ENABLED=true` | helm template fails with clear error | ✅ PASS — fails on missing API key |
| 4. MT enabled, URL+REDIS_HOST set but no API key | configmap fields set, secret missing | helm template fails | ✅ PASS — fails on missing API key |

## Source-side requirements (why these specific 4 fields are gated)

From `internal/bootstrap/config_multitenant.go:120-144` of the tracer source:

```go
if cfg.MultiTenantURL == "" {
    return fmt.Errorf("MULTI_TENANT_URL must be set when MULTI_TENANT_ENABLED=true: ...")
}
if cfg.MultiTenantServiceAPIKey == "" {
    return fmt.Errorf("MULTI_TENANT_SERVICE_API_KEY must be set when MULTI_TENANT_ENABLED=true: ...")
}
if cfg.MultiTenantRedisHost == "" {
    return fmt.Errorf("MULTI_TENANT_REDIS_HOST must be set when MULTI_TENANT_ENABLED=true: ...")
}
```

Plus two security gates that are validated by the app at boot (these are NOT chart-enforced — the app fails fast itself):

- `PLUGIN_AUTH_ENABLED=true` (chart already supports this)
- `API_KEY_ENABLED_ONLY_VALIDATION=false` (handled in the app config; does not need chart support)

## Backward compatibility

For any existing deployment that does not set `MULTI_TENANT_ENABLED`, the rendered output is identical to chart `2.0.0-beta.2` plus one new line: `MULTI_TENANT_ENABLED: "false"`. The Go runtime treats absent and `"false"` identically (zero-value boolean), so existing single-tenant deployments are unaffected.

## Files

- `charts/tracer/Chart.yaml`
- `charts/tracer/templates/configmap.yaml`
- `charts/tracer/templates/secrets.yaml`
- `charts/tracer/values.yaml`

## Out of scope

- `charts/tracer/values-template.yaml` (customer-facing template) is left untouched — it deliberately exposes only a minimal subset for end-user customization, and MT enablement is not yet a customer-facing feature.
- This PR does **not** enable MT in any gitops env. That decision is per-environment and goes through the gitops repo separately.