### PR TITLE
feat(lerian-notification): use /migrate binary in migrations Job

### DIFF
--- a/charts/lerian-notification/templates/migrations-job.yaml
+++ b/charts/lerian-notification/templates/migrations-job.yaml
@@ -3,12 +3,21 @@
   golang-migrate Job — runs as a Helm pre-install / pre-upgrade hook so DDL
   is applied before the API and workers attempt to connect.
 
-  Uses the API image because the service Dockerfile bundles /migrations
-  (COPY --from=builder /app/migrations /migrations). Override
-  .Values.migrations.image only when you build a dedicated migrations image.
+  Uses the API image because the service Dockerfile (starting at
+  lerian-notification v1.0.0-beta.2) bundles both /migrations and a
+  static /migrate binary alongside /api. The Job overrides the image
+  command to invoke /migrate directly — distroless has no shell, so the
+  binary is invoked with a fixed args list and DATABASE_URL is consumed
+  via $(DATABASE_URL) env substitution (handled by the kubelet, not a
+  shell).
 
-  The DATABASE_URL is constructed at runtime from the shared ConfigMap +
-  Secret so the Job stays consistent with whatever the app pods see.
+  DATABASE_URL must be supplied pre-built and URL-escaped by the
+  consumer — either inside .Values.secrets.DATABASE_URL (which the
+  ArgoCD Vault Plugin resolves at apply time) or, when an external
+  Secret is referenced via .Values.secretRef.name, as a DATABASE_URL
+  key in that Secret. The chart does not try to assemble the DSN from
+  POSTGRES_* values because a distroless Job has no shell to URL-encode
+  the password at runtime.
 */}}
 apiVersion: batch/v1
 kind: Job
@@ -53,43 +62,27 @@ spec:
           imagePullPolicy: {{ .Values.migrations.image.pullPolicy | default .Values.api.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.migrations.securityContext | nindent 12 }}
-          {{- /*
-            Env vars are inlined (not envFrom) because the chart's ConfigMap
-            and Secret are regular release resources applied AFTER hooks.
-            For secretRef.name (external Secret) we read POSTGRES_PASSWORD
-            via secretKeyRef; otherwise we fall back to the rendered Secret
-            values (which the ArgoCD Vault Plugin resolves at apply time).
-          */}}
           env:
-            - name: POSTGRES_HOST
-              value: {{ .Values.config.POSTGRES_HOST | quote }}
-            - name: POSTGRES_PORT
-              value: {{ .Values.config.POSTGRES_PORT | quote }}
-            - name: POSTGRES_USER
-              value: {{ .Values.config.POSTGRES_USER | quote }}
-            - name: POSTGRES_NAME
-              value: {{ .Values.config.POSTGRES_NAME | quote }}
-            - name: POSTGRES_SSLMODE
-              value: {{ .Values.config.POSTGRES_SSLMODE | quote }}
-            - name: POSTGRES_PASSWORD
+            - name: DATABASE_URL
               {{- if .Values.secretRef.name }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secretRef.name }}
-                  key: POSTGRES_PASSWORD
+                  key: DATABASE_URL
               {{- else }}
-              value: {{ .Values.secrets.POSTGRES_PASSWORD | quote }}
+              value: {{ .Values.secrets.DATABASE_URL | quote }}
               {{- end }}
           command:
