### PR TITLE
fix(tracer): chart cleanup for 2.0.0-beta.5

### DIFF
--- a/charts/tracer/Chart.yaml
+++ b/charts/tracer/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.4
+version: 2.0.0-beta.5
 
 appVersion: "1.0.0"
 

--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -40,7 +40,6 @@ data:
   SWAGGER_SCHEMES: {{ .Values.tracer.configmap.SWAGGER_SCHEMES | default "http" | quote }}
 
   # CEL Expression Engine
-  CEL_CACHE_MAX_SIZE: {{ .Values.tracer.configmap.CEL_CACHE_MAX_SIZE | default "1000" | quote }}
   CEL_COST_LIMIT: {{ .Values.tracer.configmap.CEL_COST_LIMIT | default "10000" | quote }}
 
   # OpenTelemetry (Observability)
@@ -52,7 +51,6 @@ data:
   # Cleanup Worker
   CLEANUP_WORKER_ENABLED: {{ .Values.tracer.configmap.CLEANUP_WORKER_ENABLED | default "false" | quote }}
   CLEANUP_INTERVAL_HOURS: {{ .Values.tracer.configmap.CLEANUP_INTERVAL_HOURS | default "24" | quote }}
-  CLEANUP_RETENTION_DAYS: {{ .Values.tracer.configmap.CLEANUP_RETENTION_DAYS | default "90" | quote }}
 
   # Multi-Tenant
   MULTI_TENANT_ENABLED: {{ .Values.tracer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
@@ -61,7 +59,7 @@ data:
   MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ .Values.tracer.configmap.MULTI_TENANT_ALLOW_INSECURE_HTTP | default "false" | quote }}
   MULTI_TENANT_REDIS_HOST: {{ required "tracer.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.tracer.configmap.MULTI_TENANT_REDIS_HOST | quote }}
   MULTI_TENANT_REDIS_PORT: {{ .Values.tracer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
-  MULTI_TENANT_REDIS_TLS: {{ .Values.tracer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
+  MULTI_TENANT_REDIS_TLS: {{ .Values.tracer.configmap.MULTI_TENANT_REDIS_TLS | default "true" | quote }}
   MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.tracer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | default "100" | quote }}
   MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.tracer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
   MULTI_TENANT_TIMEOUT: {{ .Values.tracer.configmap.MULTI_TENANT_TIMEOUT | default "30" | quote }}

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -197,7 +197,6 @@ tracer:
     SWAGGER_SCHEMES: "http"
 
     # CEL Expression Engine
-    CEL_CACHE_MAX_SIZE: "1000"
     CEL_COST_LIMIT: "10000"
 
     # OpenTelemetry
@@ -213,7 +212,6 @@ tracer:
     # Cleanup Worker
     CLEANUP_WORKER_ENABLED: "false"
     CLEANUP_INTERVAL_HOURS: "24"
-    CLEANUP_RETENTION_DAYS: "90"
 
     # Multi-Tenant
     # -- Enable multi-tenant mode. When true, the following fields are required:
@@ -231,8 +229,9 @@ tracer:
     MULTI_TENANT_REDIS_HOST: ""
     # -- Redis port for tenant registry.
     MULTI_TENANT_REDIS_PORT: "6379"
-    # -- Use TLS for tenant Redis connection.
-    MULTI_TENANT_REDIS_TLS: "false"
+    # -- Use TLS for tenant Redis connection. Default true (matches app's
+    #    secure-by-default; app forces true when env var is unset).
+    MULTI_TENANT_REDIS_TLS: "true"
     # -- Maximum number of tenant connection pools held in memory.
     MULTI_TENANT_MAX_TENANT_POOLS: "100"
     # -- Idle timeout (seconds) before evicting unused tenant pool.
@@ -257,8 +256,10 @@ tracer:
   secrets:
     # -- PostgreSQL password
     DB_PASSWORD: "lerian"
-    # -- API Key secret (if API_KEY_ENABLED is true)
-    API_KEY_SECRET: ""
+    # -- API Key value (read by the app as $API_KEY when API_KEY_ENABLED=true).
+    #    The chart previously named this API_KEY_SECRET, which the app never
+    #    reads — silently disabling API-key auth even with API_KEY_ENABLED=true.
+    API_KEY: ""
     # -- Tenant Manager service API key (required when MULTI_TENANT_ENABLED=true).
     #    Helm render fails fast if MT is enabled and this is empty.
     # MULTI_TENANT_SERVICE_API_KEY: ""


### PR DESCRIPTION
## Summary

Audit of the tracer Helm chart against the application source code
(applications/products/tracer/internal/bootstrap/config.go) surfaced four
issues that this PR fixes ahead of the multi-tenant staging deployment.

## Fixes

### 1. Remove dead config keys
The chart renders two ConfigMap keys that the application never reads:

- **CEL_CACHE_MAX_SIZE** — CEL adapter cache size is hardcoded inside the adapter; no env var exists in source.
- **CLEANUP_RETENTION_DAYS** — Counter retention is a Go const \`CounterRetentionDays = 90\` in pkg/constant/limits.go; no env var exists in source.

### 2. Flip MULTI_TENANT_REDIS_TLS default to \"true\"
\`ApplyMultiTenantDefaults\` in config_multitenant.go forces \`MultiTenantRedisTLS = true\` when the env var is unset. The chart was defaulting to \`\"false\"\`, which actively opted operators into cleartext Redis on a fresh MT install. New default matches the app's secure-by-default behavior.

### 3. Rename values.yaml secrets.API_KEY_SECRET → API_KEY
The chart's secrets.yaml does \`range \$key, \$value\` over \`.Values.tracer.secrets\`, so the key name is rendered verbatim into the Secret. The app reads \`\$API_KEY\` (no \`_SECRET\` suffix), meaning the previous values.yaml example silently disabled API-key auth even with \`API_KEY_ENABLED=true\`.

### 4. Bump chart version
\`2.0.0-beta.4\` → \`2.0.0-beta.5\`.

## Validation

- helm lint: clean
- helm template with MULTI_TENANT_ENABLED=true: renders MULTI_TENANT_REDIS_TLS=\"true\"
- helm template with API_KEY_ENABLED=true and secrets.API_KEY=mykey: Secret contains API_KEY=mykey
- Dead keys removed from rendered ConfigMap

## Notes for staging

When deploying tracer-mt to lerian-aws-gitops staging, operators must still set:
- \`MULTI_TENANT_ENABLED: \"true\"\`
- \`MULTI_TENANT_URL\`, \`MULTI_TENANT_REDIS_HOST\`
- \`PLUGIN_AUTH_ENABLED: \"true\"\` (app blocks MT boot otherwise)
- \`secrets.MULTI_TENANT_SERVICE_API_KEY\`
- \`DEPLOYMENT_MODE: \"saas\"\` via extraEnvVars

Evaluation knobs (\`MAX_RULES_PER_REQUEST\`, \`DEFAULT_DECISION_WHEN_NO_MATCH\`) and a few observability/readyz tunables are not in the ConfigMap; the application provides safe defaults. Operators can pass them via \`extraEnvVars\`.