### PR TITLE
feat(plugin-br-pix-switch): providers ingress + remove dead global.image (1.1.0-beta.8)

### DIFF
--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -1,6 +1,56 @@
 # Plugin-br-pix-switch Changelog
 
-## [1.1.0-beta.8] - Providers ingress
+## [1.1.0-beta.8] - Providers ingress + prefixed health probes
+
+Two additions, single chart bump.
+
+### Providers ingress
+
+Adds a third top-level ingress, `providersIngress`, routed by URL path
+prefix and disabled by default. Same shape as `appsIngress` /
+`systemplaneIngress` (custom `routes` list, enabled-aware rendering,
+no path rewriting at the ingress).
+
+Default `routes` ships a single path:
+
+  /mock-btg  ->  adapter-btg-mock (port 4103)
+
+Reserved paths (commented placeholders) for `/bacen` and `/jd` —
+added when those adapter components ship.
+
+### Per-component probe paths
+
+Each component now defaults its readiness + liveness probes to the
+HTTP path that matches its source-side `routePrefix`:
+
+| Component | readiness | liveness |
+|---|---|---|
+| spi | /spi/readyz | /spi/health |
+| spi-systemplane | /spi/readyz | /spi/health |
+| dict-hub | /dict-hub/readyz | /dict-hub/health |
+| dict-hub-vsync | /readyz | /health |
+| dict-proxy | /dict-proxy/readyz | /dict-proxy/health |
+| dict-systemplane | /dict/readyz | /dict/health |
+| cob-hub | /cob-hub/readyz | /cob-hub/health |
+| cob-proxy | /cob-proxy/readyz | /cob-proxy/health |
+| cob-systemplane | /cob/readyz | /cob/health |
+| adapter-btg-mock | /btg-mock/readyz | /btg-mock/health |
+
+Source repo `1.0.0-beta.103` mounted every component's HTTP router
+under its own `/<component>` prefix (issue #135), which shifted
+`/health` and `/readyz` to e.g. `/spi/health` and `/spi/readyz`. The
+chart was still probing the un-prefixed paths, so kubelet liveness
+failed → pod restart → CrashLoopBackOff that surfaced "license
+validation failed" in the shutdown log (a red-herring shutdown
+message, not the actual cause).
+
+dict-hub-vsync is a background worker with no `routePrefix` — its
+probe paths stay at `/health` and `/readyz`.
+
+Operators can still override per env via
+`<component>.readinessProbe.path` / `<component>.livenessProbe.path`.
+
+## [1.1.0-beta.7] - Remove dead global.image block
 
 Adds a third top-level ingress, `providersIngress`, routed by URL path
 prefix and disabled by default. Same shape as `appsIngress` /

--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Plugin-br-pix-switch Changelog
 
+## [1.1.0-beta.7] - Remove dead global.image block
+
+Drop the `global.image` block from `values.yaml`. Since `1.1.0-beta.6`
+every component already sets its own `image.repository` to a distinct
+per-component image, so the global default was never reached at render
+time and the old `repository: ghcr.io/lerianstudio/plugin-br-pix-switch`
+value misled readers into thinking pods pulled from the original
+single-binary image.
+
+Changes:
+
+- `values.yaml`: remove `global.image` (the `{repository, pullPolicy,
+  tag}` sub-block). `global.imagePullSecrets` stays — it's still
+  the natural place to set a single pull-secret list for the whole
+  cohort.
+- `_helpers.tpl`: simplify `componentImage` to read repo directly from
+  per-component values and default tag to `.Chart.AppVersion`. Drop the
+  intermediate `global.image.tag` fallback.
+- `componentPullPolicy`: hard-default to `IfNotPresent` instead of
+  reading `global.image.pullPolicy`.
+- 10 component `configmap.yaml` templates: drop the
+  `global.image.tag` fallback when deriving
+  `OTEL_RESOURCE_SERVICE_VERSION`.
+
+No rendered output changes when component-level `image.repository` and
+`image.tag` are set (which is the documented use). Operators who relied
+on `global.image.tag` for cohort-wide tag override must switch to
+setting `image.tag` per component (or use a YAML anchor / helmfile
+override list).
+
 ## [1.1.0-beta.6] - Per-component image repositories
 
 Each component's `image.repository` now defaults to its own GHCR image

--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Plugin-br-pix-switch Changelog
 
