### PR TITLE
fix(flowker): align Mongo env vars with app source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | Flowker Version |
 | :---: | :---: |
-| `2.1.0-beta.4` | 1.0.0-beta.22 |
+| `2.1.0-beta.5` | 1.0.0-beta.22 |
 -----------------
 
 ### Tracer

--- a/charts/flowker/CHANGELOG.md
+++ b/charts/flowker/CHANGELOG.md
@@ -1,4 +1,41 @@
-# Changelog
+## [2.1.0-beta.5] — Unreleased
+
+### Changed
+
+- **Move `MONGO_URI` from ConfigMap to Secret.** The connection URI
+  embeds the application password and must not be persisted in plaintext
+  in a ConfigMap.
+- **`MONGO_URI` is now REQUIRED** — set `flowker.secrets.MONGO_URI` to a
+  full `mongodb://` URI. Auto-construction was removed because the
+  application reads `MONGO_URI` directly and the individual fields used
+  for construction were not consumed by the app.
+
+### Removed
+
+- ConfigMap no longer emits the following Mongo env vars (the application
+  source does not read them):
+  - `MONGO_HOST`, `MONGO_PORT`, `MONGO_APP_USER`
+  - `MONGO_MIN_POOL_SIZE`, `MONGO_MAX_IDLE_TIME_MS`
+  - `MONGO_CONNECT_TIMEOUT_MS`, `MONGO_SOCKET_TIMEOUT_MS`
+- Secret no longer emits `MONGO_APP_PASSWORD` standalone — the password
+  is provided as part of `MONGO_URI`.
+
+### Kept in ConfigMap
+
+- `MONGO_DB_NAME` (read via `env:"MONGO_DB_NAME"`)
+- `MONGO_MAX_POOL_SIZE` (read via `getEnvAsIntOrDefault`)
+
+### Kept in Secret
+
+- `MONGO_URI` (REQUIRED, read via `env:"MONGO_URI"`)
+- `MONGO_TLS_CA_CERT` (read via `env:"MONGO_TLS_CA_CERT"`)
+
+### Migration notes
+
+Installs that previously set `flowker.configmap.MONGO_URI` or
+`flowker.secrets.MONGO_APP_PASSWORD` MUST move to
+`flowker.secrets.MONGO_URI` with the full URI. The chart will fail to
+render if `MONGO_URI` is not set.
 
 ## [2.2.0-beta.1] — Unreleased
 

--- a/charts/flowker/Chart.yaml
+++ b/charts/flowker/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 2.1.0-beta.4
+version: 2.1.0-beta.5
 appVersion: "1.0.0"
 keywords:
   - flowker

--- a/charts/flowker/templates/configmap.yaml
+++ b/charts/flowker/templates/configmap.yaml
@@ -35,16 +35,12 @@ data:
   SSRF_ALLOW_PRIVATE: {{ .Values.flowker.configmap.SSRF_ALLOW_PRIVATE | default "false" | quote }}
 
   # MongoDB
-  MONGO_URI: {{ .Values.flowker.configmap.MONGO_URI | default "mongodb" | quote }}
-  MONGO_HOST: {{ .Values.flowker.configmap.MONGO_HOST | default "flowker-mongodb" | quote }}
-  MONGO_PORT: {{ .Values.flowker.configmap.MONGO_PORT | default "27017" | quote }}
+  # MONGO_URI lives in the Secret (templates/secrets.yaml) because it
+  # contains the application password.
+  # MONGO_DB_NAME is non-sensitive and used by the app to scope database operations.
   MONGO_DB_NAME: {{ .Values.flowker.configmap.MONGO_DB_NAME | default "flowker" | quote }}
-  MONGO_APP_USER: {{ .Values.flowker.configmap.MONGO_APP_USER | default "flowker" | quote }}
-  MONGO_MAX_POOL_SIZE: {{ .Values.flowker.configmap.MONGO_MAX_POOL_SIZE | default "10" | quote }}
-  MONGO_MIN_POOL_SIZE: {{ .Values.flowker.configmap.MONGO_MIN_POOL_SIZE | default "5" | quote }}
-  MONGO_MAX_IDLE_TIME_MS: {{ .Values.flowker.configmap.MONGO_MAX_IDLE_TIME_MS | default "60000" | quote }}
-  MONGO_CONNECT_TIMEOUT_MS: {{ .Values.flowker.configmap.MONGO_CONNECT_TIMEOUT_MS | default "10000" | quote }}
-  MONGO_SOCKET_TIMEOUT_MS: {{ .Values.flowker.configmap.MONGO_SOCKET_TIMEOUT_MS | default "30000" | quote }}
+  # MongoDB driver pool size (read directly via getEnvAsIntOrDefault, not via struct tag).
+  MONGO_MAX_POOL_SIZE: {{ .Values.flowker.configmap.MONGO_MAX_POOL_SIZE | default "20" | quote }}
 
   # Swagger
   SWAGGER_TITLE: {{ .Values.flowker.configmap.SWAGGER_TITLE | default "Flowker API" | quote }}

