### PR TITLE
docs(fetcher): add v2.2 upgrade guide

### DIFF
--- a/charts/fetcher/docs/UPGRADE-2.2.md
+++ b/charts/fetcher/docs/UPGRADE-2.2.md
@@ -1,0 +1,68 @@
+# Helm Upgrade from v2.1.x to v2.2.x
+## Topics
+- **[Overview](#overview)**- **[Version changes](#version-changes)**- **[Configuration changes](#configuration-changes)**- **[Template changes](#template-changes)**- **[Migration steps](#migration-steps)**- **[Preview changes before upgrading](#preview-changes-before-upgrading)**- **[Command to upgrade](#command-to-upgrade)**
+
+## Overview
+This guide covers the `fetcher` chart upgrade from `2.1.1` to `2.2.0-beta.4`. It was generated retroactively from the chart history and focuses on minor version changes; patch-only releases are intentionally ignored.
+
+Because this is a minor upgrade, the expected path is an in-place Helm upgrade after reviewing new values and changed defaults.
+
+## Version changes
+
+| Field | Previous | Current |
+|-------|----------|---------|
+| Chart version | `2.1.1` | `2.2.0-beta.4` |
+| App version | `1.3.0` | `1.3.0` |
+
+## Configuration changes
+
+### Added values
+
+_No direct values.yaml key changes detected._
+
+### Removed values
+
+_No direct values.yaml key changes detected._
+
+### Changed operational values
+
+_No image, env, secret, probe, ingress, service, port, or enablement changes detected in values.yaml._
+
+## Template changes
+
+### Added files
+
+- No chart files added.
+
+### Removed files
+
+- No chart files removed.
+
+### Modified files
+
+- `charts/fetcher/CHANGELOG.md`
+- `charts/fetcher/Chart.yaml`
+- `charts/fetcher/templates/manager/deployment.yaml`
+
+## Migration steps
+
+1. Read this guide and compare your custom values against `charts/fetcher/values.yaml`.
+2. Add any required new values for your environment, especially secrets, configmaps, probes, ingress, and service settings.
+3. Render the chart locally with your production values and review the manifest diff.
+4. Apply the upgrade in a controlled environment before production.
+
+## Preview changes before upgrading
+
+```bash
+helm diff upgrade fetcher ./charts/fetcher \
+  --namespace <namespace> \
+  --values <your-values.yaml>
+```
+
+## Command to upgrade
+
+```bash
+helm upgrade fetcher ./charts/fetcher \
+  --namespace <namespace> \
+  --values <your-values.yaml>
+```

--- a/charts/fetcher/docs/UPGRADE-2.2.md
+++ b/charts/fetcher/docs/UPGRADE-2.2.md
@@ -1,68 +1,99 @@
 # Helm Upgrade from v2.1.x to v2.2.x
+
 ## Topics
-- **[Overview](#overview)**- **[Version changes](#version-changes)**- **[Configuration changes](#configuration-changes)**- **[Template changes](#template-changes)**- **[Migration steps](#migration-steps)**- **[Preview changes before upgrading](#preview-changes-before-upgrading)**- **[Command to upgrade](#command-to-upgrade)**
+
+- **[Overview](#overview)**
+- **[Features](#features)**
+  - [1. Configurable liveness and readiness probe paths](#1-configurable-liveness-and-readiness-probe-paths)
+  - [2. New `successThreshold` knob on manager probes](#2-new-successthreshold-knob-on-manager-probes)
+- **[Configuration Changes](#configuration-changes)**
+- **[Migration Steps](#migration-steps)**
+- **[Preview changes before upgrading](#preview-changes-before-upgrading)**
+- **[Command to upgrade](#command-to-upgrade)**
 
 ## Overview
-This guide covers the `fetcher` chart upgrade from `2.1.1` to `2.2.0-beta.4`. It was generated retroactively from the chart history and focuses on minor version changes; patch-only releases are intentionally ignored.
 
-Because this is a minor upgrade, the expected path is an in-place Helm upgrade after reviewing new values and changed defaults.
+This guide covers the `fetcher` chart upgrade from `2.1.1` to `2.2.0-beta.4`. It is a minor maintenance release that makes the `manager` Deployment probes more flexible without changing existing behavior for users who do not override the new knobs.
 
-## Version changes
+The application image (`appVersion: 1.3.0`) is unchanged. No breaking changes, no required `values.yaml` modifications, and no data migration are needed.
 
-| Field | Previous | Current |
-|-------|----------|---------|
-| Chart version | `2.1.1` | `2.2.0-beta.4` |
-| App version | `1.3.0` | `1.3.0` |
+## Features
 
-## Configuration changes
+### 1. Configurable liveness and readiness probe paths
 
-### Added values
+The `manager` Deployment previously hard-coded `/health` for both liveness and readiness probes. Both paths are now configurable via values, with backwards-compatible defaults:
 
-_No direct values.yaml key changes detected._
+| Probe | v2.1.1 path | v2.2.0-beta.4 default | Override key |
+|-------|-------------|------------------------|--------------|
+| Liveness | `/health` | `/health` | `manager.livenessProbe.path` |
+| Readiness | `/health` | `/readyz` | `manager.readinessProbe.path` |
 
-### Removed values
+> **Note:** The readiness probe default changed from `/health` to `/readyz`. If your `fetcher-manager` image still serves readiness on `/health`, set `manager.readinessProbe.path: /health` explicitly before upgrading.
 
-_No direct values.yaml key changes detected._
+```yaml
+manager:
+  livenessProbe:
+    path: /health
+  readinessProbe:
+    path: /readyz
+```
 
-### Changed operational values
+### 2. New `successThreshold` knob on manager probes
 
-_No image, env, secret, probe, ingress, service, port, or enablement changes detected in values.yaml._
+Both probes now honor a `successThreshold` value. If omitted, it defaults to `1`, matching the previous implicit behavior.
 
-## Template changes
+```yaml
+manager:
+  livenessProbe:
+    successThreshold: 1
+  readinessProbe:
+    successThreshold: 1
+```
 
-### Added files
+## Configuration Changes
 
-- No chart files added.
+No `values.yaml` keys were added or removed. All new knobs are optional and fall back to safe defaults.
 
-### Removed files
+| Setting | v2.1.1 | v2.2.0-beta.4 |
+|---------|--------|---------------|
+| `manager.livenessProbe.path` | (hard-coded `/health`) | optional, defaults to `/health` |
+| `manager.readinessProbe.path` | (hard-coded `/health`) | optional, defaults to `/readyz` |
+| `manager.livenessProbe.successThreshold` | (not exposed) | optional, defaults to `1` |
+| `manager.readinessProbe.successThreshold` | (not exposed) | optional, defaults to `1` |
 
-- No chart files removed.
+## Migration Steps
 
-### Modified files
+This upgrade requires no manual migration steps. The Helm upgrade will roll the `manager` Deployment with the new probe template.
 
-- `charts/fetcher/CHANGELOG.md`
-- `charts/fetcher/Chart.yaml`
-- `charts/fetcher/templates/manager/deployment.yaml`
+**Recommended upgrade process:**
 
-## Migration steps
+1. Confirm which path your `fetcher-manager` image serves readiness on. If it is `/health`, pin it explicitly: `manager.readinessProbe.path: /health`.
+2. Review the changes using the helm-diff plugin (see [Preview changes before upgrading](#preview-changes-before-upgrading)).
+3. Run the upgrade command during a maintenance window.
+4. Verify the manager pods are healthy after the upgrade:
 
-1. Read this guide and compare your custom values against `charts/fetcher/values.yaml`.
-2. Add any required new values for your environment, especially secrets, configmaps, probes, ingress, and service settings.
-3. Render the chart locally with your production values and review the manifest diff.
-4. Apply the upgrade in a controlled environment before production.
+```bash
+kubectl get pods -n fetcher -l app.kubernetes.io/component=manager
+```
+
+5. Check manager logs for probe-related restarts:
+
+```bash
+kubectl logs -n fetcher -l app.kubernetes.io/component=manager --tail=50
+```
+
+> **Note:** A readiness probe pointing at a path the application does not serve will keep pods out of the Service endpoints. Verify the readiness path before upgrading in production.
 
 ## Preview changes before upgrading
 
 ```bash
-helm diff upgrade fetcher ./charts/fetcher \
-  --namespace <namespace> \
-  --values <your-values.yaml>
+helm diff upgrade fetcher oci://registry-1.docker.io/lerianstudio/fetcher-helm --version 2.2.0-beta.4 -n fetcher
 ```
+
+> **Note:** Requires the [helm-diff plugin](https://github.com/databus23/helm-diff). Install with: `helm plugin install https://github.com/databus23/helm-diff`
 
 ## Command to upgrade
 
 ```bash
-helm upgrade fetcher ./charts/fetcher \
-  --namespace <namespace> \
-  --values <your-values.yaml>
+helm upgrade fetcher oci://registry-1.docker.io/lerianstudio/fetcher-helm --version 2.2.0-beta.4 -n fetcher
 ```


### PR DESCRIPTION
## Summary
- Adds the retroactive minor upgrade guide for  from  to .
- Patch-only upgrade docs remain ignored, per task scope.

Requested by: @guimoreirar
