### PR TITLE
feat(lerian-notification): initial chart (api + 3 workers)

### DIFF
--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -37,7 +37,11 @@ plugin-br-pix-switch:
 plugin-br-payments:
   - changed-files:
       - any-glob-to-any-file: charts/plugin-br-payments/**
-      
+
+lerian-notification:
+  - changed-files:
+      - any-glob-to-any-file: charts/lerian-notification/**
+
 product-console:
   - changed-files:
       - any-glob-to-any-file: charts/product-console/**

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -25,6 +25,7 @@ jobs:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
         charts/fetcher
+        charts/lerian-notification
         charts/midaz
         charts/otel-collector-lerian
         charts/plugin-access-manager

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -39,6 +39,7 @@ jobs:
             plugin-br-pix-direct-jd
             plugin-br-pix-indirect-btg
             plugin-br-pix-switch
+            lerian-notification
             plugin-br-bank-transfer-jd
             templates
             dependencies

--- a/charts/lerian-notification/CHANGELOG.md
+++ b/charts/lerian-notification/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this chart will be documented in this file.
+
+## 0.1.0
+
+Initial chart for `lerian-notification`.
+
+- API component (`cmd/api`) on container port 8080 with ClusterIP Service and optional Ingress.
+- Three worker components (`cmd/worker-email`, `cmd/worker-sms`, `cmd/worker-webhook`) on ports 8081/8082/8083 — health-probe-only, no Service exposure.
+- Shared ConfigMap and Secret consumed by every component via `envFrom`.
+- `secretRef.name` toggle for external Secret references (gitops / ArgoCD Vault Plugin).
+- `golang-migrate` pre-install/pre-upgrade Job that reuses the API image to apply `/migrations` against the external Postgres.
+- HPA and PodDisruptionBudget templates for the API (disabled by default).
+- No chart dependencies: Postgres, Redis and RabbitMQ are external.

--- a/charts/lerian-notification/Chart.yaml
+++ b/charts/lerian-notification/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: lerian-notification-helm
+description: Lerian Notification service - multi-channel delivery (email, SMS, webhook) for the Lerian platform
+type: application
+home: https://github.com/LerianStudio/helm
+sources:
+  - https://github.com/LerianStudio/lerian-notification
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+# This is the version number of the application being deployed.
+appVersion: "0.1.0"
+keywords:
+  - lerian
+  - notification
+  - email
+  - sms
+  - webhook
+  - messaging
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+# No dependencies: Postgres, Redis and RabbitMQ are external (provided by the
+# target environment / gitops). Migrations run as a Helm pre-install/pre-upgrade
+# Job against the external Postgres.

--- a/charts/lerian-notification/README.md
+++ b/charts/lerian-notification/README.md
@@ -1,0 +1,62 @@
+# lerian-notification
+
+Helm chart for the Lerian Notification service — multi-channel delivery (email, SMS, webhook) for the Lerian platform.
+
+## Topology
+
+| Component         | Path (service repo)   | Port | Kind                              |
+|-------------------|-----------------------|------|-----------------------------------|
+| `api`             | `cmd/api`             | 8080 | Deployment + Service + Ingress    |
+| `worker-email`    | `cmd/worker-email`    | 8081 | Deployment (health probe only)    |
+| `worker-sms`      | `cmd/worker-sms`      | 8082 | Deployment (health probe only)    |
+| `worker-webhook`  | `cmd/worker-webhook`  | 8083 | Deployment (health probe only)    |
+
+All four components consume the **same** env contract, exposed via a single shared `ConfigMap` (non-sensitive) and a single shared `Secret` (sensitive). Workers bind `/health` and `/readyz` on their respective `containerPort` via `WORKER_HEALTH_ADDRESS`, which the chart injects per worker.
+
+## External dependencies
+
+The chart does **not** bundle subcharts. The target environment must provide:
+
+- PostgreSQL (configured via `POSTGRES_*` keys under `.Values.config` and `.Values.secrets`)
+- Redis (configured via `REDIS_*`)
+- RabbitMQ (configured via `RABBITMQ_*`)
+
+## Migrations
+
+`golang-migrate` runs as a Helm `pre-install`/`pre-upgrade` Job (`hook-weight: -5`). It reuses the API image — the service Dockerfile bundles `/migrations`. Toggle with `migrations.enabled` (default `true`).
+
+## Secrets
+
+Two modes:
+
+1. **Chart-rendered Secret** (default). Populate `.Values.secrets.*` from your gitops layer (ArgoCD Vault Plugin substitutes the values at sync time).
+2. **External Secret**. Set `.Values.secretRef.name` to the name of an existing Secret in the release namespace. The chart skips its own Secret template and every component mounts the external Secret via `envFrom` instead.
+
+## Install
+
+```sh
+helm install lerian-notification ./charts/lerian-notification \
+  -n lerian-notification --create-namespace \
+  -f values-firmino.yaml
+```
+
+## Key values (per-env overrides)
+
+| Key                                | Notes                                            |
+|------------------------------------|--------------------------------------------------|
+| `api.image.tag`                    | Image tag for the API and (by default) workers   |
+| `workerEmail.image.tag`            | Override per worker if independently versioned   |
+| `workerSms.image.tag`              | ditto                                            |
+| `workerWebhook.image.tag`          | ditto                                            |
+| `api.ingress.enabled`              | `false` by default                               |
+| `api.ingress.hosts[].host`         | Per-env host                                     |
+| `config.ENV_NAME`                  | `firmino` / `staging` / `production`             |
+| `config.POSTGRES_HOST`             | External Postgres host                           |
+| `config.REDIS_HOST`                | External Redis host                              |
+| `config.RABBITMQ_HOST`             | External RabbitMQ host                           |
+| `secrets.POSTGRES_PASSWORD`        | Required                                         |
+| `secrets.RABBITMQ_URL`             | Full AMQP URL with credentials (alternative)     |
+| `secretRef.name`                   | Optional: name of pre-existing Secret            |
+| `migrations.enabled`               | Skip if migrations are managed out-of-band       |
+
+See `values.yaml` for the full env contract.

--- a/charts/lerian-notification/templates/NOTES.txt
+++ b/charts/lerian-notification/templates/NOTES.txt
@@ -1,0 +1,45 @@
+Lerian Notification deployed successfully.
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart:     {{ .Chart.Name }} {{ .Chart.Version }} (appVersion {{ .Chart.AppVersion }})
+
+Components:
+  - API              {{ include "lerian-notification.fullname" . }}      :{{ .Values.api.containerPort }}
+{{- if .Values.workerEmail.enabled }}
+  - Worker (email)   {{ include "workerEmail.fullname" . }}              :{{ .Values.workerEmail.containerPort }}
+{{- end }}
+{{- if .Values.workerSms.enabled }}
+  - Worker (sms)     {{ include "workerSms.fullname" . }}                :{{ .Values.workerSms.containerPort }}
+{{- end }}
+{{- if .Values.workerWebhook.enabled }}
+  - Worker (webhook) {{ include "workerWebhook.fullname" . }}            :{{ .Values.workerWebhook.containerPort }}
+{{- end }}
+
+{{- if .Values.migrations.enabled }}
+
+Migrations ran as a pre-install/pre-upgrade Helm hook:
+  kubectl logs -n {{ .Release.Namespace }} job/{{ include "lerian-notification.fullname" . }}-migrations
+{{- end }}
+
+External dependencies (NOT bundled):
+  - Postgres : {{ .Values.config.POSTGRES_HOST | default "<unset>" }}:{{ .Values.config.POSTGRES_PORT }}
+  - Redis    : {{ .Values.config.REDIS_HOST | default "<unset>" }}:{{ .Values.config.REDIS_PORT }}
+  - RabbitMQ : {{ .Values.config.RABBITMQ_HOST | default "<unset>" }}:{{ .Values.config.RABBITMQ_PORT_AMQP }}
+
+{{- if .Values.api.ingress.enabled }}
+
+Ingress:
+{{- $tls := (and .Values.api.ingress.tls (gt (len .Values.api.ingress.tls) 0)) }}
+{{- range .Values.api.ingress.hosts }}
+  URL: http{{ if $tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+
+Local access (ingress disabled):
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "lerian-notification.fullname" . }} 8080:{{ .Values.api.service.port }}
+  curl http://localhost:8080/health
+{{- end }}
+
+Logs:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/part-of=lerian-notification --tail=200 -f

--- a/charts/lerian-notification/templates/_helpers.tpl
+++ b/charts/lerian-notification/templates/_helpers.tpl
@@ -1,0 +1,143 @@
+{{/*
+================================================================================
+LERIAN NOTIFICATION - HELM TEMPLATE HELPERS
+================================================================================
+Topology:
+  - api             (HTTP service + ingress)
+  - worker-email    (consumer, health probe only)
+  - worker-sms      (consumer, health probe only)
+  - worker-webhook  (consumer, health probe only)
+External deps (no subcharts): Postgres, Redis, RabbitMQ.
+================================================================================
+*/}}
+
+{{/*
+================================================================================
+NAME HELPERS
+================================================================================
+*/}}
+
+{{- define "lerian-notification.name" -}}
+{{- default .Values.api.name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "workerEmail.name" -}}
+{{- default "lerian-notification-worker-email" .Values.workerEmail.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "workerSms.name" -}}
+{{- default "lerian-notification-worker-sms" .Values.workerSms.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "workerWebhook.name" -}}
+{{- default "lerian-notification-worker-webhook" .Values.workerWebhook.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+================================================================================
+FULLNAME HELPERS
+================================================================================
+*/}}
+
+{{- define "lerian-notification.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- default "lerian-notification" .Values.api.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "workerEmail.fullname" -}}
+{{- default "lerian-notification-worker-email" .Values.workerEmail.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "workerSms.fullname" -}}
+{{- default "lerian-notification-worker-sms" .Values.workerSms.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "workerWebhook.fullname" -}}
+{{- default "lerian-notification-worker-webhook" .Values.workerWebhook.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+================================================================================
+CHART / VERSION HELPERS
+================================================================================
+*/}}
+
+{{- define "lerian-notification.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "lerian-notification.version" -}}
+{{- printf "%s" .Chart.AppVersion | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+================================================================================
+LABEL HELPERS (parametric: pass dict with "context" and "name")
+================================================================================
+*/}}
+
+{{- define "lerian-notification.labels" -}}
+helm.sh/chart: {{ include "lerian-notification.chart" .context }}
+{{ include "lerian-notification.selectorLabels" (dict "context" .context "name" .name) }}
+app.kubernetes.io/version: {{ include "lerian-notification.version" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: lerian-notification
+{{- end }}
+
+{{- define "lerian-notification.selectorLabels" -}}
+{{- if .name }}
+app.kubernetes.io/name: {{ .name }}
+{{- end }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- if .name }}
+app.kubernetes.io/component: {{ .name }}
+{{- end }}
+{{- end }}
+
+{{/*
+================================================================================
+SERVICE ACCOUNT HELPER
+================================================================================
+*/}}
+
+{{- define "lerian-notification.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lerian-notification.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+================================================================================
+SHARED CONFIGMAP / SECRET REFS
+================================================================================
+All components consume the same env contract, so we point envFrom at a single
+ConfigMap and Secret (overridable via .Values.secretRef.name for AVP / external
+secrets integration).
+*/}}
+
+{{- define "lerian-notification.configMapName" -}}
+{{- default (include "lerian-notification.fullname" .) .Values.configMapNameOverride }}
+{{- end }}
+
+{{- define "lerian-notification.secretName" -}}
+{{- if .Values.secretRef.name }}
+{{- .Values.secretRef.name }}
+{{- else }}
+{{- include "lerian-notification.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+================================================================================
+NAMESPACE HELPER
+================================================================================
+*/}}
+
+{{- define "lerian-notification.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}

--- a/charts/lerian-notification/templates/api/deployment.yaml
+++ b/charts/lerian-notification/templates/api/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lerian-notification.fullname" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.api.name) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .Values.api.revisionHistoryLimit | default 10 }}
+  strategy:
+    {{- toYaml .Values.api.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.api.autoscaling.enabled }}
+  replicas: {{ .Values.api.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lerian-notification.selectorLabels" (dict "context" . "name" .Values.api.name) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lerian-notification.labels" (dict "context" . "name" .Values.api.name) | nindent 8 }}
+      annotations:
+        # Force pod restart on ConfigMap/Secret change.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.secretRef.name }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.api.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "lerian-notification.serviceAccountName" . }}
+      {{- with (concat .Values.imagePullSecrets .Values.api.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.api.name }}
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.api.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "lerian-notification.configMapName" . }}
+            - secretRef:
+                name: {{ include "lerian-notification.secretName" . }}
+          {{- with .Values.api.extraEnvVars }}
+          env:
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          {{- if .Values.api.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.api.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.api.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.probes.startup.failureThreshold }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.api.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.api.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.api.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.api.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.probes.liveness.failureThreshold }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lerian-notification/templates/api/hpa.yaml
+++ b/charts/lerian-notification/templates/api/hpa.yaml
@@ -13,8 +13,11 @@ spec:
     name: {{ include "lerian-notification.fullname" . }}
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+  {{- $cpu := .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+  {{- $mem := .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- if or $cpu $mem }}
   metrics:
-    {{- with .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- with $cpu }}
     - type: Resource
       resource:
         name: cpu
@@ -22,7 +25,7 @@ spec:
           type: Utilization
           averageUtilization: {{ . }}
     {{- end }}
-    {{- with .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- with $mem }}
     - type: Resource
       resource:
         name: memory
@@ -30,4 +33,7 @@ spec:
           type: Utilization
           averageUtilization: {{ . }}
     {{- end }}
+  {{- else }}
+  {{- fail "api.autoscaling.enabled=true requires targetCPUUtilizationPercentage and/or targetMemoryUtilizationPercentage" }}
+  {{- end }}
 {{- end }}

--- a/charts/lerian-notification/templates/api/hpa.yaml
+++ b/charts/lerian-notification/templates/api/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.api.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lerian-notification.fullname" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.api.name) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lerian-notification.fullname" . }}
+  minReplicas: {{ .Values.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/lerian-notification/templates/api/ingress.yaml
+++ b/charts/lerian-notification/templates/api/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.api.ingress.enabled -}}
+{{- $fullName := include "lerian-notification.fullname" . -}}
+{{- $svcPort := .Values.api.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.api.name) | nindent 4 }}
+  {{- with .Values.api.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.api.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.api.ingress.tls }}
+  tls:
+    {{- range . }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.api.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/lerian-notification/templates/api/pdb.yaml
+++ b/charts/lerian-notification/templates/api/pdb.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if hasKey .Values.api.pdb "maxUnavailable" }}
+  {{- if and (hasKey .Values.api.pdb "maxUnavailable") (ne .Values.api.pdb.maxUnavailable nil) }}
   maxUnavailable: {{ .Values.api.pdb.maxUnavailable }}
   {{- else }}
   minAvailable: {{ .Values.api.pdb.minAvailable | default 1 }}

--- a/charts/lerian-notification/templates/api/pdb.yaml
+++ b/charts/lerian-notification/templates/api/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.api.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "lerian-notification.fullname" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.api.name) | nindent 4 }}
+  {{- with .Values.api.pdb.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.api.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- else }}
+  minAvailable: {{ .Values.api.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lerian-notification.selectorLabels" (dict "context" . "name" .Values.api.name) | nindent 6 }}
+{{- end }}

--- a/charts/lerian-notification/templates/api/pdb.yaml
+++ b/charts/lerian-notification/templates/api/pdb.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.api.pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey .Values.api.pdb "maxUnavailable" }}
+  maxUnavailable: {{ .Values.api.pdb.maxUnavailable }}
   {{- else }}
   minAvailable: {{ .Values.api.pdb.minAvailable | default 1 }}
   {{- end }}

--- a/charts/lerian-notification/templates/api/service.yaml
+++ b/charts/lerian-notification/templates/api/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lerian-notification.fullname" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.api.name) | nindent 4 }}
+spec:
+  type: {{ .Values.api.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "lerian-notification.selectorLabels" (dict "context" . "name" .Values.api.name) | nindent 4 }}

--- a/charts/lerian-notification/templates/configmap.yaml
+++ b/charts/lerian-notification/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lerian-notification.configMapName" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" (include "lerian-notification.fullname" .)) | nindent 4 }}
+data:
+  # ---- App version (overrides config-supplied value with chart appVersion) ----
+  VERSION: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
+  SWAGGER_VERSION: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
+  {{- /*
+       Render every key under .Values.config followed by extraConfig.
+       Values are always quoted to keep "true"/"false"/"123" as strings,
+       which is what envconfig (env: tags) expects.
+  */}}
+  {{- range $key, $value := .Values.config }}
+  {{- if not (has $key (list "VERSION" "OTEL_RESOURCE_SERVICE_VERSION" "SWAGGER_VERSION")) }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.extraConfig }}
+  {{- range $key, $value := . }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/lerian-notification/templates/configmap.yaml
+++ b/charts/lerian-notification/templates/configmap.yaml
@@ -15,13 +15,17 @@ data:
        Values are always quoted to keep "true"/"false"/"123" as strings,
        which is what envconfig (env: tags) expects.
   */}}