--- a/charts/flowker/templates/secrets.yaml
+++ b/charts/flowker/templates/secrets.yaml
@@ -8,8 +8,12 @@ metadata:
     {{- include "flowker.labels" (dict "context" . "component" .Values.flowker.name "name" .Values.flowker.name) | nindent 4 }}
 type: Opaque
 stringData:
-  # MongoDB credentials
-  MONGO_APP_PASSWORD: {{ .Values.flowker.secrets.MONGO_APP_PASSWORD | default "lerian" | quote }}
+  # MongoDB connection URI — Secret-only because it embeds the password.
+  # The full mongodb:// URI must be provided; the chart no longer
+  # auto-constructs it from individual host/port/user/password fields
+  # because the application reads only MONGO_URI/MONGO_DB_NAME/MONGO_TLS_CA_CERT
+  # (see flowker source: internal/bootstrap/database.go and config.go).
+  MONGO_URI: {{ required "flowker.secrets.MONGO_URI is required (e.g. mongodb://user:pass@host:27017/flowker?authSource=flowker)" .Values.flowker.secrets.MONGO_URI | quote }}
   {{- if .Values.flowker.secrets.MONGO_TLS_CA_CERT }}
   MONGO_TLS_CA_CERT: {{ .Values.flowker.secrets.MONGO_TLS_CA_CERT | quote }}
   {{- end }}

--- a/charts/flowker/values-template.yaml
+++ b/charts/flowker/values-template.yaml
@@ -45,16 +45,14 @@ flowker:
     LOG_LEVEL: "info"
     API_KEY_ENABLED: "false"
     CORS_ALLOWED_ORIGINS: "*"
-    MONGO_URI: "mongodb"
-    MONGO_HOST: ""
-    MONGO_PORT: "27017"
     MONGO_DB_NAME: "flowker"
-    MONGO_APP_USER: "flowker"
+    MONGO_MAX_POOL_SIZE: "20"
     ENABLE_TELEMETRY: "false"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
 
   secrets:
-    MONGO_APP_PASSWORD: ""
+    # REQUIRED: full mongodb:// URI with password embedded.
+    MONGO_URI: ""
     API_KEY: ""
 
   useExistingSecret: false

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -202,16 +202,12 @@ flowker:
     SSRF_ALLOW_PRIVATE: "false"
 
     # MongoDB
-    MONGO_URI: "mongodb://flowker:lerian@flowker-mongodb:27017/flowker?authSource=admin"
-    MONGO_HOST: "flowker-mongodb"
-    MONGO_PORT: "27017"
+    # MONGO_URI is in `secrets:` (not here) because it embeds the password.
+    # The application only reads MONGO_URI, MONGO_DB_NAME, MONGO_TLS_CA_CERT,
+    # and MONGO_MAX_POOL_SIZE — so we expose only those.
     MONGO_DB_NAME: "flowker"
-    MONGO_APP_USER: "flowker"
-    MONGO_MAX_POOL_SIZE: "10"
-    MONGO_MIN_POOL_SIZE: "5"
-    MONGO_MAX_IDLE_TIME_MS: "60000"
-    MONGO_CONNECT_TIMEOUT_MS: "10000"
-    MONGO_SOCKET_TIMEOUT_MS: "30000"
+    # MongoDB driver pool size
+    MONGO_MAX_POOL_SIZE: "20"
 
     # Swagger Documentation
     SWAGGER_TITLE: "Flowker API"
@@ -278,8 +274,11 @@ flowker:
   # -- Secrets for storing sensitive data
   # @default -- templates/secrets.yaml
   secrets:
