### PR TITLE
fix(plugin-br-pix-switch): providers ingress default path /mock-btg -> /btg-mock

### DIFF
--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Plugin-br-pix-switch Changelog
 
-## [1.1.0-beta.8] - Providers ingress + prefixed health probes
+## [1.1.0-beta.8] - Fix providers ingress default path for adapter-btg-mock
+
+`providersIngress.routes` default for `adapterBtgMock` had `/mock-btg`
+but the source binary mounts its router at `/btg-mock` (per
+`apps/adapter-btg-mock/components/api/bootstrap/server.go`:
+`const routePrefix = "/btg-mock"`). Requests reaching the ingress at
+`/mock-btg/<anything>` were forwarded to the pod which had no route
+registered there → 404s.
+
+Switch the default path to `/btg-mock` so it matches what the binary
+actually serves (and what the deployment template's probe defaults
+already use).
+
+## [1.1.0-beta.7] - Providers ingress + prefixed health probes
 
 Two additions, single chart bump.
 

--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.1.0-beta.7
+version: 1.1.0-beta.8
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.101"

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -1313,7 +1313,10 @@ providersIngress:
   hosts: []
   tls: []
   routes:
-    - path: /mock-btg
+    # Path must match the source-side routePrefix:
+    #   apps/adapter-btg-mock/components/api/bootstrap/server.go
+    #     const routePrefix = "/btg-mock"
+    - path: /btg-mock
       pathType: Prefix
       component: adapterBtgMock
       serviceName: adapter-btg-mock


### PR DESCRIPTION
## Summary

\`providersIngress.routes\` default for \`adapterBtgMock\` was \`/mock-btg\` but the source binary mounts its router at \`/btg-mock\`:

\`\`\`go
// apps/adapter-btg-mock/components/api/bootstrap/server.go
const routePrefix = "/btg-mock"
\`\`\`

External requests reaching the ingress at \`/mock-btg/<anything>\` were forwarded to the pod, which had no route registered there → 404s.

## Fix

Switch the default path to \`/btg-mock\` so it matches the binary's actual mount point (and what the deployment template's probe defaults already use, \`/btg-mock/readyz\` + \`/btg-mock/health\`).

## Validation

- \`helm template\` with providers ingress enabled now renders the route as \`/btg-mock\` pointing at \`adapter-btg-mock:4103\`.
- \`helm lint\` passes.

## Followup

firmino-dev gitops PR will follow — just removing the per-env path override (chart default is now correct).