+## [1.1.0-beta.8] - Providers ingress
+
+Adds a third top-level ingress, `providersIngress`, routed by URL path
+prefix and disabled by default. Same shape as `appsIngress` /
+`systemplaneIngress` (custom `routes` list, enabled-aware rendering,
+no path rewriting at the ingress).
+
+The hostname is dedicated to outbound-provider adapters so cluster
+operators can apply provider-specific annotations (mTLS, IP allowlists,
+per-provider WAF rules) without coupling to the apps or systemplane
+ingresses.
+
+Default `routes` ships a single path:
+
+  /mock-btg  ->  adapter-btg-mock (port 4103)
+
+Future provider components (BACEN, JD, …) can be added by either:
+
+1. Defining a new component (`bacenAdapter`, `jdAdapter`, …) and
+   appending to `providersIngress.routes` at the chart level (separate
+   PR).
+2. Overriding `providersIngress.routes` per env in gitops to point at
+   an existing component or external Service.
+
+The chart skips routes whose target component is disabled, so the
+default `mock-btg` route is silently dropped when `adapterBtgMock.enabled`
+is false.
+
 ## [1.1.0-beta.7] - Remove dead global.image block
 
 Drop the `global.image` block from `values.yaml`. Since `1.1.0-beta.6`

--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.1.0-beta.6
+version: 1.1.0-beta.7
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.101"

--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.1.0-beta.7
+version: 1.1.0-beta.8
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.101"

--- a/charts/plugin-br-pix-switch/templates/_helpers.tpl
+++ b/charts/plugin-br-pix-switch/templates/_helpers.tpl
@@ -31,22 +31,28 @@ Returns: <chartname>-<component-name>  (e.g. plugin-br-pix-switch-spi)
 {{- end }}
 
 {{/*
-Resolve image repository for a component, falling back to the global default.
-Tag resolution order: component override > global override > Chart.AppVersion.
+Resolve image repository + tag for a component.
+Each component sets its own image.repository (default to per-component image
+shipped by the plugin-br-pix-switch source repo). image.tag falls back to
+.Chart.AppVersion when unset, which keeps the cohort in lockstep by default.
+
+Override only image.tag at deploy time (per env) when you need to pin a
+specific build.
+
 Usage: include "plugin-br-pix-switch.componentImage" (dict "context" $ "componentValues" .Values.spi)
 */}}
 {{- define "plugin-br-pix-switch.componentImage" -}}
-{{- $repo := default .context.Values.global.image.repository .componentValues.image.repository -}}
-{{- $globalTag := default .context.Chart.AppVersion .context.Values.global.image.tag -}}
-{{- $tag := default $globalTag .componentValues.image.tag -}}
+{{- $repo := .componentValues.image.repository -}}
+{{- $tag := default .context.Chart.AppVersion .componentValues.image.tag -}}
 {{- printf "%s:%s" $repo $tag -}}
 {{- end }}
 
 {{/*
-Resolve image pullPolicy for a component, falling back to the global default.
+Resolve image pullPolicy for a component. Falls back to IfNotPresent — the
+K8s convention for tagged images.
 */}}
 {{- define "plugin-br-pix-switch.componentPullPolicy" -}}
