### PR TITLE
fix(tracer): rename PLUGIN_AUTH_HOST to PLUGIN_AUTH_ADDRESS (2.0.0-beta.4)

### DIFF
--- a/charts/tracer/Chart.yaml
+++ b/charts/tracer/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.3
+version: 2.0.0-beta.4
 
 appVersion: "1.0.0"
 

--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
 
   # Auth Plugin (Access Manager)
   PLUGIN_AUTH_ENABLED: {{ .Values.tracer.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
-  PLUGIN_AUTH_HOST: {{ .Values.tracer.configmap.PLUGIN_AUTH_HOST | default "http://plugin-auth:4000" | quote }}
+  PLUGIN_AUTH_ADDRESS: {{ .Values.tracer.configmap.PLUGIN_AUTH_ADDRESS | default "http://plugin-auth:4000" | quote }}
 
   # PostgreSQL Database
   DB_HOST: {{ .Values.tracer.configmap.DB_HOST | default "tracer-postgresql" | quote }}

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -179,7 +179,7 @@ tracer:
 
     # Auth Plugin (Access Manager)
     PLUGIN_AUTH_ENABLED: "false"
-    PLUGIN_AUTH_HOST: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000"
+    PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000"
 
     # PostgreSQL Database
     DB_HOST: "tracer-postgresql.tracer.svc.cluster.local."


### PR DESCRIPTION
## Summary

The tracer Go binary reads `PLUGIN_AUTH_ADDRESS`, but the chart was rendering `PLUGIN_AUTH_HOST` — a silent bug that goes unnoticed in single-tenant deployments (because `PLUGIN_AUTH_ENABLED` defaults to `false`) but **breaks immediately** when MT is enabled.

## Reproduction

After enabling multi-tenant mode in any tracer env (gitops PR #606 in midaz-firmino-gitops, for clotilde/dev), the new pod fail-fasts at boot:

```
fatal: failed to initialize servers: invalid access manager configuration:
       PLUGIN_AUTH_ADDRESS must be set when PLUGIN_AUTH_ENABLED=true
```

The configmap had `PLUGIN_AUTH_HOST` set but the binary was looking for `PLUGIN_AUTH_ADDRESS`.

## Source of truth

Tracer source declares the correct env key:

```go
// internal/bootstrap/config.go:82
PluginAuthAddress    string `env:"PLUGIN_AUTH_ADDRESS"`
```

Validator that triggered the failure:

```go
// internal/bootstrap/config.go:560
return fmt.Errorf("PLUGIN_AUTH_ADDRESS must be set when PLUGIN_AUTH_ENABLED=true")
```

## Fix

```yaml
# templates/configmap.yaml (was)
PLUGIN_AUTH_HOST: {{ .Values.tracer.configmap.PLUGIN_AUTH_HOST | default "http://plugin-auth:4000" | quote }}

# now
PLUGIN_AUTH_ADDRESS: {{ .Values.tracer.configmap.PLUGIN_AUTH_ADDRESS | default "http://plugin-auth:4000" | quote }}
```

Plus the same rename in `values.yaml` for the default value documentation.

Bumps chart version `2.0.0-beta.3` → `2.0.0-beta.4`.

## Validation

`helm template` dry-run renders correctly:

```
PLUGIN_AUTH_ENABLED: "false"
PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local.:4000"
```

## Breaking change note

This renames a values.yaml key, so users who explicitly set `tracer.configmap.PLUGIN_AUTH_HOST` must rename to `tracer.configmap.PLUGIN_AUTH_ADDRESS`. However, since the old key was being silently ignored by the chart anyway (the value never reached the pod's env under the right name), no live env was actually getting any benefit from setting `PLUGIN_AUTH_HOST`. Renaming is a **fix, not a regression**.

## Fleet-wide audit

Other charts in this repo have the same split between the two key names:

**Charts using `PLUGIN_AUTH_HOST` (likely also incorrect — needs per-app verification):**
- `go-boilerplate-ddd`
- `midaz/transaction`, `midaz/ledger`, `midaz/onboarding`
- `plugin-bc-correios`
- `plugin-br-pix-direct-jd` (×2)
- `plugin-br-pix-indirect-btg/inbound`, `outbound`
- ~~`tracer`~~ (this PR)

**Charts using `PLUGIN_AUTH_ADDRESS` (matches lib-commons convention):**
- `midaz/crm`
- `plugin-access-manager/identity`
- `plugin-br-bank-transfer`
- `plugin-br-pix-indirect-btg/pix`
- `plugin-br-pix-switch`
- `plugin-fees`

Each app's source code determines which key is correct. This PR fixes only tracer (the one I can confirm needs `PLUGIN_AUTH_ADDRESS` from source). The other charts should be audited individually as a follow-up.

## Files

- `charts/tracer/Chart.yaml`
- `charts/tracer/templates/configmap.yaml`
- `charts/tracer/values.yaml`

## After release

A follow-up gitops PR will:
1. Rename `PLUGIN_AUTH_ADDRESS` → keep as-is in clotilde/dev tracer values.yaml (already correct)
2. Bump tracer chart `2.0.0-beta.3` → `2.0.0-beta.4` in clotilde/dev (and any other env using tracer)