### PR TITLE
fix(tracer): align chart default port with source convention (2.0.0-beta.6)

### DIFF
--- a/charts/tracer/Chart.yaml
+++ b/charts/tracer/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.5
+version: 2.0.0-beta.6
 
 appVersion: "1.0.0"
 

--- a/charts/tracer/README.md
+++ b/charts/tracer/README.md
@@ -68,7 +68,7 @@ global:
 | `tracer.replicaCount` | Number of replicas | `1` |
 | `tracer.image.repository` | Image repository | `lerianstudio/tracer` |
 | `tracer.image.tag` | Image tag | `1.0.0` |
-| `tracer.service.port` | Service port | `8080` |
+| `tracer.service.port` | Service port | `4020` |
 | `tracer.ingress.enabled` | Enable ingress | `false` |
 | `tracer.autoscaling.enabled` | Enable HPA | `true` |
 | `tracer.pdb.enabled` | Enable PodDisruptionBudget | `true` |

--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- include "tracer.labels" (dict "context" . "component" .Values.tracer.name "name" .Values.tracer.name) | nindent 4 }}
 data:
   # Application Configuration
-  SERVER_PORT: {{ .Values.tracer.configmap.SERVER_PORT | default "8080" | quote }}
-  SERVER_ADDRESS: {{ .Values.tracer.configmap.SERVER_ADDRESS | default ":8080" | quote }}
+  SERVER_PORT: {{ .Values.tracer.configmap.SERVER_PORT | default "4020" | quote }}
+  SERVER_ADDRESS: {{ .Values.tracer.configmap.SERVER_ADDRESS | default ":4020" | quote }}
 
   # Logging
   LOG_LEVEL: {{ .Values.tracer.configmap.LOG_LEVEL | default "info" | quote }}
@@ -35,7 +35,7 @@ data:
   # Swagger Documentation
   SWAGGER_TITLE: {{ .Values.tracer.configmap.SWAGGER_TITLE | default "Tracer API" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.tracer.configmap.SWAGGER_DESCRIPTION | default "Real-time transaction validation and fraud prevention API" | quote }}