-    # -- MongoDB application password
-    MONGO_APP_PASSWORD: "lerian"
+    # -- MongoDB connection URI (REQUIRED — must include the password).
+    # Example: mongodb://flowker:lerian@flowker-mongodb:27017/flowker?authSource=flowker
+    # For AWS DocumentDB add TLS query parameters:
+    #   mongodb://user:pass@host:27017/flowker?tls=true&tlsInsecure=true&directConnection=true&retryWrites=false&authSource=flowker
+    MONGO_URI: "mongodb://flowker:lerian@flowker-mongodb:27017/flowker?authSource=flowker"
     # -- Base64-encoded PEM CA certificate for MongoDB TLS (e.g., AWS DocumentDB). Empty disables TLS CA validation.
     MONGO_TLS_CA_CERT: ""
     # -- API Key secret (if API_KEY_ENABLED is true)


### PR DESCRIPTION
## Summary

Aligns the flowker chart's MongoDB env var surface with what the application actually reads. The chart was exposing 9 `MONGO_*` env vars but the app only reads 4 of them.

## App audit (source: `flowker/internal/bootstrap/`)

| Env var | Read by app? | Source |
|---------|:--:|--------|
| `MONGO_URI` | ✅ | `database.go:84` + struct tag |
| `MONGO_DB_NAME` | ✅ | `database.go:85` + struct tag |
| `MONGO_TLS_CA_CERT` | ✅ | `database.go:87` + struct tag |
| `MONGO_MAX_POOL_SIZE` | ✅ | `database.go:78` (`getEnvAsIntOrDefault`) |
| `MONGO_HOST`, `MONGO_PORT`, `MONGO_APP_USER` | ❌ | not read (info in URI) |
| `MONGO_APP_PASSWORD` | ❌ | not read (in URI) |
| `MONGO_MIN_POOL_SIZE` | ❌ | not read |
| `MONGO_MAX_IDLE_TIME_MS` | ❌ | not read |
| `MONGO_CONNECT_TIMEOUT_MS` | ❌ | not read |
| `MONGO_SOCKET_TIMEOUT_MS` | ❌ | not read |

## Changes

**`charts/flowker/templates/configmap.yaml`:**
- Removed: `MONGO_URI` (sensitive — moved to Secret), `MONGO_HOST`, `MONGO_PORT`, `MONGO_APP_USER`, `MONGO_MIN_POOL_SIZE`, `MONGO_MAX_IDLE_TIME_MS`, `MONGO_CONNECT_TIMEOUT_MS`, `MONGO_SOCKET_TIMEOUT_MS`
- Kept: `MONGO_DB_NAME`, `MONGO_MAX_POOL_SIZE`

**`charts/flowker/templates/secrets.yaml`:**
- `MONGO_URI` is now **REQUIRED** via Helm `required` helper. Renders fail-fast if not set.
- Removed: standalone `MONGO_APP_PASSWORD` (not used by app — embed in `MONGO_URI` instead)
- Removed: URI auto-construction (was building URI from non-app fields; the app expects a complete connection string anyway)
- Kept: `MONGO_TLS_CA_CERT` (optional, only emitted when populated)

**`charts/flowker/templates/deployment.yaml`:**
- Reverted envFrom order to original `[secretRef, configMapRef]` — no longer needed since there's no key duplication

**`bootstrap-mongodb.yaml` Job is unchanged** — it reads its own credentials from `.Values.global.externalMongoDefinitions.flowkerCredentials`, not from `flowker.configmap` or `flowker.secrets`.

## Final ConfigMap surface

```yaml
MONGO_DB_NAME: "flowker"
MONGO_MAX_POOL_SIZE: "20"
```

## Final Secret surface

```yaml
MONGO_URI: "mongodb://flowker:<pass>@host:27017/flowker?authSource=flowker"  # REQUIRED
MONGO_TLS_CA_CERT: "<base64 PEM>"  # optional
```

## Migration

Existing installations:
- Previously set `flowker.configmap.MONGO_URI` → move to `flowker.secrets.MONGO_URI`
- Previously set `flowker.secrets.MONGO_APP_PASSWORD` → embed it in `flowker.secrets.MONGO_URI`
- Previously set any of `MONGO_HOST`/`PORT`/`APP_USER`/`MIN_POOL_SIZE`/`*_TIMEOUT_MS` → safe to drop, they were never read by the app

The chart will fail to render with a clear error if `MONGO_URI` is empty.

## Verified

- `helm lint` passes
- `helm template` (default values): ConfigMap has only `MONGO_DB_NAME` + `MONGO_MAX_POOL_SIZE`; Secret has `MONGO_URI`
- `helm template --set 'flowker.secrets.MONGO_URI='` → fails with `required` error pointing at `secrets.yaml:16`

## Chart version

`2.1.0-beta.4` → `2.1.0-beta.5`