-            - /bin/sh
-            - -ec
-            - |
-              # Build DSN from POSTGRES_* env vars. URL-encode the password so
-              # special characters survive the connection string.
-              PW_ENC=$(printf '%s' "${POSTGRES_PASSWORD}" | od -An -tx1 -v | tr -d ' \n' | sed 's/\(..\)/%\1/g')
-              DATABASE_URL="postgres://${POSTGRES_USER}:${PW_ENC}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}?sslmode=${POSTGRES_SSLMODE}"
-              echo "Running migrations against ${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME} (sslmode=${POSTGRES_SSLMODE})"
-              exec migrate -path /migrations -database "${DATABASE_URL}" {{ range .Values.migrations.extraArgs }}{{ . | quote }} {{ end }}up
+            - /migrate
+          args:
+            - "-path"
+            - "/migrations"
+            - "-database"
+            - "$(DATABASE_URL)"
+            {{- range .Values.migrations.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+            - "up"
           resources:
             {{- toYaml .Values.migrations.resources | nindent 12 }}
 {{- end }}

--- a/charts/lerian-notification/values.yaml
+++ b/charts/lerian-notification/values.yaml
@@ -249,6 +249,11 @@ extraConfig: {}
 # Sensitive env vars. Leave empty here; populate per-env via gitops + AVP, or
 # point `secretRef.name` at an externally-managed Secret to skip this entirely.
 secrets:
+  # -- DATABASE_URL is the pre-built, URL-escaped Postgres DSN consumed
+  # by the migrations Job (templates/migrations-job.yaml). Required when
+  # `migrations.enabled` is true. Format:
+  #   postgres://USER:URLENCODED_PW@HOST:PORT/DB?sslmode=disable
+  DATABASE_URL: ""
   # -- Postgres
   POSTGRES_PASSWORD: ""
   # -- Postgres replica (optional, leave empty if unused)


### PR DESCRIPTION
# Lerian Helm Pull Request Checklist

## Pull Request Type

- [x] **lerian-notification**

## Summary

Starting at `lerian-notification@v1.0.0-beta.2` (LerianStudio/lerian-notification#40, merged into develop), the API image bundles a static `/migrate` binary alongside `/api`. That removes the last reason the chart was abusing a distroless container with a `/bin/sh` wrapper, env-var URL encoding, and a hand-built DSN — none of which actually worked, because distroless has no shell at all.

The previous chart version (`1.0.0-beta.2`) shipped a Job that crashed on every first install with `exec: "/bin/sh": stat /bin/sh: no such file or directory` and forced migrations to be applied manually against the target Postgres (see [midaz-firmino-gitops#657](https://github.com/LerianStudio/midaz-firmino-gitops/pull/657)). With this PR, the Job runs to completion using only the binaries that ship in the api image.

## Changes

### `templates/migrations-job.yaml`

- Drop the `/bin/sh -ec` wrapper, the POSTGRES_* env hand-off, and the in-Job DSN construction.
- Invoke `/migrate` directly with a fixed args list. Kubelet performs `$(DATABASE_URL)` substitution; no shell required.
- `DATABASE_URL` is now the single source of truth, supplied pre-built and URL-escaped by the consumer:
  - When `.Values.secretRef.name` is set: read via `secretKeyRef` from that external Secret.
  - Otherwise: inlined from `.Values.secrets.DATABASE_URL`. The ArgoCD Vault Plugin resolves the `<path:...>` token at apply time, so plaintext never lands in the rendered manifest.
- `migrations.extraArgs` still slot in between `-database` and the trailing `up` for callers that need `-lock-timeout`, `-verbose`, etc.

Rendered Job command after this change:

```yaml
command:
  - /migrate
args:
  - -path
  - /migrations
  - -database
  - $(DATABASE_URL)
  - up
env:
  - name: DATABASE_URL
    value: <path:...>             # or valueFrom.secretKeyRef when secretRef.name is set
```

### `values.yaml`

- Add `DATABASE_URL: ""` to the default `secrets:` block, with a comment documenting the expected DSN shape:
  `postgres://USER:URLENCODED_PW@HOST:PORT/DB?sslmode=disable`.

## Validation

- `helm lint --strict charts/lerian-notification` — 0 failures.
- `helm template test charts/lerian-notification --set migrations.enabled=true` renders the Job with the new command/args/env shape and no shell wrapper.

## Consumer impact

Gitops values currently pinning `api.image.tag` to anything < `1.0.0-beta.2` must also bump the tag when adopting this chart bump — older images don't ship `/migrate` and the Job would fail to exec.

Existing migration consumers can:

1. Add `secrets.DATABASE_URL` to their values (Vault path recommended) **or** point `secretRef.name` at a Secret that already contains a `DATABASE_URL` key.
2. Drop the per-component `POSTGRES_*` references they were keeping just for the migrations Job.

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] I have updated the version appropriately (semantic-release will bump on merge).
- [x] I have confirmed this code is ready for review.

## Obs

PR targeted to `develop` per repo convention.
