### PR TITLE
feat(plugin-br-pix-switch): per-component image repository defaults (1.1.0-beta.6)

### DIFF
--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Plugin-br-pix-switch Changelog
 
-## [1.2.0-beta.1] - Shared multi-path ingresses
+## [1.1.0-beta.6] - Per-component image repositories
+
+Each component's `image.repository` now defaults to its own GHCR image
+name, published by the plugin-br-pix-switch source repo as 10 distinct
+per-component images (one per Dockerfile):
+
+| Component (values key) | Default image |
+|---|---|
+| `spi` | `ghcr.io/lerianstudio/plugin-br-pix-switch-spi-api` |
+| `spiSystemplane` | `ghcr.io/lerianstudio/plugin-br-pix-switch-spi-systemplane-api` |
+| `adapterBtgMock` | `ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-btg-mock-api` |
+| `dictHub` | `ghcr.io/lerianstudio/plugin-br-pix-switch-dict-hub-api` |
+| `dictHubVsync` | `ghcr.io/lerianstudio/plugin-br-pix-switch-dict-hub-vsync` |
+| `dictProxy` | `ghcr.io/lerianstudio/plugin-br-pix-switch-dict-proxy-api` |
+| `dictSystemplane` | `ghcr.io/lerianstudio/plugin-br-pix-switch-dict-systemplane-api` |
+| `cobHub` | `ghcr.io/lerianstudio/plugin-br-pix-switch-cob-hub-api` |
+| `cobProxy` | `ghcr.io/lerianstudio/plugin-br-pix-switch-cob-proxy-api` |
+| `cobSystemplane` | `ghcr.io/lerianstudio/plugin-br-pix-switch-cob-systemplane-api` |
+
+Previously every component fell back to the global default
+`ghcr.io/lerianstudio/plugin-br-pix-switch`, which only contained the
+SPI binary — meaning all 9 component pods ran SPI regardless of role.
+With the source repo now publishing per-component images
+(plugin-br-pix-switch PR #137, available from `1.0.0-beta.101`), each
+pod can run its own binary out of the box.
+
+The `global.image.repository` fallback stays unchanged for backwards
+compatibility — operators using a custom registry can still override
+globally without setting every component.
+
+`appVersion` bumped to `1.0.0-beta.101` so the chart's default tag
+points at real published images (was `1.0.0-beta.1` which never existed
+in GHCR as a per-component image).
+
+## [1.1.0-beta.5] - Shared multi-path ingresses
 
 Replaces 9 of the per-component `ingress:` blocks with two top-level
 ingress objects routed by URL path prefix:

--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -13,10 +13,10 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.1.0-beta.5
+version: 1.1.0-beta.6
 
 # This is the version number of the application being deployed.
-appVersion: "1.0.0-beta.1"
+appVersion: "1.0.0-beta.101"
 
 # A list of keywords about the chart. This helps others discover the chart.
 keywords:

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -143,8 +143,10 @@ spi:
   revisionHistoryLimit: 10
 
   image:
-    # Inherits global.image.repository / pullPolicy when not set
-    repository: ""
+    # Defaults to the per-component image published from
+    # apps/<path>/Dockerfile by the plugin-br-pix-switch build pipeline.
+    # Override only when pinning to a different registry or fork.
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-spi-api"
     pullPolicy: ""
     tag: ""
 
@@ -273,7 +275,7 @@ spiSystemplane:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-spi-systemplane-api"
     pullPolicy: ""
     tag: ""
 
@@ -367,7 +369,7 @@ adapterBtgMock:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-btg-mock-api"
     pullPolicy: ""
     tag: ""
 
@@ -469,7 +471,7 @@ dictHub:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-dict-hub-api"
     pullPolicy: ""
     tag: ""
 
@@ -577,7 +579,7 @@ dictHubVsync:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-dict-hub-vsync"
     pullPolicy: ""
     tag: ""
 
@@ -691,7 +693,7 @@ dictProxy:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-dict-proxy-api"
     pullPolicy: ""
     tag: ""
 
@@ -782,7 +784,7 @@ dictSystemplane:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-dict-systemplane-api"
     pullPolicy: ""
     tag: ""
 
@@ -876,7 +878,7 @@ cobHub:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-cob-hub-api"
     pullPolicy: ""
     tag: ""
 
@@ -974,7 +976,7 @@ cobProxy:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-cob-proxy-api"
     pullPolicy: ""
     tag: ""
 
@@ -1065,7 +1067,7 @@ cobSystemplane:
   revisionHistoryLimit: 10
 
   image:
-    repository: ""
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-cob-systemplane-api"
     pullPolicy: ""
     tag: ""
 


### PR DESCRIPTION
## Summary

Each component's \`image.repository\` now defaults to its own GHCR image name. The plugin-br-pix-switch source repo started publishing 10 distinct per-component images (one per Dockerfile) at \`1.0.0-beta.101\` via [plugin-br-pix-switch#137](https://github.com/LerianStudio/plugin-br-pix-switch/pull/137).

## Mapping

| Values key | Default image |
|---|---|
| \`spi\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-spi-api\` |
| \`spiSystemplane\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-spi-systemplane-api\` |
| \`adapterBtgMock\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-btg-mock-api\` |
| \`dictHub\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-dict-hub-api\` |
| \`dictHubVsync\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-dict-hub-vsync\` |
| \`dictProxy\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-dict-proxy-api\` |
| \`dictSystemplane\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-dict-systemplane-api\` |
| \`cobHub\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-cob-hub-api\` |
| \`cobProxy\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-cob-proxy-api\` |
| \`cobSystemplane\` | \`ghcr.io/lerianstudio/plugin-br-pix-switch-cob-systemplane-api\` |

## Why

Previously every component fell back to the global default \`ghcr.io/lerianstudio/plugin-br-pix-switch\`, which only contained the SPI binary. **All 9 component pods ran SPI regardless of role.** The chart's per-component \`image.repository\` knobs had no images to point at.

Now each pod runs its own binary out of the box.

## Versions

- chart: \`1.1.0-beta.5\` -> \`1.1.0-beta.6\`
- appVersion: \`1.0.0-beta.1\` -> \`1.0.0-beta.101\` (so the chart's default tag points at real published images instead of a tag that never existed in GHCR as a per-component image)

## Backward compatibility

\`global.image.repository\` fallback stays unchanged. Operators using a custom registry can still override globally without setting every component.

## Validation

- \`helm lint\` -> 0 failed
- \`helm template\` with defaults -> all 9 enabled components render their per-component image:tag (\`1.0.0-beta.101\` from \`appVersion\`)
- All 10 per-component images verified present on GHCR at \`1.0.0-beta.101\`

## Follow-up

A gitops PR will bump \`midaz-firmino-gitops\` to chart \`1.1.0-beta.6\`, removing the now-redundant per-component image overrides from \`values.yaml\` (the chart defaults are correct).