### PR TITLE
docs(otel-collector): add v3.1 upgrade guide

### DIFF
--- a/charts/otel-collector-lerian/docs/UPGRADE-3.1.md
+++ b/charts/otel-collector-lerian/docs/UPGRADE-3.1.md
@@ -1,0 +1,67 @@
+# Helm Upgrade from v3.0.x to v3.1.x
+## Topics
+- **[Overview](#overview)**- **[Version changes](#version-changes)**- **[Configuration changes](#configuration-changes)**- **[Template changes](#template-changes)**- **[Migration steps](#migration-steps)**- **[Preview changes before upgrading](#preview-changes-before-upgrading)**- **[Command to upgrade](#command-to-upgrade)**
+
+## Overview
+This guide covers the `otel-collector-lerian` chart upgrade from `3.0.0` to `3.1.0-beta.2`. It was generated retroactively from the chart history and focuses on minor version changes; patch-only releases are intentionally ignored.
+
+Because this is a minor upgrade, the expected path is an in-place Helm upgrade after reviewing new values and changed defaults.
+
+## Version changes
+
+| Field | Previous | Current |
+|-------|----------|---------|
+| Chart version | `3.0.0` | `3.1.0-beta.2` |
+| App version | `0.1.0` | `0.1.0` |
+
+## Configuration changes
+
+### Added values
+
+_No direct values.yaml key changes detected._
+
+### Removed values
+
+_No direct values.yaml key changes detected._
+
+### Changed operational values
+
+_No image, env, secret, probe, ingress, service, port, or enablement changes detected in values.yaml._
+
+## Template changes
+
+### Added files
+
+- No chart files added.
+
+### Removed files
+
+- No chart files removed.
+
+### Modified files
+
+- `charts/otel-collector-lerian/CHANGELOG.md`
+- `charts/otel-collector-lerian/Chart.yaml`
+
+## Migration steps
+
+1. Read this guide and compare your custom values against `charts/otel-collector-lerian/values.yaml`.
+2. Add any required new values for your environment, especially secrets, configmaps, probes, ingress, and service settings.
+3. Render the chart locally with your production values and review the manifest diff.
+4. Apply the upgrade in a controlled environment before production.
+
+## Preview changes before upgrading
+
+```bash
+helm diff upgrade otel-collector-lerian ./charts/otel-collector-lerian \
+  --namespace <namespace> \
+  --values <your-values.yaml>
+```
+
+## Command to upgrade
+
+```bash
+helm upgrade otel-collector-lerian ./charts/otel-collector-lerian \
+  --namespace <namespace> \
+  --values <your-values.yaml>
+```

--- a/charts/otel-collector-lerian/docs/UPGRADE-3.1.md
+++ b/charts/otel-collector-lerian/docs/UPGRADE-3.1.md
@@ -1,67 +1,75 @@
 # Helm Upgrade from v3.0.x to v3.1.x
+
 ## Topics
-- **[Overview](#overview)**- **[Version changes](#version-changes)**- **[Configuration changes](#configuration-changes)**- **[Template changes](#template-changes)**- **[Migration steps](#migration-steps)**- **[Preview changes before upgrading](#preview-changes-before-upgrading)**- **[Command to upgrade](#command-to-upgrade)**
+
+- **[Overview](#overview)**
+- **[Features](#features)**
+  - [1. Chart version bump to 3.1.0-beta.2](#1-chart-version-bump-to-310-beta2)
+- **[Configuration Changes](#configuration-changes)**
+- **[Migration Steps](#migration-steps)**
+- **[Preview changes before upgrading](#preview-changes-before-upgrading)**
+- **[Command to upgrade](#command-to-upgrade)**
 
 ## Overview
-This guide covers the `otel-collector-lerian` chart upgrade from `3.0.0` to `3.1.0-beta.2`. It was generated retroactively from the chart history and focuses on minor version changes; patch-only releases are intentionally ignored.
 
-Because this is a minor upgrade, the expected path is an in-place Helm upgrade after reviewing new values and changed defaults.
+This guide covers the `otel-collector-lerian` chart upgrade from `3.0.0` to `3.1.0-beta.2`. It is a maintenance release that bumps the chart version only. The application version (`appVersion: 0.1.0`) and all rendered manifests are unchanged.
 
-## Version changes
+There are no breaking changes, no new values, no removed values, and no template changes. Existing `values.yaml` overrides remain compatible.
 
-| Field | Previous | Current |
-|-------|----------|---------|
+## Features
+
+### 1. Chart version bump to 3.1.0-beta.2
+
+The chart version has been bumped from `3.0.0` to `3.1.0-beta.2`. No other chart files (templates, values, dependencies) were changed between these releases.
+
+| Field | v3.0.0 | v3.1.0-beta.2 |
+|-------|--------|---------------|
 | Chart version | `3.0.0` | `3.1.0-beta.2` |
 | App version | `0.1.0` | `0.1.0` |
 
-## Configuration changes
+Files modified between `3.0.0` and `3.1.0-beta.2`:
 
-### Added values
-
-_No direct values.yaml key changes detected._
-
-### Removed values
-
-_No direct values.yaml key changes detected._
-
-### Changed operational values
-
-_No image, env, secret, probe, ingress, service, port, or enablement changes detected in values.yaml._
-
-## Template changes
-
-### Added files
-
-- No chart files added.
-
-### Removed files
-
-- No chart files removed.
-
-### Modified files
-
-- `charts/otel-collector-lerian/CHANGELOG.md`
 - `charts/otel-collector-lerian/Chart.yaml`
+- `charts/otel-collector-lerian/CHANGELOG.md`
 
-## Migration steps
+> **Note:** `3.1.0-beta.2` is a pre-release. Pin the exact version when upgrading and validate in a non-production environment before promoting.
 
-1. Read this guide and compare your custom values against `charts/otel-collector-lerian/values.yaml`.
-2. Add any required new values for your environment, especially secrets, configmaps, probes, ingress, and service settings.
-3. Render the chart locally with your production values and review the manifest diff.
-4. Apply the upgrade in a controlled environment before production.
+## Configuration Changes
+
+No configuration changes are required. All existing `values.yaml` settings remain compatible with `3.1.0-beta.2`.
+
+| Setting | v3.0.0 | v3.1.0-beta.2 |
+|---------|--------|---------------|
+| `values.yaml` keys | (unchanged) | (unchanged) |
+| Templates | (unchanged) | (unchanged) |
+| Image references | (unchanged) | (unchanged) |
+
+## Migration Steps
+
+This upgrade requires no manual migration steps. The Helm upgrade will produce no changes to rendered manifests, so no rollout should occur.
+
+**Recommended upgrade process:**
+
+1. Review the rendered diff using the helm-diff plugin (see [Preview changes before upgrading](#preview-changes-before-upgrading)). Expect an empty diff.
+2. Run the upgrade command during a normal change window.
+3. Verify pod state is unchanged after the upgrade:
+
+```bash
+kubectl get pods -n otel-collector-lerian
+```
+
+> **Note:** Because no manifest fields change, Kubernetes should not perform a rollout. If a rollout occurs, capture the diff and report it before proceeding in production.
 
 ## Preview changes before upgrading
 
 ```bash
-helm diff upgrade otel-collector-lerian ./charts/otel-collector-lerian \
-  --namespace <namespace> \
-  --values <your-values.yaml>
+helm diff upgrade otel-collector-lerian oci://registry-1.docker.io/lerianstudio/otel-collector-lerian-helm --version 3.1.0-beta.2 -n otel-collector-lerian
 ```
+
+> **Note:** Requires the [helm-diff plugin](https://github.com/databus23/helm-diff). Install with: `helm plugin install https://github.com/databus23/helm-diff`
 
 ## Command to upgrade
 
 ```bash
-helm upgrade otel-collector-lerian ./charts/otel-collector-lerian \
-  --namespace <namespace> \
-  --values <your-values.yaml>
+helm upgrade otel-collector-lerian oci://registry-1.docker.io/lerianstudio/otel-collector-lerian-helm --version 3.1.0-beta.2 -n otel-collector-lerian
 ```


### PR DESCRIPTION
## Summary
- Adds the retroactive minor upgrade guide for  from  to .
- Patch-only upgrade docs remain ignored, per task scope.

Requested by: @guimoreirar
