### PR TITLE
chore(pipe): register lerian-notification as a chart scope

### DIFF
--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -37,7 +37,11 @@ plugin-br-pix-switch:
 plugin-br-payments:
   - changed-files:
       - any-glob-to-any-file: charts/plugin-br-payments/**
-      
+
+lerian-notification:
+  - changed-files:
+      - any-glob-to-any-file: charts/lerian-notification/**
+
 product-console:
   - changed-files:
       - any-glob-to-any-file: charts/product-console/**

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -25,6 +25,7 @@ jobs:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
         charts/fetcher
+        charts/lerian-notification
         charts/midaz
         charts/otel-collector-lerian
         charts/plugin-access-manager

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -39,6 +39,7 @@ jobs:
             plugin-br-pix-direct-jd
             plugin-br-pix-indirect-btg
             plugin-br-pix-switch
+            lerian-notification
             plugin-br-bank-transfer-jd
             templates
             dependencies


### PR DESCRIPTION
# Lerian Helm Pull Request Checklist

## Pull Request Type

- [x] **Pipeline / repository configuration**

## Summary

Registers \`lerian-notification\` across the three \`.github\` configs that gate chart onboarding so that PR [#1332](https://github.com/LerianStudio/helm/pull/1332) (the initial \`charts/lerian-notification\` chart) can pass the semantic PR title check and benefit from the same automation every other chart already has.

## Changes

| File | Change |
|---|---|
| \`.github/workflows/pr-title.yml\` | Add \`lerian-notification\` to the \`scopes:\` list of \`amannn/action-semantic-pull-request\`. Without it, PRs scoped to the new chart fail with \`Unknown scope\`. |
| \`.github/configs/labeler.yaml\` | Add a labeler entry mapping \`charts/lerian-notification/**\` → \`lerian-notification\` label. Matches the pattern used by every other chart. |
| \`.github/workflows/gptchangelog.yml\` | Add \`charts/lerian-notification\` to the AI changelog \`filter_paths\` so release notes are generated when the chart ships tags. |

Alphabetical / canonical ordering matches the existing files (under \`fetcher\`, between \`fetcher\` and \`midaz\` in the changelog list; appended to the scope list with the other plugins/services).

## Why a separate PR

Keeps the scope of #1332 clean (only the chart itself; scope \`lerian-notification\`). After this PR merges, #1332's title check passes and the auto-labeler will tag it correctly.

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (N/A — repo-level config change only).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Order to land: this PR first, then re-run / re-push #1332's title check.

## Obs

PR targeted to \`develop\` per repo convention.