-{{- default .context.Values.global.image.pullPolicy .componentValues.image.pullPolicy -}}
+{{- default "IfNotPresent" .componentValues.image.pullPolicy -}}
 {{- end }}
 
 {{/*

--- a/charts/plugin-br-pix-switch/templates/adapter-btg-mock/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-btg-mock/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-btg-mock/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-btg-mock/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/btg-mock/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/btg-mock/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/cob-hub/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-hub/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/cob-hub/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-hub/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/cob-hub/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/cob-hub/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/cob-proxy/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-proxy/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/cob-proxy/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-proxy/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/cob-proxy/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/cob-proxy/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/cob-systemplane/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-systemplane/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/cob-systemplane/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-systemplane/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/cob/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/cob/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/dict-hub-vsync/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-hub-vsync/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/dict-hub/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-hub/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/dict-hub/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-hub/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/dict-hub/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/dict-hub/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/dict-proxy/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-proxy/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/dict-proxy/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-proxy/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/dict-proxy/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/dict-proxy/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/dict-systemplane/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-systemplane/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/dict-systemplane/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-systemplane/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/dict/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/dict/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/ingress-providers.yaml
+++ b/charts/plugin-br-pix-switch/templates/ingress-providers.yaml
@@ -1,0 +1,63 @@
+{{- /*
+Providers Ingress — single hostname routes outbound-provider traffic to
+adapter components (BTG mock today; BACEN, JD, and other ISPs as they ship).
+
+Lives on its own hostname so the cluster operator can layer different ingress
+annotations (provider-specific mTLS, IP allowlists, per-provider WAF rules)
+than the apps/systemplane ingresses without coupling them.
+
+Each path under .Values.providersIngress.routes maps to one component's
+Service. Same enabled-aware rendering as ingress-apps.yaml — routes whose
+target component is disabled are silently skipped, so partial deployments
+render only the path rules with a backing Service.
+*/}}
+{{- if .Values.providersIngress.enabled }}
+{{- $ctx := . }}
+{{- $cfg := .Values.providersIngress }}
+{{- $fullName := include "plugin-br-pix-switch.componentFullname" (dict "context" $ctx "component" "providers") }}
+{{- $renderedRoutes := list }}
+{{- range $route := $cfg.routes }}
+  {{- $componentValues := index $ctx.Values $route.component }}
+  {{- if and $componentValues $componentValues.enabled }}
+    {{- $renderedRoutes = append $renderedRoutes $route }}
+  {{- end }}
+{{- end }}
+{{- if $renderedRoutes }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ctx "component" "providers") | nindent 4 }}
+  {{- with $cfg.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $cfg.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $cfg.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $host := $cfg.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          {{- range $route := $renderedRoutes }}
+          {{- $componentValues := index $ctx.Values $route.component }}
+          {{- $serviceFullname := include "plugin-br-pix-switch.componentFullname" (dict "context" $ctx "component" $route.serviceName) }}
+          - path: {{ $route.path }}
+            pathType: {{ default "Prefix" $route.pathType }}
+            backend:
+              service:
+                name: {{ $serviceFullname }}
+                port:
+                  number: {{ $componentValues.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/spi-systemplane/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/spi-systemplane/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/spi-systemplane/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/spi-systemplane/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/spi/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/spi/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/spi/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/spi/configmap.yaml
@@ -15,14 +15,13 @@ data:
   {{- /*
   OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
   tracks releases automatically. Resolution order:
-    component image.tag > global image.tag > Chart.AppVersion.
+    component image.tag > Chart.AppVersion.
   Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
   explicitly (the range above wins because data keys are unique per YAML map,
   but we only emit this when the key wasn't already provided).
   */}}
   {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
-  {{- $globalTag := default $.Chart.AppVersion $.Values.global.image.tag }}
-  {{- $compTag := default $globalTag $values.image.tag }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
   {{- end }}
 {{- end }}

--- a/charts/plugin-br-pix-switch/templates/spi/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/spi/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/spi/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/spi/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -34,13 +34,9 @@ namespaceOverride: ""
 # GLOBAL DEFAULTS — applied to all components unless overridden in their block
 # =============================================================================
 global:
-  # -- Image pull secrets propagated to every component
+  # -- Image pull secrets propagated to every component when the component's
+  # own `imagePullSecrets` list is empty.
   imagePullSecrets: []
-  # -- Default image config (each component can override)
-  image:
-    repository: ghcr.io/lerianstudio/plugin-br-pix-switch
-    pullPolicy: IfNotPresent
-    # tag: defaults to .Chart.AppVersion when empty
 
   # ---------------------------------------------------------------------------
   # External PostgreSQL bootstrap

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -198,8 +198,10 @@ spi:
   tolerations: []
   affinity: {}
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/spi/readyz"
+  livenessProbe:
+    path: "/spi/health"
 
   serviceAccount:
     create: true
@@ -317,8 +319,10 @@ spiSystemplane:
     minReplicas: 1
     maxReplicas: 1
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/spi/readyz"
+  livenessProbe:
+    path: "/spi/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -414,8 +418,10 @@ adapterBtgMock:
     minReplicas: 1
     maxReplicas: 1
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/btg-mock/readyz"
+  livenessProbe:
+    path: "/btg-mock/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -513,8 +519,10 @@ dictHub:
     minReplicas: 1
     maxReplicas: 3
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/dict-hub/readyz"
+  livenessProbe:
+    path: "/dict-hub/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -621,8 +629,10 @@ dictHubVsync:
     minReplicas: 1
     maxReplicas: 1   # vsync is a singleton worker
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/readyz"
+  livenessProbe:
+    path: "/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -735,8 +745,10 @@ dictProxy:
     minReplicas: 1
     maxReplicas: 3
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/dict-proxy/readyz"
+  livenessProbe:
+    path: "/dict-proxy/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -826,8 +838,10 @@ dictSystemplane:
     minReplicas: 1
     maxReplicas: 1
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/dict/readyz"
+  livenessProbe:
+    path: "/dict/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -920,8 +934,10 @@ cobHub:
     minReplicas: 1
     maxReplicas: 3
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/cob-hub/readyz"
+  livenessProbe:
+    path: "/cob-hub/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -1018,8 +1034,10 @@ cobProxy:
     minReplicas: 1
     maxReplicas: 3
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/cob-proxy/readyz"
+  livenessProbe:
+    path: "/cob-proxy/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -1109,8 +1127,10 @@ cobSystemplane:
     minReplicas: 1
     maxReplicas: 1
 
-  readinessProbe: {}
-  livenessProbe: {}
+  readinessProbe:
+    path: "/cob/readyz"
+  livenessProbe:
+    path: "/cob/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -1276,6 +1276,38 @@ systemplaneIngress:
       component: cobSystemplane
       serviceName: cob-systemplane
 
+# -----------------------------------------------------------------------------
+# Providers Ingress — outbound-provider adapters (BTG mock, BACEN, JD, ...).
+#
+# Single hostname routes provider traffic by path prefix. Each route names a
+# component already defined in the chart (or one a future PR adds) and the
+# kebab-case Service name suffix.
+#
+# Today only adapter-btg-mock is shipped; BACEN and JD providers will be
+# added as components in future PRs and exposed here under their own paths.
+# -----------------------------------------------------------------------------
+providersIngress:
+  enabled: false
+  className: "nginx"
+  annotations: {}
+  hosts: []
+  tls: []
+  routes:
+    - path: /mock-btg
+      pathType: Prefix
+      component: adapterBtgMock
+      serviceName: adapter-btg-mock
+    # Reserved for future components — uncomment when the bacen/jd
+    # adapter components ship in the chart:
+    # - path: /bacen
+    #   pathType: Prefix
+    #   component: bacenAdapter
+    #   serviceName: bacen-adapter
+    # - path: /jd
+    #   pathType: Prefix
+    #   component: jdAdapter
+    #   serviceName: jd-adapter
+
 postgresql:
   enabled: false
   global:


### PR DESCRIPTION
## Summary

Two related chart changes for plugin-br-pix-switch. Chart `1.1.0-beta.6` → `1.1.0-beta.8`.

## 1. Providers ingress (new, beta.8)

Adds a third top-level ingress, \`providersIngress\`, routed by URL path prefix and disabled by default. Same shape as \`appsIngress\` / \`systemplaneIngress\` (custom \`routes\` list, enabled-aware rendering, no path rewriting at the ingress).

Dedicated hostname so the cluster operator can layer provider-specific annotations (mTLS, IP allowlists, per-provider WAF rules) without coupling to the apps or systemplane ingresses.

**Default routes:**

| Path | Component | Service |
|---|---|---|
| \`/mock-btg\` | \`adapterBtgMock\` | \`adapter-btg-mock:4103\` |

Reserved paths (commented in values.yaml) for \`/bacen\` and \`/jd\` — added when the corresponding adapter components ship.

The chart skips routes whose target component is disabled, so the default \`mock-btg\` route is silently dropped when \`adapterBtgMock.enabled\` is false.

## 2. Remove dead global.image block (beta.7)

Drop the \`global.image\` block from \`values.yaml\` (and the template paths that referenced it). Since \`1.1.0-beta.6\` every component sets its own \`image.repository\` to a distinct per-component image, so the global default was never reached at render time. The old \`repository: ghcr.io/lerianstudio/plugin-br-pix-switch\` value misled readers into thinking pods still pulled from the original single-binary image.

Changes:

- \`values.yaml\`: remove \`global.image\` (\`{repository, pullPolicy, tag}\`). \`global.imagePullSecrets\` stays.
- \`_helpers.tpl\`:
  - \`componentImage\` reads repo directly from per-component values; tag defaults to \`.Chart.AppVersion\`.
  - \`componentPullPolicy\` hard-defaults to \`IfNotPresent\`.
- 10 component \`configmap.yaml\` templates: drop the \`global.image.tag\` fallback when deriving \`OTEL_RESOURCE_SERVICE_VERSION\`.

## Validation

- \`helm lint\` passes.
- \`helm template\` default render: 9 component Deployments + 9 Services + 9 Secrets + 9 ConfigMaps + 9 ServiceAccounts + 5 PDBs, 0 Ingresses.
- \`helm template\` with providers ingress enabled + adapter-btg-mock enabled: 1 \`providers\` Ingress with the \`/mock-btg\` path routed to \`adapter-btg-mock:4103\`.
- \`helm template\` with providers ingress enabled but adapter-btg-mock disabled: 0 \`providers\` Ingress objects (route auto-skipped).

## Breaking changes

From \`1.1.0-beta.6\`:

- Operators who relied on \`global.image.tag\` for cohort-wide tag override must switch to setting \`image.tag\` per component. The midaz-firmino-gitops install already does per-component pinning (gitops PR #638 onward), so no gitops change is required.
- The previously misleading \`global.image.repository\` is gone — operators who set this for a custom registry mirror must now override each component's \`image.repository\` instead. (No known consumers do this today.)

## Follow-up

A gitops PR will enable \`providersIngress\` in firmino-dev with hostname \`pix-switch-providers.dev.firmino.lerian.net\`, route \`/mock-btg\` -> adapter-btg-mock.