### PR TITLE
fix(lerian-notification): declare kubeVersion compatibility

### DIFF
--- a/charts/lerian-notification/Chart.yaml
+++ b/charts/lerian-notification/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: lerian-notification-helm
 description: Lerian Notification service - multi-channel delivery (email, SMS, webhook) for the Lerian platform
 type: application
+kubeVersion: ">=1.24.0-0"
 home: https://github.com/LerianStudio/helm
 sources:
   - https://github.com/LerianStudio/lerian-notification


### PR DESCRIPTION
# Lerian Helm Pull Request Checklist

## Pull Request Type

- [x] **lerian-notification**

## Summary

Adds the missing \`kubeVersion\` constraint to \`charts/lerian-notification/Chart.yaml\`. Two motivations:

1. **Helm best practice**: the chart uses \`policy/v1\` PodDisruptionBudget and \`autoscaling/v2\` HPA, both stable from Kubernetes 1.24+. Declaring \`kubeVersion: \">=1.24.0-0\"\` lets Helm refuse install on older clusters at \`helm install\` time instead of failing on an unknown API at apply time.
2. **Trigger the first chart release on develop**: the Helm Release workflow ignores \`README.md\` and \`.github/**\` changes, so the prior README fix in #1349 did not produce a release for this chart. This PR is the first chart-path commit on \`develop\` after onboarding, so semantic-release will compute and publish the initial beta tag (\`lerian-notification-v1.0.0-beta.1\`) usable by \`midaz-firmino-gitops\`.

## Changes

\`\`\`diff
 apiVersion: v2
 name: lerian-notification-helm
 description: ...
 type: application
+kubeVersion: ">=1.24.0-0"
\`\`\`

## Checklist

- [x] I have tested these changes locally (\`helm lint --strict\` passes).
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] I have updated the version appropriately (semantic-release will bump on merge).
- [x] I have confirmed this code is ready for review.

## Additional Notes

After merge, the Helm Release workflow will publish \`lerian-notification-helm 1.0.0-beta.1\` to \`oci://ghcr.io/lerianstudio\` and tag the repo \`lerian-notification-v1.0.0-beta.1\`. That tag is the input for the next PR in the sequence (\`midaz-firmino-gitops\`).

## Obs

PR targeted to \`develop\` per repo convention.