### PR TITLE
fix(plugin-br-pix-switch): swap envFrom order so Secret overrides ConfigMap (1.1.0-beta.4)

### DIFF
--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.1.0-beta.3
+version: 1.1.0-beta.4
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.1"

--- a/charts/plugin-br-pix-switch/templates/adapter-btg-mock/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-btg-mock/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/cob-hub/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-hub/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/cob-proxy/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-proxy/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/cob-systemplane/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-systemplane/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/dict-hub-vsync/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-hub-vsync/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/dict-hub/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-hub/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/dict-proxy/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-proxy/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/dict-systemplane/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-systemplane/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/spi-systemplane/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/spi-systemplane/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each

--- a/charts/plugin-br-pix-switch/templates/spi/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/spi/deployment.yaml
@@ -57,10 +57,10 @@ spec:
               containerPort: {{ $values.service.port }}
               protocol: TCP
           envFrom:
-            - secretRef:
-                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
             - configMapRef:
                 name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
           {{- /*
           Build the env: list when EITHER telemetry is enabled (HOST_IP +
           OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each


### PR DESCRIPTION
## Summary

Real bug found during the firmino-dev rollout: external-secret overrides for `DATABASE_URL`, `MONGO_URL`, `VALKEY_URL`, `RABBITMQ_URI` were being silently dropped, leaving pods trying to resolve the bundled-subchart hostnames (which don't exist when subcharts are disabled).

## Root cause

K8s evaluates `envFrom` in list order with **"later wins"** semantics. The main container had:

```yaml
envFrom:
  - secretRef:  { name: <comp> }   # evaluated first
  - configMapRef: { name: <comp> } # evaluated second -> WINS
```

Combined with the chart's ConfigMap defaults that point at bundled subchart names (e.g. `DATABASE_URL: postgres://...@plugin-br-pix-switch-postgresql:5432/...`), every external-secret override was overwritten.

## Evidence

Live pod log from firmino-dev:
```
Failed to initialize servers: open database: failed to connect to database:
dial tcp: lookup plugin-br-pix-switch-postgresql on 10.43.0.10:53: no such host
```

The Vault-injected DSN was `postgres://pixswitch:lerian@postgresql.dev.firmino.lerian.net:5432/pix-spi?sslmode=disable` but the running container resolved the ConfigMap value pointing at the disabled subchart.

## Fix

Swap order on all 10 component `deployment.yaml` templates:

```yaml
envFrom:
  - configMapRef: { name: <comp> } # evaluated first
  - secretRef:    { name: <comp> } # evaluated second -> WINS
```

The `waitForDependencies` init container already had this order — this brings the main container into alignment.

Bump chart `1.1.0-beta.3` -> `1.1.0-beta.4`.

## Validation

- `helm template` renders all 10 main containers with `[configMapRef, secretRef]`
- `helm lint` passes
- Pattern matches lib-license / lib-commons examples and other Lerian charts (Secret last to override defaults)