### PR TITLE
feat(plugin-br-pix-switch): schema migration Jobs (1.1.0-beta.9)

### DIFF
--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Plugin-br-pix-switch Changelog
 
+## [1.1.0-beta.9] - Schema migration Jobs for spi/dict-hub/cob-hub
+
+Add `golang-migrate` Helm-hook Jobs for the 3 components that own
+schema migrations (`spi`, `dictHub`, `cobHub`). Each Job:
+
+- Uses the component's own image (which now ships both `/app` and
+  `/migrate` per plugin-br-pix-switch#143).
+- Overrides `command:` to invoke `/migrate -path /migrations -database
+  $DATABASE_URL up` against the same database the app reads.
+- Annotates `helm.sh/hook: pre-upgrade,post-install` + weight `-5`, so
+  migrations land before pod rollout. `helm.sh/hook-delete-policy:
+  before-hook-creation,hook-succeeded` keeps successful runs out of
+  the cluster after completion.
+
+Configurable per-component:
+
+```yaml
+<component>:
+  migrations:
+    enabled: true         # set false to skip the Job entirely
+    migrationsPath: /migrations
+    ttlSecondsAfterFinished: 300
+    backoffLimit: 3
+```
+
+Without this, app tables never get created — the live firmino-dev
+`pix-spi`/`pix-dict`/`pix-cob` databases currently contain only
+`systemplane_entries` (created by lib-commons at startup), which is
+why SPI/DICT/COB pods start cleanly but would fail on any real
+business request.
+
+Requires plugin-br-pix-switch#143 to be merged + released first (it
+adds `/migrate` to the spi-api, dict-hub-api, cob-hub-api images). The
+Job will fail to run otherwise (exec: "/migrate": no such file).
+
 ## [1.1.0-beta.8] - Fix providers ingress default path for adapter-btg-mock
 
 `providersIngress.routes` default for `adapterBtgMock` had `/mock-btg`

--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.1.0-beta.8
+version: 1.1.0-beta.9
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.101"

