### PR TITLE
feat(plugin-br-payments): add helm chart

### DIFF
--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -33,6 +33,10 @@ plugin-br-pix-direct-jd:
 plugin-br-pix-switch:
   - changed-files:
       - any-glob-to-any-file: charts/plugin-br-pix-switch/**
+
+plugin-br-payments:
+  - changed-files:
+      - any-glob-to-any-file: charts/plugin-br-payments/**
       
 product-console:
   - changed-files:

--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ For implementation and configuration details, see the [README](https://charts.le
 | `2.3.0-beta.2` | 1.5.1 | 1.5.1 | 1.5.1 | 1.5.1 |
 -----------------
 
+### Plugin BR Payments
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/plugin-br-payments).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `0.1.0` | 1.0.0-beta.9 |
+-----------------
+
 ### Fetcher
 
 See the [official documentation](https://docs.lerian.studio/en/fetcher) for details.

--- a/charts/plugin-br-payments/CHANGELOG.md
+++ b/charts/plugin-br-payments/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this chart adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — Unreleased
+
+### Added
+
+- Initial Helm chart for the `plugin-br-payments` service.
+- Single Deployment running the `/app` binary with `SERVICE_TYPE=both` —
+  HTTP API, reconciliation worker, outbox dispatcher, and webhook delivery
+  all run as goroutines in one process.
+- PostgreSQL 17 subchart dependency (Bitnami `bitnamisecure/postgresql:latest`,
+  Bitnami's free repo after the August 2025 image migration) with replication
+  enabled by default.
+- Optional `bootstrap-postgres` Job for externally managed PostgreSQL deployments
+  (creates database, role, and grants idempotently).
+- Canonical Lerian readiness contract (matches `docs/readyz-guide.md` in the plugin):
+  - `livenessProbe` -> `/health`
+  - `readinessProbe` -> `/readyz`
+  - `terminationGracePeriodSeconds: 60`
+- Multi-tenancy support: when `MULTI_TENANCY_ENABLED=true`, the chart enforces
+  `MULTI_TENANT_MANAGER_URL` and `MULTI_TENANT_SERVICE_API_KEY`.
+- Worker secrets validation: when `SERVICE_TYPE` includes the worker
+  (`both` or `worker`), the chart enforces `INTERNAL_API_KEY` (>=32 chars)
+  and `CREDENTIAL_ENCRYPTION_KEY` (base64 AES-256). When `SERVICE_TYPE=api`,
+  it enforces `INTERNAL_WORKER_URL` and `INTERNAL_API_KEY`.
+- Validation helpers fail-fast on missing `OUTBOX_ENABLED`, provider, Midaz, and
+  PostgreSQL configuration.
+- Optional integration with `otel-collector-lerian` for host-level OTLP injection.
+- HPA + PDB.
+- Ingress template (disabled by default).
+- `SERVER_ADDRESS` defaults to `0.0.0.0:8080` so the in-pod bind reaches all
+  interfaces. The plugin's `ServerAddress()` rewrites empty-host values to
+  `localhost`, which would break kubelet probes if left as `:8080`.
+
+### Verified
+
+Tested in a live K3s cluster with `appVersion 1.0.0-beta.9`:
+helm lint passes; helm install succeeds end-to-end; deployment reaches
+`2/2 Ready`; `/health`, `/readyz`, and `/version` all return 200 via the
+generated Service; the readyz response reports `postgres`, `midaz`, and
+`provider` checks all `up`.

--- a/charts/plugin-br-payments/Chart.yaml
+++ b/charts/plugin-br-payments/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: plugin-br-payments-helm
+description: A Helm chart for the Brazilian Payments Plugin (boletos, bill payments, DARF, settlement)
+type: application
+home: https://github.com/LerianStudio/helm
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/plugin-br-payments
+  - https://github.com/LerianStudio/plugin-br-payments
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed.
+appVersion: "1.0.0-beta.9"
+
+# A list of keywords about the chart. This helps others discover the chart.
+keywords:
+  - midaz
+  - lerian
+  - ledger
+  - plugins
+  - payments
+  - boleto
+  - darf
+  - bankslip
+  - brazil
+
+# The URL to an icon file for this chart.
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+
+# Dependencies — plugin-br-payments only requires PostgreSQL.
+# Idempotency uses PostgreSQL (ADR-003, no Redis), and async event publishing
+# uses the outbox pattern with PostgreSQL (ADR-002, no message broker).
+dependencies:
+  - name: postgresql
+    version: "16.3"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: postgresql.enabled

--- a/charts/plugin-br-payments/README.md
+++ b/charts/plugin-br-payments/README.md
@@ -1,0 +1,180 @@
+# plugin-br-payments-helm
+
+A Helm chart for [plugin-br-payments](https://github.com/LerianStudio/plugin-br-payments) — Lerian Studio's plugin for Brazilian payment operations: boleto issuance, bill payments (bankslip, utilities, DARF), settlement via webhooks, and periodic reconciliation.
+
+## TL;DR
+
+```bash
+helm repo add lerian https://lerianstudio.github.io/helm
+helm install my-payments lerian/plugin-br-payments-helm \
+  --namespace midaz-plugins --create-namespace \
+  -f values-prod.yaml
+```
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.10+
+- Either:
+  - the in-cluster PostgreSQL subchart (default, `postgresql.enabled=true`), or
+  - an externally managed PostgreSQL 16+ instance.
+- A reachable `plugin-auth` (lib-auth) deployment when `PLUGIN_AUTH_ENABLED=true`.
+- A reachable Midaz onboarding/transaction stack.
+- A configured Brazilian payment provider (BTG is the first supported adapter).
+
+## Architecture
+
+The chart deploys **one Deployment, one process** (`/app` with `SERVICE_TYPE=both`):
+
+- HTTP API (boletos, payments, DARF, webhooks, dashboards)
+- Reconciliation worker (in-process goroutine, period: `RECONCILIATION_INTERVAL`)
+- Outbox dispatcher (in-process goroutine, polls every `OUTBOX_DISPATCH_INTERVAL_SEC`)
+- Webhook delivery (in-process)
+
+There is **no separate worker Deployment** — all background work runs inside the API pod. The Dockerfile also ships a standalone `/worker` binary for split deployments, but the chart does not use it; the unified `SERVICE_TYPE=both` mode is the operational model agreed with the plugin team.
+
+## Storage
+
+The plugin uses **PostgreSQL only**:
+- Idempotency is stored in PostgreSQL (no Redis — see ADR-003 in the plugin repo).
+- Async events use the **outbox pattern** with PostgreSQL (no message broker — ADR-002).
+
+## Required configuration
+
+The chart **fails fast** on `helm install` if any of the following are missing:
+
+| Field | Description |
+|-------|-------------|
+| `app.configmap.OUTBOX_ENABLED` | Must be `"true"`. The plugin only registers HTTP routes when the outbox is enabled. |
+| `app.configmap.PROVIDER_API_BASE_URL` | Provider API base URL. |
+| `app.configmap.PROVIDER_AUTH_URL` | Provider OAuth2 token URL. |
+| `app.configmap.MIDAZ_ONBOARDING_URL` | Midaz onboarding service URL. |
+| `app.configmap.MIDAZ_TRANSACTION_URL` | Midaz transaction service URL. |
+| `app.secrets.PROVIDER_CLIENT_ID` | Provider OAuth2 client ID. |
+| `app.secrets.PROVIDER_CLIENT_SECRET` | Provider OAuth2 client secret. |
+| `app.secrets.PROVIDER_WEBHOOK_SECRET` | Bearer token for incoming provider webhooks. |
+| `app.secrets.POSTGRES_PASSWORD` | PostgreSQL application password. |
+| `app.secrets.INTERNAL_API_KEY` | At least 32 characters. Required when `SERVICE_TYPE` includes worker (default `both`). Generate with `openssl rand -hex 32`. |
+| `app.secrets.CREDENTIAL_ENCRYPTION_KEY` | Base64-encoded AES-256 key. Required when `SERVICE_TYPE` includes worker. Generate with `openssl rand -base64 32`. |
+
+When `app.configmap.MULTI_TENANCY_ENABLED=true`, the following are additionally required:
+
+| Field | Description |
+|-------|-------------|
+| `app.configmap.MULTI_TENANT_MANAGER_URL` | Tenant Manager service URL. |
+| `app.secrets.MULTI_TENANT_SERVICE_API_KEY` | Tenant Manager service API key. |
+
+## Probes
+
+| Probe | Path | Notes |
+|-------|------|-------|
+| Liveness | `/health` | Lightweight startup self-probe. Returns 200 once startup completes. |
+| Readiness | `/readyz` | Deep per-dependency checks (Postgres, Provider, Midaz, Tenant Manager). Returns 503 if any dep is `down`/`degraded`. |
+| Tenant readiness | `/readyz/tenant/:id` | Mounted only when `MULTI_TENANCY_ENABLED=true`. Anti-enumeration uniform shape. |
+
+Default probe values match the canonical Lerian readiness contract documented in [`plugin-br-payments/docs/readyz-guide.md`](https://github.com/LerianStudio/plugin-br-payments/blob/main/docs/readyz-guide.md):
+
+```yaml
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 2
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+```
+
+`terminationGracePeriodSeconds` is set to **60** to match the service's drain + shutdown budget. Setting it lower will cause `SIGKILL` mid-shutdown.
+
+## Multi-tenancy
+
+The plugin supports schema-per-tenant via Lerian's Tenant Manager. To enable:
+
+```yaml
+app:
+  configmap:
+    MULTI_TENANCY_ENABLED: "true"
+    MULTI_TENANT_MANAGER_URL: "https://tenant-manager.example.com"
+    MULTI_TENANT_SERVICE_NAME: "plugin-br-payments"
+  secrets:
+    MULTI_TENANT_SERVICE_API_KEY: "<api key>"
+```
+
+When enabled, `/readyz/tenant/:id` becomes available and `/readyz` reports `provider:n/a` globally (use the per-tenant probe instead).
+
+## Common values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `app.replicaCount` | `2` | Number of replicas. |
+| `app.image.repository` | `ghcr.io/lerianstudio/plugin-br-payments` | Container image. |
+| `app.image.tag` | `""` (Chart `appVersion`) | Image tag. |
+| `app.service.port` | `8080` | Service port. |
+| `app.ingress.enabled` | `false` | Expose via Ingress. |
+| `app.autoscaling.enabled` | `true` | Enable HPA. |
+| `app.terminationGracePeriodSeconds` | `60` | Required by the readyz contract. |
+| `app.configmap.SERVICE_TYPE` | `both` | Run API + worker in one process. |
+| `app.configmap.OUTBOX_ENABLED` | `"true"` | REQUIRED — the plugin won't register routes otherwise. |
+| `app.configmap.MULTI_TENANCY_ENABLED` | `"false"` | Toggle multi-tenant mode. |
+| `postgresql.enabled` | `true` | Deploy the in-cluster PostgreSQL subchart. |
+| `postgresql.architecture` | `replication` | Primary + read replica. |
+| `global.externalPostgresDefinitions.enabled` | `false` | Run a bootstrap Job against an external PostgreSQL. |
+| `otel-collector-lerian.enabled` | `false` | Inject host-level OTLP endpoint env vars. |
+
+See [`values.yaml`](./values.yaml) for the full list, and [`values-template.yaml`](./values-template.yaml) for a production-ready overlay starter.
+
+## Production layout
+
+In production, you typically:
+
+1. **Disable the in-cluster PostgreSQL** and point at a managed service:
+   ```yaml
+   postgresql:
+     enabled: false
+
+   app:
+     configmap:
+       POSTGRES_HOST: my-rds-instance.example.com
+       POSTGRES_SSLMODE: require
+   ```
+
+2. **Use existing secrets** instead of inline values:
+   ```yaml
+   app:
+     useExistingSecret: true
+     existingSecretName: plugin-br-payments-secrets
+   ```
+
+3. **Optional bootstrap** for a fresh external Postgres (creates DB + role + grants, idempotent):
+   ```yaml
+   global:
+     externalPostgresDefinitions:
+       enabled: true
+       connection:
+         host: my-rds-instance.example.com
+         port: "5432"
+       postgresAdminLogin:
+         username: postgres
+         password: <admin password>
+       paymentsCredentials:
+         password: <plugin_br_payments role password>
+   ```
+
+## Uninstall
+
+```bash
+helm uninstall my-payments -n midaz-plugins
+```
+
+If `postgresql.enabled=true` was used, the PVCs are NOT deleted automatically. Remove them manually if no longer needed:
+
+```bash
+kubectl delete pvc -n midaz-plugins -l app.kubernetes.io/instance=my-payments
+```
+
+## License
+
+[Apache 2.0](../../LICENSE) (chart). The `plugin-br-payments` application itself is licensed under the [Elastic License 2.0](https://github.com/LerianStudio/plugin-br-payments/blob/main/LICENSE.md).

--- a/charts/plugin-br-payments/templates/NOTES.txt
+++ b/charts/plugin-br-payments/templates/NOTES.txt
@@ -1,0 +1,82 @@
+# Plugin BR Payments
+
+Thank you for installing {{ .Chart.Name }} v{{ .Chart.Version }}!
+
+## Deployment Status
+
+{{ if .Release.IsUpgrade }}
+The chart has been UPGRADED to version {{ .Chart.Version }} (appVersion {{ .Chart.AppVersion }}).
+{{ else }}
+The chart has been INSTALLED at version {{ .Chart.Version }} (appVersion {{ .Chart.AppVersion }}).
+{{ end }}
+
+## Component Deployed
+
+Single Deployment ({{ .Values.app.replicaCount }} replica(s)) running the /app binary
+with SERVICE_TYPE={{ .Values.app.configmap.SERVICE_TYPE | default "both" }}.
+HTTP API + reconciliation worker + outbox dispatcher run as goroutines in one process.
+
+  Service: {{ include "plugin-br-payments.fullname" . }}.{{ include "global.namespace" . }}.svc.cluster.local:{{ .Values.app.service.port }}
+  Liveness:  /health
+  Readiness: /readyz (deep dependency checks)
+  {{- if eq (.Values.app.configmap.MULTI_TENANCY_ENABLED | toString) "true" }}
+  Tenant readiness: /readyz/tenant/:id (multi-tenant mode)
+  {{- end }}
+
+## Dependencies
+
+{{- if eq (include "postgresql.enabled" .) "true" }}
+1. PostgreSQL (in-cluster, Bitnami subchart)
+   - Primary: {{ .Release.Name }}-postgresql-primary.{{ include "global.namespace" . }}.svc.cluster.local:5432
+   - Database: {{ .Values.postgresql.auth.database }}
+   - User:     {{ .Values.postgresql.auth.username }}
+{{- else if .Values.global.externalPostgresDefinitions.enabled }}
+1. PostgreSQL (external, bootstrapped by Helm)
+   - Host: {{ .Values.global.externalPostgresDefinitions.connection.host }}:{{ .Values.global.externalPostgresDefinitions.connection.port }}
+   - Database/Role: plugin_br_payments
+{{- else }}
+1. PostgreSQL (external, expected to be pre-provisioned)
+   - Configure POSTGRES_HOST/POSTGRES_PORT/POSTGRES_USER/POSTGRES_DB/POSTGRES_PASSWORD before installing.
+{{- end }}
+
+## Required Configuration
+
+The following values MUST be set for the deployment to start successfully:
+
+  - app.configmap.OUTBOX_ENABLED          (must be "true" — HTTP routes only register when the outbox is enabled)
+  - app.configmap.PROVIDER_API_BASE_URL   (provider API base URL)
+  - app.configmap.PROVIDER_AUTH_URL       (provider OAuth2 token URL)
+  - app.configmap.MIDAZ_ONBOARDING_URL    (Midaz onboarding service URL)
+  - app.configmap.MIDAZ_TRANSACTION_URL   (Midaz transaction service URL)
+  - app.secrets.PROVIDER_CLIENT_ID        (provider OAuth2 client ID)
+  - app.secrets.PROVIDER_CLIENT_SECRET    (provider OAuth2 client secret)
+  - app.secrets.PROVIDER_WEBHOOK_SECRET   (provider webhook bearer token)
+  - app.secrets.POSTGRES_PASSWORD         (PostgreSQL application password)
+  - app.secrets.INTERNAL_API_KEY          (>=32 chars; required for SERVICE_TYPE=both/worker)
+  - app.secrets.CREDENTIAL_ENCRYPTION_KEY (base64 AES-256; required for SERVICE_TYPE=both/worker)
+  - app.secrets.LICENSE_KEY               (recommended — required in production)
+
+When MULTI_TENANCY_ENABLED=true, additionally:
+  - app.configmap.MULTI_TENANT_MANAGER_URL
+  - app.secrets.MULTI_TENANT_SERVICE_API_KEY
+
+## Accessing the API
+
+{{- if contains "ClusterIP" .Values.app.service.type }}
+
+Port-forward locally:
+
+  kubectl port-forward -n {{ include "global.namespace" . }} svc/{{ include "plugin-br-payments.fullname" . }} {{ .Values.app.service.port }}:{{ .Values.app.service.port }}
+
+Then access: http://localhost:{{ .Values.app.service.port }}/health
+{{- end }}
+
+## Useful Commands
+
+  kubectl get pods -n {{ include "global.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl logs   -n {{ include "global.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }} --tail=200
+
+## Source
+
+  - Plugin source:   https://github.com/LerianStudio/plugin-br-payments
+  - Chart source:    https://github.com/LerianStudio/helm/tree/main/charts/plugin-br-payments

--- a/charts/plugin-br-payments/templates/_helpers.tpl
+++ b/charts/plugin-br-payments/templates/_helpers.tpl
@@ -1,0 +1,229 @@
+{{/*
+================================================================================
+PLUGIN BR PAYMENTS - HELM TEMPLATE HELPERS
+================================================================================
+The plugin runs API + worker logic in a SINGLE process (SERVICE_TYPE=both).
+One Deployment, one pod. No separate worker Deployment.
+================================================================================
+*/}}
+
+{{/*
+================================================================================
+NAME HELPERS
+================================================================================
+*/}}
+
+{{/*
+Top-level chart name.
+*/}}
+{{- define "plugin-br-payments.name" -}}
+{{- default "plugin-br-payments" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Application name (single deployment).
+*/}}
+{{- define "plugin-br-payments.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- default "plugin-br-payments" .Values.app.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+================================================================================
+CHART HELPERS
+================================================================================
+*/}}
+
+{{- define "plugin-br-payments.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Resolve the application image tag (Chart.appVersion if app.image.tag is empty).
+*/}}
+{{- define "plugin-br-payments.defaultTag" -}}
+{{- default .Chart.AppVersion .Values.app.image.tag }}
+{{- end -}}
+
+{{/*
+Sanitize tag for use in app.kubernetes.io/version label.
+*/}}
+{{- define "plugin-br-payments.versionLabelValue" -}}
+{{ regexReplaceAll "[^-A-Za-z0-9_.]" (include "plugin-br-payments.defaultTag" .) "-" | trunc 63 | trimAll "-" | trimAll "_" | trimAll "." | quote }}
+{{- end -}}
+
+{{/*
+================================================================================
+LABEL HELPERS
+================================================================================
+*/}}
+
+{{/*
+Common labels.
+Usage: {{ include "plugin-br-payments.labels" (dict "context" .) }}
+*/}}
+{{- define "plugin-br-payments.labels" -}}
+helm.sh/chart: {{ include "plugin-br-payments.chart" .context }}
+{{ include "plugin-br-payments.selectorLabels" (dict "context" .context) }}
+app.kubernetes.io/version: {{ include "plugin-br-payments.versionLabelValue" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: plugin-br-payments
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "plugin-br-payments.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "plugin-br-payments.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- end }}
+
+{{/*
+================================================================================
+SERVICE ACCOUNT HELPER
+================================================================================
+*/}}
+
+{{- define "plugin-br-payments.serviceAccountName" -}}
+{{- if .Values.app.serviceAccount.create }}
+{{- default (include "plugin-br-payments.fullname" .) .Values.app.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.app.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+================================================================================
+NAMESPACE HELPER
+================================================================================
+*/}}
+
+{{- define "global.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+================================================================================
+DEPENDENCY ENABLED HELPER
+================================================================================
+*/}}
+
+{{- define "postgresql.enabled" -}}
+{{- if and (default true .Values.postgresql.enabled) (not .Values.postgresql.external) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+================================================================================
+VALIDATION HELPERS
+================================================================================
+ERRORS (fail) block deployment for truly required fields.
+Mirrors the OUTBOX_ENABLED + provider/Midaz requirements documented in the
+plugin-br-payments README.
+================================================================================
+*/}}
+
+{{- define "plugin-br-payments.validateRequired" -}}
+
+{{/* OUTBOX must be enabled for HTTP routes to register */}}
+{{- if ne (.Values.app.configmap.OUTBOX_ENABLED | toString) "true" }}
+{{- fail "\n\nERROR: app.configmap.OUTBOX_ENABLED must be \"true\".\n   plugin-br-payments only registers its routes when the outbox pattern is enabled.\n   See README -> 'Local Development Config'.\n" }}
+{{- end }}
+
+{{/* Provider integration — required for any write operation */}}
+{{- if not .Values.app.configmap.PROVIDER_API_BASE_URL }}
+{{- fail "\n\nERROR: app.configmap.PROVIDER_API_BASE_URL is REQUIRED.\n   Set the provider API base URL (e.g., https://api.btgpactual.com).\n" }}
+{{- end }}
+
+{{- if not .Values.app.configmap.PROVIDER_AUTH_URL }}
+{{- fail "\n\nERROR: app.configmap.PROVIDER_AUTH_URL is REQUIRED.\n   Set the provider OAuth2 token endpoint URL.\n" }}
+{{- end }}
+
+{{- if not .Values.app.secrets.PROVIDER_CLIENT_ID }}
+{{- fail "\n\nERROR: app.secrets.PROVIDER_CLIENT_ID is REQUIRED.\n   Set the provider OAuth2 client ID in the secrets section.\n" }}
+{{- end }}
+
+{{- if not .Values.app.secrets.PROVIDER_CLIENT_SECRET }}
+{{- fail "\n\nERROR: app.secrets.PROVIDER_CLIENT_SECRET is REQUIRED.\n   Set the provider OAuth2 client secret in the secrets section.\n" }}
+{{- end }}
+
+{{- if not .Values.app.secrets.PROVIDER_WEBHOOK_SECRET }}
+{{- fail "\n\nERROR: app.secrets.PROVIDER_WEBHOOK_SECRET is REQUIRED.\n   Set the provider webhook bearer token in the secrets section.\n" }}
+{{- end }}
+
+{{/* Midaz Ledger URLs — required for production */}}
+{{- if not .Values.app.configmap.MIDAZ_ONBOARDING_URL }}
+{{- fail "\n\nERROR: app.configmap.MIDAZ_ONBOARDING_URL is REQUIRED.\n   Set the Midaz onboarding service URL.\n" }}
+{{- end }}
+
+{{- if not .Values.app.configmap.MIDAZ_TRANSACTION_URL }}
+{{- fail "\n\nERROR: app.configmap.MIDAZ_TRANSACTION_URL is REQUIRED.\n   Set the Midaz transaction service URL.\n" }}
+{{- end }}
+
+{{/* PostgreSQL password — required */}}
+{{- if not .Values.app.secrets.POSTGRES_PASSWORD }}
+{{- fail "\n\nERROR: app.secrets.POSTGRES_PASSWORD is REQUIRED.\n   Set the PostgreSQL application password.\n" }}
+{{- end }}
+
+{{/* Multi-tenant required fields when enabled */}}
+{{- if eq (.Values.app.configmap.MULTI_TENANCY_ENABLED | toString) "true" }}
+{{- if not .Values.app.configmap.MULTI_TENANT_MANAGER_URL }}
+{{- fail "\n\nERROR: app.configmap.MULTI_TENANT_MANAGER_URL is REQUIRED when MULTI_TENANCY_ENABLED=true.\n" }}
+{{- end }}
+{{- if not .Values.app.secrets.MULTI_TENANT_SERVICE_API_KEY }}
+{{- fail "\n\nERROR: app.secrets.MULTI_TENANT_SERVICE_API_KEY is REQUIRED when MULTI_TENANCY_ENABLED=true.\n" }}
+{{- end }}
+{{- end }}
+
+{{/* Internal API key + credential encryption — required when worker runs in-process or as worker pod */}}
+{{- $svcType := .Values.app.configmap.SERVICE_TYPE | default "both" | toString }}
+{{- if or (eq $svcType "both") (eq $svcType "worker") }}
+{{- if not .Values.app.secrets.INTERNAL_API_KEY }}
+{{- fail "\n\nERROR: app.secrets.INTERNAL_API_KEY is REQUIRED when SERVICE_TYPE includes worker (\"both\" or \"worker\").\n   The plugin uses this key for cross-pod token retrieval.\n   Must be at least 32 characters. Generate with: openssl rand -hex 32\n" }}
+{{- end }}
+{{- if lt (len (.Values.app.secrets.INTERNAL_API_KEY | toString)) 32 }}
+{{- fail "\n\nERROR: app.secrets.INTERNAL_API_KEY must be at least 32 characters.\n   Generate with: openssl rand -hex 32\n" }}
+{{- end }}
+{{- if not .Values.app.secrets.CREDENTIAL_ENCRYPTION_KEY }}
+{{- fail "\n\nERROR: app.secrets.CREDENTIAL_ENCRYPTION_KEY is REQUIRED when SERVICE_TYPE includes worker (\"both\" or \"worker\").\n   The plugin uses this key to encrypt provider OAuth credentials at rest.\n   Must be a base64-encoded AES-256 key (32 random bytes).\n   Generate with: openssl rand -base64 32\n" }}
+{{- end }}
+{{- end }}
+
+{{/* Split-deployment API mode requires INTERNAL_WORKER_URL */}}
+{{- if eq $svcType "api" }}
+{{- if not .Values.app.configmap.INTERNAL_WORKER_URL }}
+{{- fail "\n\nERROR: app.configmap.INTERNAL_WORKER_URL is REQUIRED when SERVICE_TYPE=\"api\".\n   API pods need to reach the worker pod's internal token endpoint.\n" }}
+{{- end }}
+{{- if not .Values.app.secrets.INTERNAL_API_KEY }}
+{{- fail "\n\nERROR: app.secrets.INTERNAL_API_KEY is REQUIRED when SERVICE_TYPE=\"api\".\n" }}
+{{- end }}
+{{- end }}
+
+{{- end }}
+
+{{/*
+Generate annotation listing default-value warnings (non-blocking).
+*/}}
+{{- define "plugin-br-payments.secretWarnings" -}}
+{{- $warnings := list -}}
+{{- if eq (.Values.app.secrets.POSTGRES_PASSWORD | toString) "lerian" -}}
+{{- $warnings = append $warnings "POSTGRES_PASSWORD is using default value 'lerian'" -}}
+{{- end -}}
+{{- if .Values.postgresql.enabled -}}
+{{- if eq (.Values.postgresql.auth.password | toString) "lerian" -}}
+{{- $warnings = append $warnings "postgresql.auth.password is using default value 'lerian'" -}}
+{{- end -}}
+{{- end -}}
+{{- if not .Values.app.secrets.LICENSE_KEY -}}
+{{- $warnings = append $warnings "LICENSE_KEY is empty - required for production" -}}
+{{- end -}}
+{{- if gt (len $warnings) 0 -}}
+lerian.studio/security-warnings: {{ $warnings | join "; " | quote }}
+{{- end -}}
+{{- end -}}

