### PR TITLE
fix(flowker): align chart default port with source convention (2.1.0-beta.6)

### DIFF
--- a/charts/flowker/Chart.yaml
+++ b/charts/flowker/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 2.1.0-beta.5
+version: 2.1.0-beta.6
 appVersion: "1.0.0"
 keywords:
   - flowker

--- a/charts/flowker/README.md
+++ b/charts/flowker/README.md
@@ -58,7 +58,7 @@ The secret must contain the keys defined in `flowker.secrets` (e.g., `MONGO_APP_
 | `flowker.replicaCount` | Number of replicas | `1` |
 | `flowker.image.repository` | Image repository | `ghcr.io/lerianstudio/flowker` |
 | `flowker.image.tag` | Image tag | `1.0.0-beta.22` |
-| `flowker.service.port` | Service port | `4000` |
+| `flowker.service.port` | Service port | `4021` |
 | `flowker.ingress.enabled` | Enable ingress | `false` |
 | `flowker.autoscaling.enabled` | Enable HPA | `true` |
 | `flowker.pdb.enabled` | Enable PodDisruptionBudget | `true` |

--- a/charts/flowker/templates/configmap.yaml
+++ b/charts/flowker/templates/configmap.yaml
@@ -10,8 +10,8 @@ data:
   # Server
   ENV_NAME: {{ .Values.flowker.configmap.ENV_NAME | default "development" | quote }}
   VERSION: {{ .Values.flowker.image.tag | default .Chart.AppVersion | quote }}
-  SERVER_PORT: {{ .Values.flowker.configmap.SERVER_PORT | default "4000" | quote }}
-  SERVER_ADDRESS: {{ .Values.flowker.configmap.SERVER_ADDRESS | default ":4000" | quote }}
+  SERVER_PORT: {{ .Values.flowker.configmap.SERVER_PORT | default "4021" | quote }}
+  SERVER_ADDRESS: {{ .Values.flowker.configmap.SERVER_ADDRESS | default ":4021" | quote }}
 
   # Deployment mode (saas/byoc/local — controls TLS enforcement at startup)
   DEPLOYMENT_MODE: {{ .Values.flowker.configmap.DEPLOYMENT_MODE | default "local" | quote }}
@@ -46,7 +46,7 @@ data:
   SWAGGER_TITLE: {{ .Values.flowker.configmap.SWAGGER_TITLE | default "Flowker API" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.flowker.configmap.SWAGGER_DESCRIPTION | default "Workflow orchestration platform for financial validation" | quote }}
   SWAGGER_VERSION: {{ .Values.flowker.image.tag | default .Chart.AppVersion | quote }}
-  SWAGGER_HOST: {{ .Values.flowker.configmap.SWAGGER_HOST | default ":4000" | quote }}
+  SWAGGER_HOST: {{ .Values.flowker.configmap.SWAGGER_HOST | default ":4021" | quote }}
   SWAGGER_BASE_PATH: {{ .Values.flowker.configmap.SWAGGER_BASE_PATH | default "/" | quote }}
   SWAGGER_SCHEMES: {{ .Values.flowker.configmap.SWAGGER_SCHEMES | default "http" | quote }}
   SWAGGER_LEFT_DELIM: {{ .Values.flowker.configmap.SWAGGER_LEFT_DELIM | default "{{" | quote }}

--- a/charts/flowker/values-template.yaml
+++ b/charts/flowker/values-template.yaml
@@ -41,7 +41,7 @@ flowker:
     targetMemoryUtilizationPercentage: 80
 
   configmap:
-    SERVER_ADDRESS: ":4000"
+    SERVER_ADDRESS: ":4021"
     LOG_LEVEL: "info"
     API_KEY_ENABLED: "false"
     CORS_ALLOWED_ORIGINS: "*"

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -116,8 +116,10 @@ flowker:
   service:
     # -- Kubernetes service type
     type: ClusterIP
-    # -- Port for the HTTP API
-    port: 4000
+    # -- Port for the HTTP API. Matches the flowker source convention
+    # (.env.example SERVER_PORT=4021). Override in environment values.yaml
+    # when an existing deployment expects a different port (e.g. legacy 4000).
+    port: 4021
     annotations: {}
 
   ingress:
@@ -172,10 +174,14 @@ flowker:
   # @default -- templates/configmap.yaml
   configmap:
     # Server
+    # SERVER_PORT/SERVER_ADDRESS default to 4021 to match the flowker source
+    # convention (.env.example SERVER_PORT=4021). Keep these in sync with
+    # service.port above (and containerPort) when overriding in environment
+    # values.yaml.
     ENV_NAME: "development"
     VERSION: "v1.0.0"
-    SERVER_PORT: "4000"
-    SERVER_ADDRESS: ":4000"
+    SERVER_PORT: "4021"
+    SERVER_ADDRESS: ":4021"
 
     # Deployment mode (controls TLS enforcement)
     # Values: saas (TLS mandatory), byoc (TLS recommended), local (TLS optional)
@@ -213,7 +219,7 @@ flowker:
     SWAGGER_TITLE: "Flowker API"
     SWAGGER_DESCRIPTION: "Workflow orchestration platform for financial validation"
     SWAGGER_VERSION: "v1.0.0"
-    SWAGGER_HOST: ":4000"
+    SWAGGER_HOST: ":4021"
     SWAGGER_BASE_PATH: "/"
     SWAGGER_SCHEMES: "http"
     SWAGGER_LEFT_DELIM: "{{"


### PR DESCRIPTION
## Summary

Flowker source defines port \`4021\` in \`.env.example\`. The chart
defaulted to \`4000\`, forcing every consumer to override
\`service.port\`, \`SERVER_PORT\`, and \`SERVER_ADDRESS\` just to match.

This PR aligns the chart defaults with the source convention. Mirrors
the tracer chart fix in #1308.

## Source-of-truth references

| File | Port |
|---|---|
| \`flowker/.env.example\` | \`SERVER_PORT=4021\` |
| \`flowker/Dockerfile\` (production) | \`EXPOSE 3005 7001\` (legacy, unused) |
| **Chart 2.1.0-beta.5 (before)** | **\`4000\`** ❌ |
| **Chart 2.1.0-beta.6 (this PR)** | **\`4021\`** ✓ |

The Dockerfile \`EXPOSE 3005\` is just a static hint — Kubernetes ignores
it, and the runtime listening port is fully driven by \`SERVER_ADDRESS\` /
\`SERVER_PORT\` env vars. Same situation as tracer: \`.env.example\` is
the actual source of truth.

## Changes

| File | Before | After |
|---|---|---|
| \`Chart.yaml\` version | \`2.1.0-beta.5\` | \`2.1.0-beta.6\` |
| \`values.yaml\` \`flowker.service.port\` | \`4000\` | \`4021\` |
| \`values.yaml\` \`flowker.configmap.SERVER_PORT\` | \`"4000"\` | \`"4021"\` |
| \`values.yaml\` \`flowker.configmap.SERVER_ADDRESS\` | \`":4000"\` | \`":4021"\` |
| \`values.yaml\` \`flowker.configmap.SWAGGER_HOST\` | \`":4000"\` | \`":4021"\` |
| \`templates/configmap.yaml\` SERVER_PORT default | \`"4000"\` | \`"4021"\` |
| \`templates/configmap.yaml\` SERVER_ADDRESS default | \`":4000"\` | \`":4021"\` |
| \`templates/configmap.yaml\` SWAGGER_HOST default | \`":4000"\` | \`":4021"\` |
| \`values-template.yaml\` SERVER_ADDRESS | \`":4000"\` | \`":4021"\` |
| \`README.md\` service port row | \`4000\` | \`4021\` |

## Backwards compatibility

Existing flowker deployments (8 firmino-gitops envs + flowker-mt
staging) explicitly set \`service.port: 4000\`, \`SERVER_PORT: "4000"\`,
\`SERVER_ADDRESS: ":4000"\` in their values.yaml. Overrides win over
chart defaults, so they keep running on 4000 unchanged.

New deployments using chart defaults pick up \`4021\`.

The corresponding gitops cleanup (drop the explicit overrides across
existing envs to inherit the new 4021 default) will land in separate
PRs after this releases.

## Validation

\`\`\`
helm lint charts/flowker
==> Linting charts/flowker
1 chart(s) linted, 0 chart(s) failed
\`\`\`

\`helm template\` with default values:

\`\`\`
SERVER_PORT: "4021"
SERVER_ADDRESS: ":4021"
SWAGGER_HOST: ":4021"
containerPort: 4021
\`\`\`

\`helm template --set flowker.service.port=4000 ...\`:

\`\`\`
SERVER_PORT: "4000"
SERVER_ADDRESS: ":4000"
containerPort: 4000
\`\`\`