--- a/charts/plugin-br-pix-switch/templates/_migrations.tpl
+++ b/charts/plugin-br-pix-switch/templates/_migrations.tpl
@@ -1,0 +1,100 @@
+{{- /*
+Shared partial that renders a Postgres migration Job for one component.
+
+The per-component image (built from apps/<app>/components/<comp>/Dockerfile)
+ships two relevant files at the image root:
+  /migrate     -- statically-linked golang-migrate binary (added in
+                  plugin-br-pix-switch#143)
+  /migrations  -- the app's SQL migration files
+
+The pod's ENTRYPOINT is /app, but the Job overrides `command:` to
+invoke /migrate against the database referenced by DATABASE_URL (the
+same Secret the app reads).
+
+The Job is a Helm hook so it runs before the regular pod rollout and is
+not part of the regular release lifecycle:
+
+  helm.sh/hook: pre-upgrade,post-install
+  helm.sh/hook-weight: -5     (run before bootstrap-postgres? no — that
+                              uses default 0; -5 ensures migrations run
+                              before pods come up on upgrade)
+  helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
+Required inputs in the dict:
+  context     -- root $ context
+  component   -- yaml key (e.g. "spi", "dictHub", "cobHub")
+  serviceName -- kebab-case service suffix (e.g. "spi", "dict-hub", "cob-hub")
+*/}}
+{{- define "plugin-br-pix-switch.migrationJob" -}}
+{{- $ctx := .context -}}
+{{- $component := .component -}}
+{{- $serviceName := .serviceName -}}
+{{- $componentValues := index $ctx.Values $component -}}
+{{- $migrationsCfg := default (dict) $componentValues.migrations -}}
+{{- /*
+  Detect 'enabled' explicitly. We can't use `default true .enabled` —
+  Go templates treat boolean false as "empty", so `default` would
+  override it to true. Check hasKey instead.
+*/}}
+{{- $migrationsEnabled := true }}
+{{- if hasKey $migrationsCfg "enabled" }}
+  {{- $migrationsEnabled = $migrationsCfg.enabled }}
+{{- end }}
+{{- if and $componentValues.enabled $migrationsEnabled }}
+{{- $componentFullname := include "plugin-br-pix-switch.componentFullname" (dict "context" $ctx "component" $serviceName) }}
+{{- $componentImage := include "plugin-br-pix-switch.componentImage" (dict "context" $ctx "componentValues" $componentValues) }}
+{{- $componentPullPolicy := include "plugin-br-pix-switch.componentPullPolicy" (dict "context" $ctx "componentValues" $componentValues) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $componentFullname }}-migrations
+  namespace: {{ include "global.namespace" $ctx }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ctx "component" (printf "%s-migrations" $serviceName)) | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade,post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: {{ default 300 $migrationsCfg.ttlSecondsAfterFinished }}
+  backoffLimit: {{ default 3 $migrationsCfg.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ctx "component" (printf "%s-migrations" $serviceName)) | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- $pullSecrets := include "plugin-br-pix-switch.componentImagePullSecrets" (dict "context" $ctx "componentValues" $componentValues) | trim }}
+      {{- if and $pullSecrets (ne $pullSecrets "[]") }}
+      imagePullSecrets:
+        {{- $pullSecrets | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+      containers:
+        - name: migrate
+          image: {{ $componentImage | quote }}
+          imagePullPolicy: {{ $componentPullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $componentFullname }}
+                  key: DATABASE_URL
+          command:
+            - /migrate
+          args:
+            - -path
+            - {{ default "/migrations" $migrationsCfg.migrationsPath | quote }}
+            - -database
+            - $(DATABASE_URL)
+            - up
+{{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/cob-hub/migrations-job.yaml
+++ b/charts/plugin-br-pix-switch/templates/cob-hub/migrations-job.yaml
@@ -1,0 +1,1 @@
+{{- include "plugin-br-pix-switch.migrationJob" (dict "context" . "component" "cobHub" "serviceName" "cob-hub") }}

--- a/charts/plugin-br-pix-switch/templates/dict-hub/migrations-job.yaml
+++ b/charts/plugin-br-pix-switch/templates/dict-hub/migrations-job.yaml
@@ -1,0 +1,1 @@
+{{- include "plugin-br-pix-switch.migrationJob" (dict "context" . "component" "dictHub" "serviceName" "dict-hub") }}

--- a/charts/plugin-br-pix-switch/templates/spi/migrations-job.yaml
+++ b/charts/plugin-br-pix-switch/templates/spi/migrations-job.yaml
@@ -1,0 +1,1 @@
+{{- include "plugin-br-pix-switch.migrationJob" (dict "context" . "component" "spi" "serviceName" "spi") }}

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -265,6 +265,19 @@ spi:
 # -----------------------------------------------------------------------------
 # spi/systemplane/api — runtime config plane for SPI
 # -----------------------------------------------------------------------------
+
+  # -- golang-migrate Job that applies SQL migrations from the component's
+  # /migrations directory against the database referenced by DATABASE_URL.
+  # The migrate binary ships in the same image (plugin-br-pix-switch#143);
+  # the chart renders a Job with command [/migrate] overriding the default
+  # ENTRYPOINT (/app). Runs as a Helm hook on pre-upgrade + post-install.
+  migrations:
+    enabled: true
+    # Image path holding the SQL files. Match the Dockerfile's COPY target.
+    migrationsPath: /migrations
+    ttlSecondsAfterFinished: 300
+    backoffLimit: 3
+
 spiSystemplane:
   enabled: true
   name: "spi-systemplane"
@@ -575,6 +588,19 @@ dictHub:
 # -----------------------------------------------------------------------------
 # dict/hub/vsync — DICT verification sync worker (background, no ingress)
 # -----------------------------------------------------------------------------
+
+  # -- golang-migrate Job that applies SQL migrations from the component's
+  # /migrations directory against the database referenced by DATABASE_URL.
+  # The migrate binary ships in the same image (plugin-br-pix-switch#143);
+  # the chart renders a Job with command [/migrate] overriding the default
+  # ENTRYPOINT (/app). Runs as a Helm hook on pre-upgrade + post-install.
+  migrations:
+    enabled: true
+    # Image path holding the SQL files. Match the Dockerfile's COPY target.
+    migrationsPath: /migrations
+    ttlSecondsAfterFinished: 300
+    backoffLimit: 3
+
 dictHubVsync:
   enabled: true
   name: "dict-hub-vsync"
@@ -980,6 +1006,19 @@ cobHub:
 # -----------------------------------------------------------------------------
 # cob/proxy/api — COB proxy to BCB (BaseConfig only)
 # -----------------------------------------------------------------------------
+
+  # -- golang-migrate Job that applies SQL migrations from the component's
+  # /migrations directory against the database referenced by DATABASE_URL.
+  # The migrate binary ships in the same image (plugin-br-pix-switch#143);
+  # the chart renders a Job with command [/migrate] overriding the default
+  # ENTRYPOINT (/app). Runs as a Helm hook on pre-upgrade + post-install.
+  migrations:
+    enabled: true
+    # Image path holding the SQL files. Match the Dockerfile's COPY target.
+    migrationsPath: /migrations
+    ttlSecondsAfterFinished: 300
+    backoffLimit: 3
+
 cobProxy:
   enabled: true
   name: "cob-proxy"


### PR DESCRIPTION
## Summary

Adds Helm-hook Jobs that run `golang-migrate` against each component's database before pods roll out. Three Jobs (one per app that owns migrations):

| Component | DB | Migrations dir |
|---|---|---|
| `spi` | `pix-spi` | `apps/spi/migrations` (3 up) |
| `dictHub` | `pix-dict` | `apps/dict/migrations` (5 up) |
| `cobHub` | `pix-cob` | `apps/cob/migrations` (2 up) |

## Mechanism

Each Job uses the **component's own image** (which now ships both `/app` and `/migrate` per **plugin-br-pix-switch#143**) and overrides `command:`:

```yaml
command: [/migrate]
args: [-path, /migrations, -database, $DATABASE_URL, up]
```

Hook annotations:

```yaml
helm.sh/hook: pre-upgrade,post-install
helm.sh/hook-weight: "-5"
helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
```

So on `helm install`, Jobs run **after** pod scheduling resolves (`post-install`); on `helm upgrade`, Jobs run **before** new pods come up (`pre-upgrade`). Successful Jobs delete themselves, leaving failed ones for debugging.

## Why this matters

Live `pix-spi` / `pix-dict` / `pix-cob` databases in firmino-dev currently contain only `systemplane_entries` (created by lib-commons at startup). The application tables (`transfer_initiations`, `transfers`, `refunds`, `entries`, `collections`, etc.) **don't exist**. SPI/DICT/COB pods start cleanly today but would fail any real business request with `relation "..." does not exist`. The SQL files were already inside the component images but no automation ran them.

## Configurability

```yaml
<component>:
  migrations:
    enabled: true                       # default true; set false to skip the Job
    migrationsPath: /migrations         # where SQL files live in the image
    ttlSecondsAfterFinished: 300
    backoffLimit: 3
```

`migrations.enabled: false` correctly disables (verified — uses `hasKey` check, not Helm's `default` filter which mishandles boolean false).

## Validation

- `helm lint` passes
- `helm template` with defaults renders **3 Jobs** + the usual 9 Deployments/Services/etc.
- `helm template` with `spi.migrations.enabled: false` renders **2 Jobs**
- `helm template` with `spi.enabled: false` renders **2 Jobs**
- Rendered Job uses correct image, command `[/migrate]`, args `[-path /migrations -database $(DATABASE_URL) up]`, secretKeyRef on the same component Secret

## Depends on

**plugin-br-pix-switch#143** (`feat: ship golang-migrate binary in components that own migrations`) — adds `/migrate` to spi-api, dict-hub-api, cob-hub-api images. Without it, the Job fails with `exec: "/migrate": no such file or directory`.

## Followup

After this chart releases and `1.1.0-beta.9` is published, a gitops PR will bump firmino-dev. ArgoCD sync will run the migration Jobs on first install (post-install hook) → application tables get created → SPI/DICT/COB become functionally callable, not just probe-passing.