### PR TITLE
chore(pipe): register lerian-notification as a chart scope

### DIFF
--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -37,7 +37,11 @@ plugin-br-pix-switch:
 plugin-br-payments:
   - changed-files:
       - any-glob-to-any-file: charts/plugin-br-payments/**
-      
+
+lerian-notification:
+  - changed-files:
+      - any-glob-to-any-file: charts/lerian-notification/**
+
 product-console:
   - changed-files:
       - any-glob-to-any-file: charts/product-console/**

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -25,6 +25,7 @@ jobs:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
         charts/fetcher
+        charts/lerian-notification
         charts/midaz
         charts/otel-collector-lerian
         charts/plugin-access-manager

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -39,6 +39,7 @@ jobs:
             plugin-br-pix-direct-jd
             plugin-br-pix-indirect-btg
             plugin-br-pix-switch
+            lerian-notification
             plugin-br-bank-transfer-jd
             templates
             dependencies

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `1.1.0-beta.7` | 1.0.0-beta.1 |
+| `1.1.0-beta.8` | 1.0.0-beta.1 |
 -----------------
 
 ### Plugin BR Pix Indirect BTG

--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Plugin-br-pix-switch Changelog
 
-## [1.1.0-beta.8] - Providers ingress + prefixed health probes
+## [1.1.0-beta.8] - Fix providers ingress default path for adapter-btg-mock
+
+`providersIngress.routes` default for `adapterBtgMock` had `/mock-btg`
+but the source binary mounts its router at `/btg-mock` (per
+`apps/adapter-btg-mock/components/api/bootstrap/server.go`:
+`const routePrefix = "/btg-mock"`). Requests reaching the ingress at
+`/mock-btg/<anything>` were forwarded to the pod which had no route
+registered there → 404s.
+
+Switch the default path to `/btg-mock` so it matches what the binary
+actually serves (and what the deployment template's probe defaults
+already use).
+
+## [1.1.0-beta.7] - Providers ingress + prefixed health probes
 
 Two additions, single chart bump.
 

--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.1.0-beta.7
+version: 1.1.0-beta.8
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.101"

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -1313,7 +1313,10 @@ providersIngress:
   hosts: []
   tls: []
   routes:
-    - path: /mock-btg
+    # Path must match the source-side routePrefix:
+    #   apps/adapter-btg-mock/components/api/bootstrap/server.go
+    #     const routePrefix = "/btg-mock"
+    - path: /btg-mock
       pathType: Prefix
       component: adapterBtgMock
       serviceName: adapter-btg-mock


### PR DESCRIPTION
# Lerian Helm Pull Request Checklist

## Pull Request Type

- [x] **Pipeline / repository configuration**

## Summary

Registers \`lerian-notification\` across the three \`.github\` configs that gate chart onboarding so that PR [#1332](https://github.com/LerianStudio/helm/pull/1332) (the initial \`charts/lerian-notification\` chart) can pass the semantic PR title check.

> Replaces PR #1334, which was accidentally merged into the chart PR's branch (\`feat/lerian-notification-chart\`) instead of \`develop\`. This one targets \`develop\` for real.

## Changes

| File | Change |
|---|---|
| \`.github/workflows/pr-title.yml\` | Add \`lerian-notification\` to the \`scopes:\` list. Without it, PRs scoped to the new chart fail with \`Unknown scope\`. |
| \`.github/configs/labeler.yaml\` | Add a labeler entry mapping \`charts/lerian-notification/**\` → \`lerian-notification\` label. |
| \`.github/workflows/gptchangelog.yml\` | Add \`charts/lerian-notification\` to the AI changelog \`filter_paths\`. |

## Why a separate PR

Keeps the scope of #1332 clean (only the chart itself; scope \`lerian-notification\`). After this PR merges into \`develop\`, #1332's title check will pass.

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (N/A — repo-level config change only).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Land this first, then re-run the title check on #1332.

## Obs

PR targeted to \`develop\` per repo convention.