--- a/charts/plugin-br-payments/templates/bootstrap-postgres.yaml
+++ b/charts/plugin-br-payments/templates/bootstrap-postgres.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.global.externalPostgresDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "plugin-br-payments.fullname" . }}-bootstrap-postgres
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+    app.kubernetes.io/component: bootstrap-postgres
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-for-dependencies
+          image: busybox:1.37
+          env:
+            - name: DB_HOST
+              value: {{ .Values.global.externalPostgresDefinitions.connection.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.global.externalPostgresDefinitions.connection.port | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              TIMEOUT=300;
+              ELAPSED=0;
+              echo "Checking $DB_HOST:$DB_PORT...";
+              while ! nc -z "$DB_HOST" "$DB_PORT"; do
+                if [ $ELAPSED -ge $TIMEOUT ]; then
+                  echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+                  exit 1;
+                fi;
+                echo "$DB_HOST:$DB_PORT not ready, waiting (${ELAPSED}s/${TIMEOUT}s)";
+                sleep 5;
+                ELAPSED=$((ELAPSED + 5));
+              done;
+              echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+        - name: psql
+          image: postgres:17
+          env:
+            - name: DB_HOST
+              value: {{ .Values.global.externalPostgresDefinitions.connection.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.global.externalPostgresDefinitions.connection.port | quote }}
+            - name: DB_USER_ADMIN
+              {{- if .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name | quote }}
+                  key: DB_USER_ADMIN
+              {{- else }}
+              value: {{ .Values.global.externalPostgresDefinitions.postgresAdminLogin.username | quote }}
+              {{- end }}
+            - name: DB_ADMIN_PASSWORD
+              {{- if .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name | quote }}
+                  key: DB_ADMIN_PASSWORD
+              {{- else }}
+              value: {{ .Values.global.externalPostgresDefinitions.postgresAdminLogin.password | quote }}
+              {{- end }}
+            - name: DB_PASSWORD_PLUGIN_BR_PAYMENTS
+              {{- if .Values.global.externalPostgresDefinitions.paymentsCredentials.useExistingSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.externalPostgresDefinitions.paymentsCredentials.useExistingSecret.name | quote }}
+                  key: DB_PASSWORD_PLUGIN_BR_PAYMENTS
+              {{- else }}
+              value: {{ .Values.global.externalPostgresDefinitions.paymentsCredentials.password | quote }}
+              {{- end }}
+            - name: DB_DATABASE
+              value: postgres
+            - name: APP_DB
+              value: plugin_br_payments
+            - name: APP_ROLE
+              value: plugin_br_payments
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              echo "=== plugin-br-payments PostgreSQL Bootstrap ==="
+              echo "Host: $DB_HOST:$DB_PORT"
+              echo ""
+
+              echo "Checking existing PostgreSQL objects..."
+              DB_EXISTS=0
+              ROLE_EXISTS=0
+
+              if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_database WHERE datname='$APP_DB'" | grep -q 1; then
+                DB_EXISTS=1
+              fi
+              if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_roles WHERE rolname='$APP_ROLE'" | grep -q 1; then
+                ROLE_EXISTS=1
+              fi
+
+              if [ "$DB_EXISTS" = "1" ] && [ "$ROLE_EXISTS" = "1" ]; then
+                echo "Bootstrap already complete (database '$APP_DB' and role '$APP_ROLE' exist). Skipping creation."
+              else
+                if [ "$ROLE_EXISTS" = "1" ]; then
+                  echo "Role '$APP_ROLE' already exists. Skipping creation."
+                else
+                  echo "Creating role '$APP_ROLE'..."
+                  PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -v pw="$DB_PASSWORD_PLUGIN_BR_PAYMENTS" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE plugin_br_payments LOGIN PASSWORD :'pw'"
+                fi
+
+                if [ "$DB_EXISTS" = "1" ]; then
+                  echo "Database '$APP_DB' already exists. Skipping creation."
+                else
+                  echo "Creating database '$APP_DB'..."
+                  PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE DATABASE plugin_br_payments OWNER plugin_br_payments"
+                fi
+              fi
+
+              # Privileges (idempotent)
+              echo "Ensuring privileges and schema permissions..."
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "GRANT ALL PRIVILEGES ON DATABASE plugin_br_payments TO plugin_br_payments"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d plugin_br_payments -c "GRANT ALL ON SCHEMA public TO plugin_br_payments"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d plugin_br_payments -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO plugin_br_payments"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d plugin_br_payments -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO plugin_br_payments"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d plugin_br_payments -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO plugin_br_payments"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d plugin_br_payments -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO plugin_br_payments"
+
+              echo ""
+              echo "=== plugin-br-payments PostgreSQL Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/plugin-br-payments/templates/configmap.yaml
+++ b/charts/plugin-br-payments/templates/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "plugin-br-payments.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+data:
+  # Application environment values
+  {{- range $key, $value := .Values.app.configmap }}
+  {{- if ne $key "POSTGRES_HOST" }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+
+  # PostgreSQL host: explicit value or dynamic default based on release name when in-cluster Postgres is enabled.
+  # The Bitnami subchart exposes the primary at "{release}-postgresql-primary" in replication
+  # architecture and at "{release}-postgresql" in standalone architecture.
+  {{- if .Values.app.configmap.POSTGRES_HOST }}
+  POSTGRES_HOST: {{ .Values.app.configmap.POSTGRES_HOST | quote }}
+  {{- else if eq (include "postgresql.enabled" .) "true" }}
+  {{- $pgArch := default "replication" .Values.postgresql.architecture }}
+  {{- if eq $pgArch "replication" }}
+  POSTGRES_HOST: {{ printf "%s-postgresql-primary.%s.svc.cluster.local" .Release.Name (include "global.namespace" .) | quote }}
+  {{- else }}
+  POSTGRES_HOST: {{ printf "%s-postgresql.%s.svc.cluster.local" .Release.Name (include "global.namespace" .) | quote }}
+  {{- end }}
+  {{- else }}
+  POSTGRES_HOST: ""
+  {{- end }}
+
+  # Always set VERSION and OTEL_RESOURCE_SERVICE_VERSION from the resolved image tag
+  VERSION: {{ include "plugin-br-payments.defaultTag" . | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ include "plugin-br-payments.defaultTag" . | quote }}
+
+  # Extra environment variables (passthrough from values.app.extraEnvVars)
+  {{- with .Values.app.extraEnvVars }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/plugin-br-payments/templates/deployment.yaml
+++ b/charts/plugin-br-payments/templates/deployment.yaml
@@ -1,0 +1,124 @@
+{{- include "plugin-br-payments.validateRequired" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "plugin-br-payments.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.app.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.app.revisionHistoryLimit | default 10 }}
+  {{- with .Values.app.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  replicas: {{ .Values.app.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-payments.selectorLabels" (dict "context" .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 8 }}
+      {{- with .Values.app.podAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- with .Values.app.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "plugin-br-payments.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.app.terminationGracePeriodSeconds | default 60 }}
+      {{- with .Values.app.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq (include "postgresql.enabled" .) "true" }}
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          envFrom:
+            - configMapRef:
+                name: {{ include "plugin-br-payments.fullname" . }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              echo "Waiting for $POSTGRES_HOST:$POSTGRES_PORT...";
+              until nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
+                echo "$POSTGRES_HOST:$POSTGRES_PORT not ready, sleeping 5s";
+                sleep 5;
+              done;
+              echo "$POSTGRES_HOST:$POSTGRES_PORT is ready";
+      {{- end }}
+      containers:
+        - name: {{ include "plugin-br-payments.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.app.securityContext | nindent 12 }}
+          image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag | default (include "plugin-br-payments.defaultTag" .) }}"
+          imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "plugin-br-payments.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.app.useExistingSecret }}{{ .Values.app.existingSecretName }}{{ else }}{{ include "plugin-br-payments.fullname" . }}{{ end }}
+          {{- if (index .Values "otel-collector-lerian").enabled }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "$(HOST_IP):4317"
+          {{- end }}
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+          # Canonical Lerian readiness contract — see plugin docs/readyz-guide.md
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.app.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds | default 3 }}
+            successThreshold: {{ .Values.app.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.app.readinessProbe.failureThreshold | default 2 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.app.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds | default 3 }}
+            successThreshold: {{ .Values.app.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.app.livenessProbe.failureThreshold | default 3 }}
+      {{- with .Values.app.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/plugin-br-payments/templates/hpa.yaml
+++ b/charts/plugin-br-payments/templates/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.app.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "plugin-br-payments.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "plugin-br-payments.fullname" . }}
+  minReplicas: {{ .Values.app.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.app.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.app.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.app.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.app.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.app.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.app.autoscaling.scaleDownStabilizationSeconds | default 300 }}
+{{- end }}

--- a/charts/plugin-br-payments/templates/ingress.yaml
+++ b/charts/plugin-br-payments/templates/ingress.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.app.ingress.enabled -}}
+{{- $fullName := include "plugin-br-payments.fullname" . -}}
+{{- $svcPort := .Values.app.service.port -}}
+{{- if and .Values.app.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.app.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.app.ingress.annotations "kubernetes.io/ingress.class" .Values.app.ingress.className }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.app.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.app.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.app.ingress.className }}
+  {{- end }}
+  {{- if .Values.app.ingress.tls }}
+  tls:
+    {{- range .Values.app.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.app.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/plugin-br-payments/templates/pdb.yaml
+++ b/charts/plugin-br-payments/templates/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.app.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "plugin-br-payments.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.app.pdb.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.app.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.app.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.app.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-payments.selectorLabels" (dict "context" .) | nindent 6 }}
+{{- end }}

--- a/charts/plugin-br-payments/templates/secrets.yml
+++ b/charts/plugin-br-payments/templates/secrets.yml
@@ -1,0 +1,24 @@
+{{- if not .Values.app.useExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "plugin-br-payments.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    {{- $warns := include "plugin-br-payments.secretWarnings" . }}
+    {{- if $warns }}
+    {{ $warns | nindent 4 }}
+    {{- end }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.app.secrets }}
+  {{- if $value }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-payments/templates/service.yaml
+++ b/charts/plugin-br-payments/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "plugin-br-payments.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.app.service.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.app.service.type }}
+  ports:
+    - port: {{ .Values.app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "plugin-br-payments.selectorLabels" (dict "context" .) | nindent 4 }}

--- a/charts/plugin-br-payments/templates/serviceaccount.yaml
+++ b/charts/plugin-br-payments/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.app.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "plugin-br-payments.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.app.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-payments/values-template.yaml
+++ b/charts/plugin-br-payments/values-template.yaml
@@ -1,0 +1,90 @@
+# Production values overlay starter for plugin-br-payments-helm.
+# Copy this file, fill in the placeholders, and pass it to helm install/upgrade.
+#
+#   helm upgrade --install plugin-br-payments lerian/plugin-br-payments-helm \
+#     -n midaz-plugins --create-namespace \
+#     -f values-prod.yaml
+
+app:
+  replicaCount: 2
+  image:
+    tag: "1.0.0"   # pin to a published immutable tag
+  ingress:
+    enabled: false
+    className: nginx
+    annotations: {}
+    hosts:
+      - host: payments.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: payments-tls
+        hosts:
+          - payments.example.com
+  configmap:
+    ENV_NAME: "production"
+    DEPLOYMENT_MODE: "saas"
+    LOG_LEVEL: "info"
+    SERVICE_TYPE: "both"
+    OUTBOX_ENABLED: "true"
+    # External PostgreSQL — leave empty here only if postgresql.enabled=true.
+    POSTGRES_HOST: ""
+    POSTGRES_SSLMODE: "require"
+    # Provider integration (REQUIRED)
+    PROVIDER_API_BASE_URL: ""
+    PROVIDER_AUTH_URL: ""
+    # Midaz Ledger (REQUIRED)
+    MIDAZ_ONBOARDING_URL: ""
+    MIDAZ_TRANSACTION_URL: ""
+    # Auth
+    PLUGIN_AUTH_ENABLED: "true"
+    PLUGIN_AUTH_ADDRESS: ""
+    # Multi-tenancy (set to "true" to enable)
+    MULTI_TENANCY_ENABLED: "false"
+    # MULTI_TENANT_MANAGER_URL: ""
+    # OpenTelemetry (use otel-collector-lerian.enabled below for host injection)
+    ENABLE_TELEMETRY: "true"
+    OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
+  secrets:
+    # Database
+    POSTGRES_PASSWORD: ""        # REQUIRED
+    # Provider OAuth2 (REQUIRED)
+    PROVIDER_CLIENT_ID: ""
+    PROVIDER_CLIENT_SECRET: ""
+    PROVIDER_WEBHOOK_SECRET: ""
+    # Internal cross-pod API (REQUIRED for SERVICE_TYPE=both/worker)
+    # Generate with: openssl rand -hex 32   (>=32 chars)
+    INTERNAL_API_KEY: ""
+    # Credential encryption (REQUIRED for SERVICE_TYPE=both/worker)
+    # Generate with: openssl rand -base64 32   (AES-256 key)
+    CREDENTIAL_ENCRYPTION_KEY: ""
+    # License (REQUIRED in production)
+    LICENSE_KEY: ""
+    ORGANIZATION_IDS: ""
+    # Multi-tenancy (REQUIRED when MULTI_TENANCY_ENABLED=true)
+    # MULTI_TENANT_SERVICE_API_KEY: ""
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+
+# Use a managed Postgres in production.
+postgresql:
+  enabled: false
+
+# When using a fresh external Postgres, optionally run the bootstrap Job once:
+# global:
+#   externalPostgresDefinitions:
+#     enabled: true
+#     connection:
+#       host: my-rds.example.com
+#       port: "5432"
+#     postgresAdminLogin:
+#       username: postgres
+#       password: <admin password>
+#     paymentsCredentials:
+#       password: <plugin_br_payments password>
+
+# otel-collector-lerian:
+#   enabled: true

--- a/charts/plugin-br-payments/values.yaml
+++ b/charts/plugin-br-payments/values.yaml
@@ -1,0 +1,399 @@
+# Default values for plugin-br-payments.
+# This is a YAML-formatted file.
+#
+# Runtime model: ONE Deployment, ONE pod, ONE process (the /app binary with
+# SERVICE_TYPE=both, the default). HTTP server, reconciliation worker, outbox
+# dispatcher, and webhook delivery all run as goroutines inside the same
+# process. There is NO separate worker Deployment.
+
+# -- Override the chart top-level name
+nameOverride: "plugin-br-payments"
+# -- Override the fully generated name
+fullnameOverride: ""
+# -- Override the namespace used by templates
+namespaceOverride: ""
+
+global:
+  # -- Bootstrap job for external PostgreSQL: creates database and role
+  externalPostgresDefinitions:
+    # -- Enable or disable the PostgreSQL bootstrap job
+    enabled: false
+    # -- PostgreSQL connection settings (used by the bootstrap job only)
+    connection:
+      # -- PostgreSQL host
+      host: "plugin-br-payments-postgresql-primary"
+      # -- PostgreSQL port
+      port: "5432"
+    # -- Admin (superuser) credentials used to create the application DB and role
+    postgresAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing DB_USER_ADMIN and DB_ADMIN_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "postgres"
+      # -- Admin password (ignored if useExistingSecret.name is set)
+      password: "lerian"
+    # -- Credentials for the plugin_br_payments role created by the job
+    paymentsCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing DB_PASSWORD_PLUGIN_BR_PAYMENTS key
+        name: ""
+      # -- Password for plugin_br_payments role (ignored if useExistingSecret.name is set)
+      password: "lerian"
+
+# ==============================================================================
+# APPLICATION
+# Single Deployment running the /app binary with SERVICE_TYPE=both.
+# Combines HTTP API + reconciliation worker + outbox dispatcher + webhook
+# delivery in one process.
+# ==============================================================================
+app:
+  # -- Service name
+  name: "plugin-br-payments"
+  # -- Number of replicas
+  replicaCount: 2
+  # -- Number of old ReplicaSets to retain for rollback
+  revisionHistoryLimit: 10
+  # -- Annotations applied to the Deployment resource
+  annotations: {}
+  # -- Annotations applied to the pods
+  podAnnotations: {}
+  image:
+    # -- Repository for the plugin-br-payments image
+    repository: ghcr.io/lerianstudio/plugin-br-payments
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+    # -- Image tag (defaults to Chart.appVersion if empty)
+    tag: ""
+  # -- Image pull secrets for private registries
+  imagePullSecrets: []
+  # -- Override of the resource name
+  nameOverride: ""
+  # -- Override of the fully qualified resource name
+  fullnameOverride: ""
+  # -- Termination grace period.
+  # The /readyz contract requires this to be 60 (drain grace + App.Shutdown budget).
+  # See applications/plugins/plugin-br-payments/docs/readyz-guide.md
+  terminationGracePeriodSeconds: 60
+  # -- Pod security context
+  podSecurityContext: {}
+  # -- Container security context (Distroless nonroot UID/GID is 65532)
+  securityContext:
+    runAsGroup: 65532
+    runAsUser: 65532
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  # -- PodDisruptionBudget configuration
+  pdb:
+    enabled: true
+    minAvailable: 1
+    maxUnavailable: ""
+    annotations: {}
+  # -- Deployment strategy
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  # -- Service configuration
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  # -- Ingress configuration
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  # -- Resource requests and limits.
+  # Reconciliation runs in-process so the limit accounts for both API + worker work.
+  resources:
+    limits:
+      cpu: 1500m
+      memory: 768Mi
+    requests:
+      cpu: 250m
+      memory: 384Mi
+  # -- HorizontalPodAutoscaler configuration
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    scaleDownStabilizationSeconds: 300
+  # -- Readiness probe configuration. Canonical values from
+  # applications/plugins/plugin-br-payments/docs/readyz-guide.md
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    successThreshold: 1
+    failureThreshold: 2
+  # -- Liveness probe configuration. Canonical values from the same guide.
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 3
+    successThreshold: 1
+    failureThreshold: 3
+  # -- Node selector for scheduling pods on specific nodes
+  nodeSelector: {}
+  # -- Tolerations for scheduling on tainted nodes
+  tolerations: []
+  # -- Affinity rules for pod scheduling
+  affinity: {}
+  # -- Host aliases for custom DNS resolution inside the pod
+  hostAliases: []
+  # -- ConfigMap (non-sensitive environment variables)
+  # @default -- templates/configmap.yaml
+  configmap:
+    # Application Settings
+    ENV_NAME: "production"
+    LOG_LEVEL: "info"
+    DEPLOYMENT_MODE: "saas"
+    # The plugin's ServerAddress() resolves an empty host to localhost, which
+    # would make pods unreachable from kubelet probes. Set the host explicitly
+    # to bind to all interfaces inside the pod.
+    SERVER_ADDRESS: "0.0.0.0:8080"
+    HTTP_BODY_LIMIT_BYTES: "104857600"
+    TLS_TERMINATED_UPSTREAM: "true"
+    # Service mode — run API + worker in the same process (default).
+    # Other valid values: "api" or "worker" for split deployments (not used here).
+    SERVICE_TYPE: "both"
+    # Cross-pod worker URL — only required for split deployments (SERVICE_TYPE=api).
+    # In SERVICE_TYPE=both mode the worker runs in-process so this is unused.
+    INTERNAL_WORKER_URL: ""
+    # CORS Configuration
+    ACCESS_CONTROL_ALLOW_ORIGIN: "*"
+    ACCESS_CONTROL_ALLOW_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+    ACCESS_CONTROL_ALLOW_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
+    ACCESS_CONTROL_EXPOSE_HEADERS: ""
+    ACCESS_CONTROL_ALLOW_CREDENTIALS: "false"
+    # Multi-Tenancy (database-per-tenant via tenant-manager)
+    # When enabled, MULTI_TENANT_MANAGER_URL and MULTI_TENANT_SERVICE_API_KEY become required.
+    MULTI_TENANCY_ENABLED: "false"
+    MULTI_TENANT_MANAGER_URL: ""
+    MULTI_TENANT_SERVICE_NAME: "plugin-br-payments"
+    MULTI_TENANT_POSTGRES_MODULE: ""
+    MULTI_TENANT_ALLOW_INSECURE_HTTP: "false"
+    MULTI_TENANT_CLIENT_TIMEOUT_SEC: "10"
+    MULTI_TENANT_CACHE_TTL_MINUTES: "60"
+    MULTI_TENANT_CB_THRESHOLD: "5"
+    MULTI_TENANT_CB_TIMEOUT_SEC: "30"
+    MULTI_TENANT_MAX_TENANT_POOLS: "100"
+    # PostgreSQL Primary (host defaults to {Release.Name}-postgresql-primary)
+    POSTGRES_HOST: ""  # Empty -> dynamic default in configmap template
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: "plugin_br_payments"
+    POSTGRES_DB: "plugin_br_payments"
+    POSTGRES_SSLMODE: "require"
+    POSTGRES_MAX_IDLE_CONNS: "15"
+    POSTGRES_MAX_OPEN_CONNS: "25"
+    POSTGRES_CONN_MAX_LIFETIME_MINS: "30"
+    POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
+    POSTGRES_CONNECT_TIMEOUT_SEC: "10"
+    # PostgreSQL Replica (optional - for CQRS read scaling)
+    # POSTGRES_REPLICA_HOST: ""
+    # POSTGRES_REPLICA_PORT: "5432"
+    # POSTGRES_REPLICA_USER: ""
+    # POSTGRES_REPLICA_DB: ""
+    # POSTGRES_REPLICA_SSLMODE: "require"
+    # Migrations (applied at startup by the /app binary)
+    INFRA_CONNECT_TIMEOUT_SEC: "30"
+    MIGRATION_TIMEOUT_SEC: "300"
+    MIGRATION_LOCK_TIMEOUT_MS: "10000"
+    # Outbox Pattern (REQUIRED - HTTP routes only register when OUTBOX_ENABLED=true)
+    OUTBOX_ENABLED: "true"
+    OUTBOX_TABLE_NAME: "outbox_events"
+    OUTBOX_DISPATCH_INTERVAL_SEC: "2"
+    OUTBOX_BATCH_SIZE: "50"
+    OUTBOX_PUBLISH_MAX_ATTEMPTS: "3"
+    OUTBOX_PUBLISH_BACKOFF_MS: "200"
+    OUTBOX_RETRY_WINDOW_SEC: "300"
+    OUTBOX_MAX_DISPATCH_ATTEMPTS: "10"
+    OUTBOX_PROCESSING_TIMEOUT_SEC: "600"
+    OUTBOX_MAX_FAILED_PER_BATCH: "25"
+    OUTBOX_INCLUDE_TENANT_METRICS: "false"
+    OUTBOX_ALLOW_EMPTY_TENANT: "true"
+    # Circuit Breaker
+    CIRCUIT_BREAKER_ENABLED: "true"
+    # Authentication (lib-auth + plugin-auth)
+    PLUGIN_AUTH_ENABLED: "true"
+    PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
+    # Provider Integration (REQUIRED - validated by helper)
+    PROVIDER_API_BASE_URL: ""
+    PROVIDER_AUTH_URL: ""
+    PROVIDER_TOKEN_REFRESH_INTERVAL: "1h"
+    # Midaz Ledger URLs (REQUIRED for production - validated by helper)
+    MIDAZ_ONBOARDING_URL: ""
+    MIDAZ_TRANSACTION_URL: ""
+    # Reconciliation worker (in-process)
+    RECONCILIATION_INTERVAL: "5m"
+    RECONCILIATION_LOOKBACK_HOURS: "24"
+    # Rate Limiting
+    RATE_LIMIT_ENABLED: "true"
+    RATE_LIMIT_MAX: "500"
+    RATE_LIMIT_WINDOW_SEC: "60"
+    AGGRESSIVE_RATE_LIMIT_MAX: "100"
+    AGGRESSIVE_RATE_LIMIT_WINDOW_SEC: "60"
+    RELAXED_RATE_LIMIT_MAX: "1000"
+    RELAXED_RATE_LIMIT_WINDOW_SEC: "60"
+    RATE_LIMIT_WRITE: "100"
+    RATE_LIMIT_READ: "500"
+    # Observability & Metrics
+    DB_METRICS_INTERVAL_SEC: "15"
+    # Idempotency
+    IDEMPOTENCY_RECORD_TTL_HOURS: "48"
+    # API Documentation
+    SWAGGER_ENABLED: "false"
+    # OpenTelemetry
+    ENABLE_TELEMETRY: "true"
+    OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-payments"
+    OTEL_RESOURCE_SERVICE_NAME: "plugin-br-payments"
+    OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
+    OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    # Resilience example (repo-local simulation only)
+    EXAMPLE_STATUS_PROVIDER_MODE: "healthy"
+  # -- Secrets (sensitive environment variables)
+  # @default -- templates/secrets.yml
+  secrets:
+    # PostgreSQL credentials
+    POSTGRES_PASSWORD: "lerian"
+    # POSTGRES_REPLICA_PASSWORD: ""
+    # Provider OAuth2 (REQUIRED)
+    PROVIDER_CLIENT_ID: ""
+    PROVIDER_CLIENT_SECRET: ""
+    PROVIDER_WEBHOOK_SECRET: ""
+    # Internal cross-pod API (REQUIRED when SERVICE_TYPE includes worker, i.e. "both" or "worker").
+    # Must be at least 32 characters. Generate with: openssl rand -hex 32
+    INTERNAL_API_KEY: ""
+    # INTERNAL_API_KEY_PREVIOUS: ""  # optional, for key rotation
+    # Credential encryption (REQUIRED when SERVICE_TYPE includes worker).
+    # Base64-encoded AES-256 key (32 random bytes). Generate with:
+    #   openssl rand -base64 32
+    CREDENTIAL_ENCRYPTION_KEY: ""
+    # CREDENTIAL_ENCRYPTION_KEY_PREVIOUS: ""  # optional, for key rotation
+    # License (required in production)
+    LICENSE_KEY: ""
+    ORGANIZATION_IDS: ""
+    # Multi-Tenant Manager API key (REQUIRED when MULTI_TENANCY_ENABLED=true)
+    MULTI_TENANT_SERVICE_API_KEY: ""
+    # Midaz M2M (optional)
+    # MIDAZ_CLIENT_ID: ""
+    # MIDAZ_CLIENT_SECRET: ""
+    # plugin-auth M2M (optional)
+    # PLUGIN_AUTH_CLIENT_ID: ""
+    # PLUGIN_AUTH_CLIENT_SECRET: ""
+  # -- Use an externally managed Secret instead of generating one
+  useExistingSecret: false
+  # -- Name of the externally managed Secret
+  existingSecretName: ""
+  # -- Extra environment variables (map of key:value pairs)
+  extraEnvVars: {}
+  # -- ServiceAccount configuration
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+
+# ==============================================================================
+# POSTGRESQL SUB-CHART (Bitnami)
+# Default: enabled with replication for in-cluster development/staging.
+# Production: set postgresql.enabled=false and configure
+#   global.externalPostgresDefinitions for an externally managed Postgres.
+# ==============================================================================
+postgresql:
+  enabled: true
+  external: false
+  global:
+    security:
+      # Bitnami moved free images to bitnamisecure / bitnamilegacy in 2025;
+      # the upstream Bitnami chart treats those repos as "non-standard" and
+      # blocks them unless this flag is set. Required for fresh installs.
+      allowInsecureImages: true
+  image:
+    repository: bitnamisecure/postgresql
+    tag: "latest"
+  architecture: replication
+  replication:
+    numSynchronousReplicas: 1
+  auth:
+    enabled: true
+    enablePostgresUser: true
+    postgresPassword: "lerian"
+    username: "plugin_br_payments"
+    password: "lerian"
+    database: "plugin_br_payments"
+    replicationUsername: "replicator"
+    replicationPassword: "replicator_password"
+  primary:
+    persistence:
+      size: 8Gi
+    resourcesPreset: "medium"
+    extendedConfiguration: |
+      shared_buffers = 512MB
+      max_wal_senders = 20
+      wal_keep_size = 512MB
+      max_replication_slots = 20
+    extraEnvVars:
+      - name: POSTGRESQL_WAL_LEVEL
+        value: "logical"
+      - name: POSTGRESQL_HOST_STANDBY
+        value: "on"
+      - name: POSTGRESQL_MAX_CONNECTIONS
+        value: "200"
+      - name: POSTGRESQL_TCP_KEEPALIVES_IDLE
+        value: "30"
+      - name: POSTGRESQL_TCP_KEEPALIVES_INTERVAL
+        value: "10"
+      - name: POSTGRESQL_TCP_KEEPALIVES_COUNT
+        value: "5"
+  readReplicas:
+    name: replication
+    replicaCount: 1
+    persistence:
+      size: 8Gi
+    resourcesPreset: "medium"
+    extendedConfiguration: |
+      shared_buffers = 512MB
+      max_wal_senders = 20
+      max_replication_slots = 20
+      wal_keep_size = 512MB
+    extraEnvVars:
+      - name: POSTGRESQL_WAL_LEVEL
+        value: "logical"
+      - name: POSTGRESQL_HOST_STANDBY
+        value: "on"
+      - name: POSTGRESQL_MAX_CONNECTIONS
+        value: "200"
+      - name: POSTGRESQL_TCP_KEEPALIVES_IDLE
+        value: "40"
+      - name: POSTGRESQL_TCP_KEEPALIVES_INTERVAL
+        value: "10"
+      - name: POSTGRESQL_TCP_KEEPALIVES_COUNT
+        value: "5"
+
+# ==============================================================================
+# OPTIONAL OTEL COLLECTOR INTEGRATION
+# Setting otel-collector-lerian.enabled=true causes the deployment to inject
+# HOST_IP/OTEL_EXPORTER_OTLP_ENDPOINT pointing at the host node's collector.
+# Mirrors the convention used by reporter, plugin-fees, and pix-indirect-btg.
+# ==============================================================================
+otel-collector-lerian:
+  enabled: false
+
+# Tag at end of file for image-update tooling.
+plugin-br-payments:
+  image:
+    tag: 1.0.0-beta.9


### PR DESCRIPTION
## Summary

Initial Helm chart for [plugin-br-payments](https://github.com/LerianStudio/plugin-br-payments) — Lerian's plugin for Brazilian payment operations (boletos, bill payments, DARF, settlement).

## Runtime model

ONE Deployment, ONE process. The `/app` binary runs with `SERVICE_TYPE=both`, executing the HTTP API + reconciliation worker + outbox dispatcher + webhook delivery as goroutines in the same pod. There is no separate worker Deployment — this matches the operational model agreed with the plugin team.

## Dependencies

PostgreSQL only:
- Idempotency uses Postgres (ADR-003); no Redis.
- Async events use the outbox pattern with Postgres (ADR-002); no message broker.

## Probes

Follows the canonical Lerian readiness contract documented in [plugin docs/readyz-guide.md](https://github.com/LerianStudio/plugin-br-payments/blob/main/docs/readyz-guide.md):

- `livenessProbe` → `/health` (delay=30s, period=10s, timeout=3s, failures=3)
- `readinessProbe` → `/readyz` (delay=5s, period=5s, timeout=3s, failures=2)
- `terminationGracePeriodSeconds: 60`

## Fail-fast validation

Chart blocks `helm install` when required values are missing:

- Provider OAuth2 fields: `PROVIDER_API_BASE_URL`, `PROVIDER_AUTH_URL`, `PROVIDER_CLIENT_ID`, `PROVIDER_CLIENT_SECRET`, `PROVIDER_WEBHOOK_SECRET`
- Midaz URLs: `MIDAZ_ONBOARDING_URL`, `MIDAZ_TRANSACTION_URL`
- `POSTGRES_PASSWORD` missing
- For `SERVICE_TYPE=both|worker`: `INTERNAL_API_KEY` (≥32 chars) and `CREDENTIAL_ENCRYPTION_KEY` (base64 AES-256) required
- For `SERVICE_TYPE=api`: `INTERNAL_WORKER_URL` and `INTERNAL_API_KEY` required
- When `MULTI_TENANCY_ENABLED=true`: `MULTI_TENANT_MANAGER_URL` and `MULTI_TENANT_SERVICE_API_KEY` required

## Optional features

- `bootstrap-postgres` Job for externally managed Postgres (creates DB + role + grants idempotently)
- `otel-collector-lerian` integration for host-level OTLP injection
- HPA + PDB
- Multi-host Ingress

## Verified live

Deployed in **clotilde-k8s** and **firmino-k8s** dev clusters with `appVersion 1.0.0-beta.9`:

- `helm lint` passes
- `helm template` renders cleanly
- Pod reaches `1/1 Ready`
- `/health`, `/readyz`, `/version` return 200 via Service AND Ingress
- `/readyz` reports `postgres`, `midaz`, `provider` checks all `up`
- Multi-host Ingress works (`payments.dev.lerian.net` + `payments.dev.firmino.lerian.net` in firmino)

## Files added/changed

- `charts/plugin-br-payments/` (new chart, 12 files)
- `.github/configs/labeler.yaml` (added labeler entry)
- `README.md` (added Application Version Mapping section)

## Notes for reviewers

- `SERVER_ADDRESS` defaults to `0.0.0.0:8080` — the plugin's `ServerAddress()` rewrites empty-host values to `localhost`, which would break kubelet probes if left as `:8080`. This is documented inline in `values.yaml`.
- PostgreSQL uses `bitnamisecure/postgresql:latest` + `allowInsecureImages: true` (Bitnami's free repo after the August 2025 image migration; same convention as `plugin-br-pix-indirect-btg`).
- Auth-related dev-bypass (`PLUGIN_AUTH_ENABLED=false`) currently doesn't work in the plugin app due to a defect in its identity middleware — tracked at [LerianStudio/plugin-br-payments#106](https://github.com/LerianStudio/plugin-br-payments/issues/106). Doesn't affect this chart; production keeps auth enabled by default.