-  {{- range $key, $value := .Values.config }}
+  {{- range $key := keys .Values.config | sortAlpha }}
+  {{- $value := index $.Values.config $key }}
   {{- if not (has $key (list "VERSION" "OTEL_RESOURCE_SERVICE_VERSION" "SWAGGER_VERSION")) }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- end }}
   {{- with .Values.extraConfig }}
-  {{- range $key, $value := . }}
+  {{- range $key := keys . | sortAlpha }}
+  {{- $value := index $.Values.extraConfig $key }}
+  {{- if not (has $key (list "VERSION" "OTEL_RESOURCE_SERVICE_VERSION" "SWAGGER_VERSION")) }}
   {{ $key }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/lerian-notification/templates/migrations-job.yaml
+++ b/charts/lerian-notification/templates/migrations-job.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.migrations.enabled }}
+{{- /*
+  golang-migrate Job — runs as a Helm pre-install / pre-upgrade hook so DDL
+  is applied before the API and workers attempt to connect.
+
+  Uses the API image because the service Dockerfile bundles /migrations
+  (COPY --from=builder /app/migrations /migrations). Override
+  .Values.migrations.image only when you build a dedicated migrations image.
+
+  The DATABASE_URL is constructed at runtime from the shared ConfigMap +
+  Secret so the Job stays consistent with whatever the app pods see.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lerian-notification.fullname" . }}-migrations
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" (printf "%s-migrations" (include "lerian-notification.fullname" .))) | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "lerian-notification.selectorLabels" (dict "context" . "name" (printf "%s-migrations" (include "lerian-notification.fullname" .))) | nindent 8 }}
+      {{- with .Values.migrations.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "lerian-notification.serviceAccountName" . }}
+      restartPolicy: {{ .Values.migrations.restartPolicy }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrations.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.migrations.image.repository | default .Values.api.image.repository }}:{{ .Values.migrations.image.tag | default .Values.api.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.migrations.image.pullPolicy | default .Values.api.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.migrations.securityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "lerian-notification.configMapName" . }}
+            - secretRef:
+                name: {{ include "lerian-notification.secretName" . }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              # Build DSN from POSTGRES_* env vars. URL-encode the password so
+              # special characters survive the connection string.
+              PW_ENC=$(printf '%s' "${POSTGRES_PASSWORD}" | od -An -tx1 -v | tr -d ' \n' | sed 's/\(..\)/%\1/g')
+              DATABASE_URL="postgres://${POSTGRES_USER}:${PW_ENC}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}?sslmode=${POSTGRES_SSLMODE}"
+              echo "Running migrations against ${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME} (sslmode=${POSTGRES_SSLMODE})"
+              exec migrate -path /migrations -database "${DATABASE_URL}" {{ range .Values.migrations.extraArgs }}{{ . | quote }} {{ end }}up
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+{{- end }}

--- a/charts/lerian-notification/templates/secret.yaml
+++ b/charts/lerian-notification/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- /*
+  Skip rendering when an external Secret is referenced via `secretRef.name`
+  (typical gitops / AVP integration).
+*/}}
+{{- if not .Values.secretRef.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lerian-notification.secretName" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" (include "lerian-notification.fullname" .)) | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | default "" | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.extraSecrets }}
+  {{- range $key, $value := . }}
+  {{ $key }}: {{ $value | default "" | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/lerian-notification/templates/secret.yaml
+++ b/charts/lerian-notification/templates/secret.yaml
@@ -12,12 +12,12 @@ metadata:
     {{- include "lerian-notification.labels" (dict "context" . "name" (include "lerian-notification.fullname" .)) | nindent 4 }}
 type: Opaque
 data:
-  {{- range $key, $value := .Values.secrets }}
-  {{ $key }}: {{ $value | default "" | b64enc | quote }}
+  {{- range $key := keys .Values.secrets | sortAlpha }}
+  {{ $key }}: {{ index $.Values.secrets $key | default "" | b64enc | quote }}
   {{- end }}
   {{- with .Values.extraSecrets }}
-  {{- range $key, $value := . }}
-  {{ $key }}: {{ $value | default "" | b64enc | quote }}
+  {{- range $key := keys . | sortAlpha }}
+  {{ $key }}: {{ index $.Values.extraSecrets $key | default "" | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/lerian-notification/templates/serviceaccount.yaml
+++ b/charts/lerian-notification/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lerian-notification.serviceAccountName" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" (include "lerian-notification.fullname" .)) | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lerian-notification/templates/worker-email/deployment.yaml
+++ b/charts/lerian-notification/templates/worker-email/deployment.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.workerEmail.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workerEmail.fullname" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.workerEmail.name) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .Values.workerEmail.revisionHistoryLimit | default 10 }}
+  strategy:
+    {{- toYaml .Values.workerEmail.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.workerEmail.autoscaling.enabled }}
+  replicas: {{ .Values.workerEmail.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lerian-notification.selectorLabels" (dict "context" . "name" .Values.workerEmail.name) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lerian-notification.labels" (dict "context" . "name" .Values.workerEmail.name) | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.secretRef.name }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.workerEmail.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "lerian-notification.serviceAccountName" . }}
+      {{- with (concat .Values.imagePullSecrets .Values.workerEmail.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerEmail.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.workerEmail.name }}
+          image: "{{ .Values.workerEmail.image.repository }}:{{ .Values.workerEmail.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.workerEmail.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.workerEmail.securityContext | nindent 12 }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.workerEmail.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "lerian-notification.configMapName" . }}
+            - secretRef:
+                name: {{ include "lerian-notification.secretName" . }}
+          env:
+            # Worker binds /health and /readyz on this address (overrides the
+            # shared ConfigMap default to match this worker's containerPort).
+            - name: WORKER_HEALTH_ADDRESS
+              value: ":{{ .Values.workerEmail.containerPort }}"
+            {{- range $key, $value := .Values.workerEmail.extraEnvVars }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.workerEmail.resources | nindent 12 }}
+          {{- if .Values.workerEmail.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.workerEmail.probes.startup.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerEmail.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerEmail.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerEmail.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerEmail.probes.startup.failureThreshold }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.workerEmail.probes.readiness.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerEmail.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerEmail.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerEmail.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerEmail.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.workerEmail.probes.liveness.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerEmail.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerEmail.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerEmail.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerEmail.probes.liveness.failureThreshold }}
+      {{- with .Values.workerEmail.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerEmail.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerEmail.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lerian-notification/templates/worker-sms/deployment.yaml
+++ b/charts/lerian-notification/templates/worker-sms/deployment.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.workerSms.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workerSms.fullname" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.workerSms.name) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .Values.workerSms.revisionHistoryLimit | default 10 }}
+  strategy:
+    {{- toYaml .Values.workerSms.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.workerSms.autoscaling.enabled }}
+  replicas: {{ .Values.workerSms.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lerian-notification.selectorLabels" (dict "context" . "name" .Values.workerSms.name) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lerian-notification.labels" (dict "context" . "name" .Values.workerSms.name) | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.secretRef.name }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.workerSms.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "lerian-notification.serviceAccountName" . }}
+      {{- with (concat .Values.imagePullSecrets .Values.workerSms.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerSms.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.workerSms.name }}
+          image: "{{ .Values.workerSms.image.repository }}:{{ .Values.workerSms.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.workerSms.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.workerSms.securityContext | nindent 12 }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.workerSms.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "lerian-notification.configMapName" . }}
+            - secretRef:
+                name: {{ include "lerian-notification.secretName" . }}
+          env:
+            # Worker binds /health and /readyz on this address (overrides the
+            # shared ConfigMap default to match this worker's containerPort).
+            - name: WORKER_HEALTH_ADDRESS
+              value: ":{{ .Values.workerSms.containerPort }}"
+            {{- range $key, $value := .Values.workerSms.extraEnvVars }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.workerSms.resources | nindent 12 }}
+          {{- if .Values.workerSms.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.workerSms.probes.startup.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerSms.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerSms.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerSms.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerSms.probes.startup.failureThreshold }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.workerSms.probes.readiness.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerSms.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerSms.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerSms.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerSms.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.workerSms.probes.liveness.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerSms.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerSms.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerSms.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerSms.probes.liveness.failureThreshold }}
+      {{- with .Values.workerSms.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerSms.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerSms.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lerian-notification/templates/worker-webhook/deployment.yaml
+++ b/charts/lerian-notification/templates/worker-webhook/deployment.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.workerWebhook.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workerWebhook.fullname" . }}
+  namespace: {{ include "lerian-notification.namespace" . }}
+  labels:
+    {{- include "lerian-notification.labels" (dict "context" . "name" .Values.workerWebhook.name) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .Values.workerWebhook.revisionHistoryLimit | default 10 }}
+  strategy:
+    {{- toYaml .Values.workerWebhook.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.workerWebhook.autoscaling.enabled }}
+  replicas: {{ .Values.workerWebhook.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lerian-notification.selectorLabels" (dict "context" . "name" .Values.workerWebhook.name) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lerian-notification.labels" (dict "context" . "name" .Values.workerWebhook.name) | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.secretRef.name }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.workerWebhook.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "lerian-notification.serviceAccountName" . }}
+      {{- with (concat .Values.imagePullSecrets .Values.workerWebhook.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerWebhook.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.workerWebhook.name }}
+          image: "{{ .Values.workerWebhook.image.repository }}:{{ .Values.workerWebhook.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.workerWebhook.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.workerWebhook.securityContext | nindent 12 }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.workerWebhook.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "lerian-notification.configMapName" . }}
+            - secretRef:
+                name: {{ include "lerian-notification.secretName" . }}
+          env:
+            # Worker binds /health and /readyz on this address (overrides the
+            # shared ConfigMap default to match this worker's containerPort).
+            - name: WORKER_HEALTH_ADDRESS
+              value: ":{{ .Values.workerWebhook.containerPort }}"
+            {{- range $key, $value := .Values.workerWebhook.extraEnvVars }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.workerWebhook.resources | nindent 12 }}
+          {{- if .Values.workerWebhook.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.workerWebhook.probes.startup.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerWebhook.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerWebhook.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerWebhook.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerWebhook.probes.startup.failureThreshold }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.workerWebhook.probes.readiness.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerWebhook.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerWebhook.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerWebhook.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerWebhook.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.workerWebhook.probes.liveness.path }}
+              port: health
+            initialDelaySeconds: {{ .Values.workerWebhook.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workerWebhook.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.workerWebhook.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.workerWebhook.probes.liveness.failureThreshold }}
+      {{- with .Values.workerWebhook.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerWebhook.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerWebhook.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lerian-notification/values-template.yaml
+++ b/charts/lerian-notification/values-template.yaml
@@ -1,0 +1,78 @@
+# Per-environment values template. Copy and override per env (firmino, staging,
+# production). Sensitive values should be left empty here and injected via
+# gitops + ArgoCD Vault Plugin, or replaced entirely with `secretRef.name`
+# pointing at a pre-existing Secret.
+
+api:
+  replicaCount: 1
+  image:
+    repository: docker.io/lerianstudio/lerian-notification
+    pullPolicy: Always
+    tag: ""  # set per release (e.g. "0.1.0-rc.1")
+  ingress:
+    enabled: false
+    className: "nginx"
+    annotations: {}
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+
+workerEmail:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: docker.io/lerianstudio/lerian-notification-worker-email
+    pullPolicy: Always
+    tag: ""
+
+workerSms:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: docker.io/lerianstudio/lerian-notification-worker-sms
+    pullPolicy: Always
+    tag: ""
+
+workerWebhook:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: docker.io/lerianstudio/lerian-notification-worker-webhook
+    pullPolicy: Always
+    tag: ""
+
+migrations:
+  enabled: true
+
+# External Secret (preferred for gitops). Leave blank to use the chart-rendered
+# Secret populated from `.Values.secrets` below.
+secretRef:
+  name: ""
+
+config:
+  ENV_NAME: "firmino"
+  LOG_LEVEL: "info"
+  POSTGRES_HOST: ""
+  POSTGRES_PORT: "5432"
+  POSTGRES_USER: "lerian-notification"
+  POSTGRES_NAME: "lerian-notification"
+  POSTGRES_SSLMODE: "require"
+  REDIS_HOST: ""
+  REDIS_PORT: "6379"
+  RABBITMQ_HOST: ""
+  RABBITMQ_PORT_AMQP: "5672"
+
+secrets:
+  POSTGRES_PASSWORD: ""
+  REDIS_PASSWORD: ""
+  RABBITMQ_URL: ""
+  RABBITMQ_DEFAULT_USER: ""
+  RABBITMQ_DEFAULT_PASS: ""
+  RABBITMQ_HEALTH_CHECK_URL: ""

--- a/charts/lerian-notification/values.yaml
+++ b/charts/lerian-notification/values.yaml
@@ -1,0 +1,585 @@
+# Default values for lerian-notification
+# This is a YAML-formatted file.
+#
+# Topology:
+#   - api             (HTTP API on :8080, ingress optional)
+#   - worker-email    (consumer on :8081 — health probe only)
+#   - worker-sms      (consumer on :8082 — health probe only)
+#   - worker-webhook  (consumer on :8083 — health probe only)
+#
+# All components share the same env contract, exposed via a single ConfigMap
+# (non-sensitive) and a single Secret (sensitive — fillable per env via gitops
+# + ArgoCD Vault Plugin, or pre-existing secret referenced by `secretRef.name`).
+#
+# External dependencies (NOT bundled): Postgres, Redis, RabbitMQ. Connection
+# details are configured under `config` (ConfigMap) and `secrets` (Secret).
+
+# -- Global overrides (chart-wide)
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+# -- Image pull secrets applied to every component (component-level
+#    `imagePullSecrets` still overrides per-deployment).
+imagePullSecrets: []
+# - name: lerian-dockerhub
+
+# -- Shared service account for all components.
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# -- Reference to an externally-managed Secret (e.g. ArgoCD Vault Plugin).
+#    If `name` is set, the chart skips rendering its own Secret resource and
+#    every component mounts this Secret via envFrom instead.
+secretRef:
+  name: ""
+
+# -- Override the generated ConfigMap name. Leave empty for default
+#    (= chart fullname).
+configMapNameOverride: ""
+
+#==============================================================================
+# Database migrations (golang-migrate)
+#==============================================================================
+# Runs as a Helm pre-install / pre-upgrade Job using the API image (which
+# bundles /migrations from the service Dockerfile). Set `enabled: false` to
+# skip when migrations are managed out-of-band.
+migrations:
+  enabled: true
+  # -- Reuses the API image by default; override here only if you ship a
+  #    dedicated migrations image.
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: Always
+  # -- Resource limits for the migration Job pod.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  restartPolicy: OnFailure
+  backoffLimit: 3
+  # -- TTL (seconds) for the completed Job. Helm hooks delete on success by
+  #    default; this is a belt-and-suspenders for clusters where the hook
+  #    annotation policy is overridden.
+  ttlSecondsAfterFinished: 600
+  # -- Extra args appended to the migrate CLI. The chart already supplies
+  #    `-path /migrations -database "$DATABASE_URL" up`.
+  extraArgs: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+
+#==============================================================================
+# Shared environment (ConfigMap)
+#==============================================================================
+# Non-sensitive env vars consumed by EVERY component. Sensitive values live
+# under `secrets` (rendered into a separate Secret).
+config:
+  # ---- Application ----
+  ENV_NAME: "firmino"
+  LOG_LEVEL: "info"
+  SERVER_ADDRESS: ":8080"
+  HTTP_BODY_LIMIT_BYTES: "104857600"
+  TLS_TERMINATED_UPSTREAM: "true"
+  DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"
+
+  # ---- CORS ----
+  CORS_ALLOWED_ORIGINS: ""
+  CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+  CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
+  CORS_EXPOSE_HEADERS: ""
+  CORS_ALLOW_CREDENTIALS: "false"
+
+  # ---- Multi-tenant (tenant-manager) ----
+  MULTI_TENANT_ENABLED: "false"
+  MULTI_TENANT_REDIS_PORT: "6379"
+  MULTI_TENANT_REDIS_TLS: "false"
+  MULTI_TENANT_MAX_TENANT_POOLS: "100"
+  MULTI_TENANT_IDLE_TIMEOUT_SEC: "300"
+  MULTI_TENANT_TIMEOUT: "30"
+  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
+  MULTI_TENANT_CACHE_TTL_SEC: "120"
+  MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: "30"
+
+  # ---- Postgres (external) ----
+  POSTGRES_HOST: ""
+  POSTGRES_PORT: "5432"
+  POSTGRES_USER: "lerian-notification"
+  POSTGRES_NAME: "lerian-notification"
+  POSTGRES_SSLMODE: "require"
+  POSTGRES_MAX_OPEN_CONNS: "25"
+  POSTGRES_MAX_IDLE_CONNS: "5"
+  POSTGRES_CONN_MAX_LIFETIME_MINS: "30"
+  POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
+  POSTGRES_CONNECT_TIMEOUT_SEC: "10"
+  MIGRATIONS_PATH: "/migrations"
+  SYSTEMPLANE_ENABLED: "false"
+  INFRA_CONNECT_TIMEOUT_SEC: "30"
+
+  # ---- Redis (external) ----
+  REDIS_HOST: ""
+  REDIS_PORT: "6379"
+  REDIS_DB: "0"
+  REDIS_PROTOCOL: "3"
+  REDIS_POOL_SIZE: "10"
+  REDIS_MIN_IDLE_CONNS: "2"
+  REDIS_READ_TIMEOUT: "3"
+  REDIS_WRITE_TIMEOUT: "3"
+  REDIS_DIAL_TIMEOUT: "5"
+  REDIS_POOL_TIMEOUT: "2"
+  REDIS_MAX_RETRIES: "3"
+  REDIS_MIN_RETRY_BACKOFF: "8"
+  REDIS_MAX_RETRY_BACKOFF: "1"
+
+  # ---- RabbitMQ (external) ----
+  RABBITMQ_HOST: ""
+  RABBITMQ_PORT_AMQP: "5672"
+  RABBITMQ_PORT_HOST: "15672"
+  RABBITMQ_VHOST: "/"
+  RABBITMQ_EXCHANGE: "events"
+  RABBITMQ_REQUIRE_HEALTH_ALLOWED_HOSTS: "false"
+  RABBITMQ_ALLOW_INSECURE_HEALTH_CHECK: "false"
+  RABBITMQ_ALLOW_INSECURE_TLS: "false"
+  RABBITMQ_PUBLISHER_CONFIRM_TIMEOUT_MS: "5000"
+  RABBITMQ_PUBLISHER_RECOVERY_INITIAL_MS: "1000"
+  RABBITMQ_PUBLISHER_RECOVERY_MAX_MS: "30000"
+  RABBITMQ_PUBLISHER_MAX_RECOVERIES: "10"
+
+  # ---- Outbox ----
+  OUTBOX_TABLE_NAME: "outbox_events"
+  OUTBOX_DISPATCH_INTERVAL_SEC: "2"
+  OUTBOX_BATCH_SIZE: "50"
+  OUTBOX_PUBLISH_MAX_ATTEMPTS: "3"
+  OUTBOX_PUBLISH_BACKOFF_MS: "200"
+  OUTBOX_RETRY_WINDOW_SEC: "300"
+  OUTBOX_MAX_DISPATCH_ATTEMPTS: "10"
+  OUTBOX_PROCESSING_TIMEOUT_SEC: "600"
+  OUTBOX_MAX_FAILED_PER_BATCH: "25"
+  OUTBOX_INCLUDE_TENANT_METRICS: "false"
+  OUTBOX_ALLOW_EMPTY_TENANT: "true"
+
+  # ---- Plugin Auth ----
+  PLUGIN_AUTH_ENABLED: "false"
+
+  # ---- Notification delivery knobs ----
+  NOTIFICATION_RETRY_MAX_ATTEMPTS: "5"
+  NOTIFICATION_RETRY_BASE_DELAY_SEC: "30"
+  NOTIFICATION_RETRY_MAX_DELAY_SEC: "3600"
+  NOTIFICATION_CONCURRENCY_EMAIL: "10"
+  NOTIFICATION_CONCURRENCY_SMS: "5"
+  NOTIFICATION_CONCURRENCY_WEBHOOK: "10"
+  NOTIFICATION_WEBHOOK_TIMEOUT_SEC: "30"
+  NOTIFICATION_CB_FAILURE_THRESHOLD: "5"
+  NOTIFICATION_CB_RECOVERY_TIMEOUT_SEC: "60"
+
+  # ---- Worker tuning (consumed by all worker-* components) ----
+  WORKER_RETRY_INTERVAL_SEC: "30"
+  WORKER_RETRY_BATCH_SIZE: "50"
+  WORKER_SHUTDOWN_TIMEOUT_SEC: "30"
+
+  # ---- Swagger ----
+  SWAGGER_ENABLED: "true"
+  SWAGGER_TITLE: "Lerian Notification"
+  SWAGGER_VERSION: "1.0.0"
+  SWAGGER_BASE_PATH: "/"
+  SWAGGER_LEFT_DELIM: "{{"
+  SWAGGER_RIGHT_DELIM: "}}"
+
+  # ---- OpenTelemetry ----
+  ENABLE_TELEMETRY: "false"
+  OTEL_LIBRARY_NAME: "lerian-notification"
+  OTEL_RESOURCE_SERVICE_NAME: "lerian-notification"
+  OTEL_RESOURCE_SERVICE_VERSION: "0.1.0"
+  OTEL_EXPORTER_OTLP_ENDPOINT: ""
+  OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "firmino"
+
+  # ---- Rate Limiting ----
+  RATE_LIMIT_ENABLED: "true"
+  RATE_LIMIT_MAX: "500"
+  RATE_LIMIT_WINDOW_SEC: "60"
+  AGGRESSIVE_RATE_LIMIT_MAX: "100"
+  AGGRESSIVE_RATE_LIMIT_WINDOW_SEC: "60"
+  RELAXED_RATE_LIMIT_MAX: "1000"
+  RELAXED_RATE_LIMIT_WINDOW_SEC: "60"
+
+  # ---- Observability ----
+  DB_METRICS_INTERVAL_SEC: "15"
+
+  # ---- Idempotency ----
+  IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
+
+  # ---- Destination Auth Cache ----
+  NOTIFICATION_AUTH_CACHE_L1_TTL: "30"
+  NOTIFICATION_AUTH_CACHE_MAX_TTL: "300"
+  NOTIFICATION_AUTH_CACHE_SAFETY_MARGIN: "30"
+  NOTIFICATION_AUTH_CACHE_REFRESH_THRESHOLD: "0.8"
+  NOTIFICATION_AUTH_CACHE_ENCRYPTION_ENABLED: "true"
+
+  # ---- M2M ----
+  M2M_CREDENTIAL_CACHE_TTL_SEC: "300"
+  AWS_REGION: "us-east-1"
+
+  # ---- Pagination ----
+  MAX_PAGINATION_LIMIT: "100"
+  MAX_PAGINATION_MONTH_DATE_RANGE: "3"
+
+# Extra non-sensitive env vars merged into the ConfigMap.
+extraConfig: {}
+
+#==============================================================================
+# Shared environment (Secret)
+#==============================================================================
+# Sensitive env vars. Leave empty here; populate per-env via gitops + AVP, or
+# point `secretRef.name` at an externally-managed Secret to skip this entirely.
+secrets:
+  # -- Postgres
+  POSTGRES_PASSWORD: ""
+  # -- Postgres replica (optional, leave empty if unused)
+  POSTGRES_REPLICA_HOST: ""
+  POSTGRES_REPLICA_PORT: ""
+  POSTGRES_REPLICA_USER: ""
+  POSTGRES_REPLICA_PASSWORD: ""
+  POSTGRES_REPLICA_NAME: ""
+  POSTGRES_REPLICA_SSLMODE: ""
+  # -- Redis
+  REDIS_PASSWORD: ""
+  REDIS_MASTER_NAME: ""
+  REDIS_TLS: ""
+  REDIS_CA_CERT: ""
+  # -- RabbitMQ (full URL with credentials)
+  RABBITMQ_URL: ""
+  RABBITMQ_DEFAULT_USER: ""
+  RABBITMQ_DEFAULT_PASS: ""
+  RABBITMQ_HEALTH_CHECK_URL: ""
+  # -- Multi-tenant
+  MULTI_TENANT_URL: ""
+  MULTI_TENANT_SERVICE_API_KEY: ""
+  MULTI_TENANT_REDIS_HOST: ""
+  MULTI_TENANT_REDIS_PASSWORD: ""
+  # -- Plugin Auth
+  PLUGIN_AUTH_HOST: ""
+  # -- Destination auth cache encryption key (base64 AES-256-GCM)
+  NOTIFICATION_AUTH_CACHE_ENCRYPTION_KEY: ""
+  # -- M2M
+  M2M_TARGET_SERVICE: ""
+  # -- Webhook SSRF allowlist override (development only)
+  NOTIFICATION_SSRF_ALLOW_PRIVATE_CIDRS: ""
+
+# Extra sensitive env vars merged into the Secret.
+extraSecrets: {}
+
+#==============================================================================
+# API (cmd/api)
+#==============================================================================
+api:
+  name: "lerian-notification"
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: docker.io/lerianstudio/lerian-notification
+    pullPolicy: Always
+    tag: ""  # defaults to .Chart.AppVersion
+  imagePullSecrets: []
+  containerPort: 8080
+  service:
+    type: ClusterIP
+    port: 8080
+  ingress:
+    enabled: false
+    className: "nginx"
+    annotations: {}
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    minAvailable: 0
+    annotations: {}
+  probes:
+    liveness:
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readiness:
+      path: /readyz
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
+    startup:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 30
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvVars: {}
+
+#==============================================================================
+# Worker - Email (cmd/worker-email)
+#==============================================================================
+workerEmail:
+  name: "lerian-notification-worker-email"
+  enabled: true
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: docker.io/lerianstudio/lerian-notification-worker-email
+    pullPolicy: Always
+    tag: ""  # defaults to .Chart.AppVersion
+  imagePullSecrets: []
+  containerPort: 8081
+  # -- Bound to WORKER_HEALTH_ADDRESS (=:8081). Exposed only via probes; no
+  #    Service is created for workers.
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    minAvailable: 0
+    annotations: {}
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  probes:
+    liveness:
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readiness:
+      path: /readyz
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
+    startup:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 30
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvVars: {}
+
+#==============================================================================
+# Worker - SMS (cmd/worker-sms)
+#==============================================================================
+workerSms:
+  name: "lerian-notification-worker-sms"
+  enabled: true
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: docker.io/lerianstudio/lerian-notification-worker-sms
+    pullPolicy: Always
+    tag: ""
+  imagePullSecrets: []
+  containerPort: 8082
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    minAvailable: 0
+    annotations: {}
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  probes:
+    liveness:
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readiness:
+      path: /readyz
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
+    startup:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 30
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvVars: {}
+
+#==============================================================================
+# Worker - Webhook (cmd/worker-webhook)
+#==============================================================================
+workerWebhook:
+  name: "lerian-notification-worker-webhook"
+  enabled: true
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: docker.io/lerianstudio/lerian-notification-worker-webhook
+    pullPolicy: Always
+    tag: ""
+  imagePullSecrets: []
+  containerPort: 8083
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    minAvailable: 0
+    annotations: {}
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  probes:
+    liveness:
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readiness:
+      path: /readyz
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
+    startup:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 30
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvVars: {}

--- a/charts/lerian-notification/values.yaml
+++ b/charts/lerian-notification/values.yaml
@@ -74,6 +74,7 @@ migrations:
   podAnnotations: {}
   podSecurityContext: {}
   securityContext:
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 65532
     runAsGroup: 65532
@@ -81,6 +82,8 @@ migrations:
       drop:
         - ALL
     readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
 
 #==============================================================================
 # Shared environment (ConfigMap)
@@ -142,8 +145,8 @@ config:
   REDIS_DIAL_TIMEOUT: "5"
   REDIS_POOL_TIMEOUT: "2"
   REDIS_MAX_RETRIES: "3"
-  REDIS_MIN_RETRY_BACKOFF: "8"
-  REDIS_MAX_RETRY_BACKOFF: "1"
+  REDIS_MIN_RETRY_BACKOFF: "1"
+  REDIS_MAX_RETRY_BACKOFF: "8"
 
   # ---- RabbitMQ (external) ----
   RABBITMQ_HOST: ""
@@ -316,6 +319,7 @@ api:
   podAnnotations: {}
   podSecurityContext: {}
   securityContext:
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 65532
     runAsGroup: 65532
@@ -323,6 +327,8 @@ api:
       drop:
         - ALL
     readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   resources:
     limits:
       cpu: 500m
@@ -385,6 +391,7 @@ workerEmail:
   podAnnotations: {}
   podSecurityContext: {}
   securityContext:
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 65532
     runAsGroup: 65532
@@ -392,6 +399,8 @@ workerEmail:
       drop:
         - ALL
     readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   resources:
     limits:
       cpu: 500m
@@ -457,6 +466,7 @@ workerSms:
   podAnnotations: {}
   podSecurityContext: {}
   securityContext:
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 65532
     runAsGroup: 65532
@@ -464,6 +474,8 @@ workerSms:
       drop:
         - ALL
     readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   resources:
     limits:
       cpu: 500m
@@ -529,6 +541,7 @@ workerWebhook:
   podAnnotations: {}
   podSecurityContext: {}
   securityContext:
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 65532
     runAsGroup: 65532
@@ -536,6 +549,8 @@ workerWebhook:
       drop:
         - ALL
     readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
# Lerian Notification Pull Request Checklist

## Pull Request Type

- [x] **lerian-notification (new chart)**

## Summary

Initial Helm chart for the [lerian-notification](https://github.com/LerianStudio/lerian-notification) service — a notification delivery platform with an HTTP API and three async workers (email, SMS, webhook).

This PR is part of the onboarding sequence:

1. ✅ `lerian-notification` PR [#38](https://github.com/LerianStudio/lerian-notification/pull/38) — split Dockerfile per `cmd/<name>` + align workflows with shared `v1.28.12`.
2. **➡️ This PR** — chart in `LerianStudio/helm`.
3. ⏭️ `midaz-firmino-gitops` — register the app under `environments/firmino/helmfile/applications/` and the ArgoCD `Application` manifest.
4. ⏭️ `lerian-notification` — uncomment the `update_gitops` job in `build.yml` and pin `yaml_key_mappings` to this chart's `values.yaml`.

## Components

| Component | Image (DockerHub default) | Port | K8s shape |
|---|---|---|---|
| api | `docker.io/lerianstudio/lerian-notification` | 8080 (HTTP) | Deployment + Service ClusterIP + optional Ingress + optional HPA/PDB |
| worker-email | `docker.io/lerianstudio/lerian-notification-worker-email` | 8081 (health) | Deployment |
| worker-sms | `docker.io/lerianstudio/lerian-notification-worker-sms` | 8082 (health) | Deployment |
| worker-webhook | `docker.io/lerianstudio/lerian-notification-worker-webhook` | 8083 (health) | Deployment |

Image naming follows the `app_name_overrides` contract configured in the service repo's `build.yml`.

## External dependencies (no subcharts)

Postgres, Redis and RabbitMQ are treated as **external** (cluster-shared instances configured per env). The chart does not declare any subchart dependencies. Connection settings are exposed through `values.yaml` and rendered into a shared `ConfigMap` + `Secret`. Use `secretRef.name` to point at an AVP-managed (ArgoCD Vault Plugin) external Secret instead of the rendered placeholder.

## Migrations

A Helm `Job` (pre-install / pre-upgrade hook) runs `golang-migrate` against the configured Postgres before any Deployment rollouts. Reuses the api image (which bundles `/migrations`). Togglable via `migrations.enabled` (default `true`).

## Validation

```
helm lint --strict charts/lerian-notification        # 0 failures
helm template test charts/lerian-notification        # 9 resources
helm template test charts/lerian-notification --set api.ingress.enabled=true --set api.autoscaling.enabled=true --set api.pdb.enabled=true   # 12 resources
helm template test charts/lerian-notification --set secretRef.name=external-secret   # 8 resources (rendered Secret correctly skipped)
```

## Deviations from `plugin-br-pix-indirect-btg` reference (and why)

1. **Single shared `ConfigMap` + `Secret`** — env contract is identical across the 4 components; duplicating per component adds noise without value.
2. **No Service / Ingress for workers** — workers expose only health probes, not application traffic.
3. **Migrations Job** — pix-btg has no migrations pattern; notification uses `golang-migrate` and the SQL lives in the api image, so a pre-install hook fits naturally.
4. **No subcharts** — there's no `bootstrap-mongodb.yaml` analog; deps are external.
5. **Startup probe + named ports** (`http`, `health`) — matches the verified endpoints in `internal/bootstrap`.
6. **DockerHub default registry** — `lerianstudio/*` instead of GHCR.

## Notable values keys gitops will need to set per env (firmino first)

- Image tags: `api.image.tag`, `workerEmail.image.tag`, `workerSms.image.tag`, `workerWebhook.image.tag`
- Env: `config.ENV_NAME`, `config.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT`
- Connectivity: `config.POSTGRES_HOST`, `config.REDIS_HOST`, `config.RABBITMQ_HOST`
- Secrets (AVP): `secrets.POSTGRES_PASSWORD`, `secrets.REDIS_PASSWORD`, `secrets.RABBITMQ_URL`, `secrets.NOTIFICATION_AUTH_CACHE_ENCRYPTION_KEY` — or set `secretRef.name` to an external Secret
- Optional: `api.ingress.{enabled,hosts,tls}`

## Checklist

- [x] I have tested these changes locally (`helm lint --strict` + 4 `helm template` scenarios).
- [x] I have updated the documentation accordingly (README + CHANGELOG inside the chart).
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues (runAsNonRoot, allowPrivilegeEscalation=false, distroless images, no plain-text secrets in defaults).
- [x] I have ensured that all tests pass (helm lint/template).
- [x] I have updated the version appropriately — initial chart `0.1.0`, appVersion `0.1.0`.
- [x] I have confirmed this code is ready for review.

## Additional Notes

Chart is **inert** until PRs 3 and 4 in the sequence above land — it's published as a Helm artifact but not deployed anywhere yet. ArgoCD `Application` registration happens in `midaz-firmino-gitops` (next PR). The `update_gitops` job in the service's `build.yml` is currently commented out and will be enabled in the final PR of the sequence.