-  SWAGGER_HOST: {{ .Values.tracer.configmap.SWAGGER_HOST | default ":8080" | quote }}
+  SWAGGER_HOST: {{ .Values.tracer.configmap.SWAGGER_HOST | default ":4020" | quote }}
   SWAGGER_BASE_PATH: {{ .Values.tracer.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
   SWAGGER_SCHEMES: {{ .Values.tracer.configmap.SWAGGER_SCHEMES | default "http" | quote }}
 

--- a/charts/tracer/values-template.yaml
+++ b/charts/tracer/values-template.yaml
@@ -57,7 +57,7 @@ tracer:
     targetMemoryUtilizationPercentage: 80
 
   configmap:
-    SERVER_ADDRESS: ":8080"
+    SERVER_ADDRESS: ":4020"
     LOG_LEVEL: "info"
     DB_HOST: ""
     DB_PORT: "5432"

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -111,8 +111,11 @@ tracer:
   service:
     # -- Kubernetes service type
     type: ClusterIP
-    # -- Port for the HTTP API
-    port: 8080
+    # -- Port for the HTTP API. Matches the tracer source convention
+    # (Dockerfile EXPOSE 4020 + .env.example + Dockerfile.dev SERVER_PORT=4020).
+    # Override in environment values.yaml when an existing deployment expects
+    # a different port (e.g. legacy 8080).
+    port: 4020
     annotations: {}
 
   ingress:
@@ -167,8 +170,13 @@ tracer:
   # @default -- templates/configmap.yaml
   configmap:
     # Application Settings
-    SERVER_PORT: "8080"
-    SERVER_ADDRESS: ":8080"
+    # SERVER_PORT/SERVER_ADDRESS default to 4020 to match the tracer source
+    # convention (Dockerfile EXPOSE 4020 + .env.example + Dockerfile.dev). The
+    # app reads SERVER_ADDRESS first; if empty, falls back to SERVER_PORT.
+    # Keep these in sync with service.port above (and containerPort) when
+    # overriding in environment values.yaml.
+    SERVER_PORT: "4020"
+    SERVER_ADDRESS: ":4020"
     LOG_LEVEL: "info"
 
     # Authentication
@@ -192,7 +200,7 @@ tracer:
     # Swagger Documentation
     SWAGGER_TITLE: "Tracer API"
     SWAGGER_DESCRIPTION: "Real-time transaction validation and fraud prevention API"
-    SWAGGER_HOST: ":8080"
+    SWAGGER_HOST: ":4020"
     SWAGGER_BASE_PATH: "/"
     SWAGGER_SCHEMES: "http"
 


### PR DESCRIPTION
## Summary

Tracer source code defines port \`4020\` everywhere — Dockerfile EXPOSE,
Dockerfile.dev SERVER_PORT, and .env.example. The chart defaulted to
\`8080\`, forcing every consumer to override \`service.port\`,
\`SERVER_PORT\`, and \`SERVER_ADDRESS\` just to match.

This PR aligns the chart defaults with the source convention.

## Source-of-truth references

| File | Port |
|---|---|
| \`tracer/Dockerfile\` (production) | \`EXPOSE 4020 7001\` |
| \`tracer/Dockerfile.dev\` | \`ARG SERVER_PORT=4020\` |
| \`tracer/.env.example\` | \`SERVER_PORT=4020\` |
| **Chart 2.0.0-beta.5 (before)** | **\`8080\`** ❌ |
| **Chart 2.0.0-beta.6 (this PR)** | **\`4020\`** ✓ |

## Changes

| File | Before | After |
|---|---|---|
| \`Chart.yaml\` version | \`2.0.0-beta.5\` | \`2.0.0-beta.6\` |
| \`values.yaml\` \`tracer.service.port\` | \`8080\` | \`4020\` |
| \`values.yaml\` \`tracer.configmap.SERVER_PORT\` | \`"8080"\` | \`"4020"\` |
| \`values.yaml\` \`tracer.configmap.SERVER_ADDRESS\` | \`":8080"\` | \`":4020"\` |
| \`values.yaml\` \`tracer.configmap.SWAGGER_HOST\` | \`":8080"\` | \`":4020"\` |
| \`templates/configmap.yaml\` SERVER_PORT default | \`"8080"\` | \`"4020"\` |
| \`templates/configmap.yaml\` SERVER_ADDRESS default | \`":8080"\` | \`":4020"\` |
| \`templates/configmap.yaml\` SWAGGER_HOST default | \`":8080"\` | \`":4020"\` |
| \`values-template.yaml\` SERVER_ADDRESS | \`":8080"\` | \`":4020"\` |
| \`README.md\` service port row | \`8080\` | \`4020\` |

## Backwards compatibility

Existing tracer deployments (firmino-gitops × 8 envs) explicitly set
\`service.port: 8080\`, \`SERVER_PORT: "8080"\`, \`SERVER_ADDRESS: ":8080"\`
in their values.yaml. Overrides win over chart defaults, so they keep
running on 8080 unchanged.

New deployments using chart defaults pick up \`4020\`.

## Validation

\`\`\`
helm lint charts/tracer
==> Linting charts/tracer
1 chart(s) linted, 0 chart(s) failed
\`\`\`

\`helm template\` with default values:
\`\`\`
SERVER_PORT: "4020"
SERVER_ADDRESS: ":4020"
SWAGGER_HOST: ":4020"
containerPort: 4020
\`\`\`

\`helm template --set tracer.service.port=8080 --set tracer.configmap.SERVER_PORT=8080 ...\`:
\`\`\`
SERVER_PORT: "8080"
SERVER_ADDRESS: ":8080"
containerPort: 8080
\`\`\`

## Why now

Surfaced while wiring up tracer-mt staging deployment
(lerian-aws-gitops PR #193). The new MT deployment will pick up the
4020 default once this lands and 2.0.0-beta.6 is released; the staging
values.yaml can drop its explicit SERVER_PORT/SERVER_ADDRESS overrides.