### PR TITLE
refactor(plugins)!: rename plugin-br-payments PROVIDER_* values to BTG_*

### DIFF
--- a/charts/plugin-br-payments/CHANGELOG.md
+++ b/charts/plugin-br-payments/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this chart adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.2] — Unreleased
+
+### Changed
+
+- **BREAKING:** Renamed provider integration value keys from `PROVIDER_*` to `BTG_*`
+  to align with the names the `plugin-br-payments` binary actually reads
+  (`internal/bootstrap/config.go`). Affected keys:
+  - `app.configmap.PROVIDER_API_BASE_URL` → `app.configmap.BTG_API_BASE_URL`
+  - `app.configmap.PROVIDER_AUTH_URL` → `app.configmap.BTG_AUTH_URL`
+  - `app.configmap.PROVIDER_TOKEN_REFRESH_INTERVAL` → `app.configmap.BTG_TOKEN_REFRESH_INTERVAL`
+  - `app.secrets.PROVIDER_CLIENT_ID` → `app.secrets.BTG_CLIENT_ID`
+  - `app.secrets.PROVIDER_CLIENT_SECRET` → `app.secrets.BTG_CLIENT_SECRET`
+  - `app.secrets.PROVIDER_WEBHOOK_SECRET` → `app.secrets.BTG_WEBHOOK_SECRET`
+
+  Existing deployments must rename these keys in their values overlays in the
+  same change set that pins to chart version `1.0.0-beta.2` or later. The
+  previous `PROVIDER_*` keys were never consumed by the running binary, so the
+  token reconciliation worker remained idle in any environment that relied on
+  them.
+
 ## [0.1.0] — Unreleased
 
 ### Added

--- a/charts/plugin-br-payments/Chart.yaml
+++ b/charts/plugin-br-payments/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.9"

--- a/charts/plugin-br-payments/README.md
+++ b/charts/plugin-br-payments/README.md
@@ -46,13 +46,13 @@ The chart **fails fast** on `helm install` if any of the following are missing:
 | Field | Description |
 |-------|-------------|
 | `app.configmap.OUTBOX_ENABLED` | Must be `"true"`. The plugin only registers HTTP routes when the outbox is enabled. |
-| `app.configmap.PROVIDER_API_BASE_URL` | Provider API base URL. |
-| `app.configmap.PROVIDER_AUTH_URL` | Provider OAuth2 token URL. |
+| `app.configmap.BTG_API_BASE_URL` | BTG API base URL. |
+| `app.configmap.BTG_AUTH_URL` | BTG OAuth2 token URL. |
 | `app.configmap.MIDAZ_ONBOARDING_URL` | Midaz onboarding service URL. |
 | `app.configmap.MIDAZ_TRANSACTION_URL` | Midaz transaction service URL. |
-| `app.secrets.PROVIDER_CLIENT_ID` | Provider OAuth2 client ID. |
-| `app.secrets.PROVIDER_CLIENT_SECRET` | Provider OAuth2 client secret. |
-| `app.secrets.PROVIDER_WEBHOOK_SECRET` | Bearer token for incoming provider webhooks. |
+| `app.secrets.BTG_CLIENT_ID` | BTG OAuth2 client ID. |
+| `app.secrets.BTG_CLIENT_SECRET` | BTG OAuth2 client secret. |
+| `app.secrets.BTG_WEBHOOK_SECRET` | Bearer token for incoming BTG webhooks. |
 | `app.secrets.POSTGRES_PASSWORD` | PostgreSQL application password. |
 | `app.secrets.INTERNAL_API_KEY` | At least 32 characters. Required when `SERVICE_TYPE` includes worker (default `both`). Generate with `openssl rand -hex 32`. |
 | `app.secrets.CREDENTIAL_ENCRYPTION_KEY` | Base64-encoded AES-256 key. Required when `SERVICE_TYPE` includes worker. Generate with `openssl rand -base64 32`. |

--- a/charts/plugin-br-payments/templates/NOTES.txt
+++ b/charts/plugin-br-payments/templates/NOTES.txt
@@ -44,13 +44,13 @@ HTTP API + reconciliation worker + outbox dispatcher run as goroutines in one pr
 The following values MUST be set for the deployment to start successfully:
 
   - app.configmap.OUTBOX_ENABLED          (must be "true" — HTTP routes only register when the outbox is enabled)
-  - app.configmap.PROVIDER_API_BASE_URL   (provider API base URL)
-  - app.configmap.PROVIDER_AUTH_URL       (provider OAuth2 token URL)
+  - app.configmap.BTG_API_BASE_URL        (BTG API base URL)
+  - app.configmap.BTG_AUTH_URL            (BTG OAuth2 token URL)
   - app.configmap.MIDAZ_ONBOARDING_URL    (Midaz onboarding service URL)
   - app.configmap.MIDAZ_TRANSACTION_URL   (Midaz transaction service URL)
-  - app.secrets.PROVIDER_CLIENT_ID        (provider OAuth2 client ID)
-  - app.secrets.PROVIDER_CLIENT_SECRET    (provider OAuth2 client secret)
-  - app.secrets.PROVIDER_WEBHOOK_SECRET   (provider webhook bearer token)
+  - app.secrets.BTG_CLIENT_ID             (BTG OAuth2 client ID)
+  - app.secrets.BTG_CLIENT_SECRET         (BTG OAuth2 client secret)
+  - app.secrets.BTG_WEBHOOK_SECRET        (BTG webhook bearer token)
   - app.secrets.POSTGRES_PASSWORD         (PostgreSQL application password)
   - app.secrets.INTERNAL_API_KEY          (>=32 chars; required for SERVICE_TYPE=both/worker)
   - app.secrets.CREDENTIAL_ENCRYPTION_KEY (base64 AES-256; required for SERVICE_TYPE=both/worker)

--- a/charts/plugin-br-payments/templates/_helpers.tpl
+++ b/charts/plugin-br-payments/templates/_helpers.tpl
@@ -136,25 +136,25 @@ plugin-br-payments README.
 {{- fail "\n\nERROR: app.configmap.OUTBOX_ENABLED must be \"true\".\n   plugin-br-payments only registers its routes when the outbox pattern is enabled.\n   See README -> 'Local Development Config'.\n" }}
 {{- end }}
 
-{{/* Provider integration — required for any write operation */}}
-{{- if not .Values.app.configmap.PROVIDER_API_BASE_URL }}
-{{- fail "\n\nERROR: app.configmap.PROVIDER_API_BASE_URL is REQUIRED.\n   Set the provider API base URL (e.g., https://api.btgpactual.com).\n" }}
+{{/* BTG provider integration — required for any write operation */}}
+{{- if not .Values.app.configmap.BTG_API_BASE_URL }}
+{{- fail "\n\nERROR: app.configmap.BTG_API_BASE_URL is REQUIRED.\n   Set the BTG API base URL (e.g., https://api.btgpactual.com).\n" }}
 {{- end }}
 
-{{- if not .Values.app.configmap.PROVIDER_AUTH_URL }}
-{{- fail "\n\nERROR: app.configmap.PROVIDER_AUTH_URL is REQUIRED.\n   Set the provider OAuth2 token endpoint URL.\n" }}
+{{- if not .Values.app.configmap.BTG_AUTH_URL }}
+{{- fail "\n\nERROR: app.configmap.BTG_AUTH_URL is REQUIRED.\n   Set the BTG OAuth2 token endpoint URL.\n" }}
 {{- end }}
 
-{{- if not .Values.app.secrets.PROVIDER_CLIENT_ID }}
-{{- fail "\n\nERROR: app.secrets.PROVIDER_CLIENT_ID is REQUIRED.\n   Set the provider OAuth2 client ID in the secrets section.\n" }}
+{{- if not .Values.app.secrets.BTG_CLIENT_ID }}
+{{- fail "\n\nERROR: app.secrets.BTG_CLIENT_ID is REQUIRED.\n   Set the BTG OAuth2 client ID in the secrets section.\n" }}
 {{- end }}
 
-{{- if not .Values.app.secrets.PROVIDER_CLIENT_SECRET }}
-{{- fail "\n\nERROR: app.secrets.PROVIDER_CLIENT_SECRET is REQUIRED.\n   Set the provider OAuth2 client secret in the secrets section.\n" }}
+{{- if not .Values.app.secrets.BTG_CLIENT_SECRET }}
+{{- fail "\n\nERROR: app.secrets.BTG_CLIENT_SECRET is REQUIRED.\n   Set the BTG OAuth2 client secret in the secrets section.\n" }}
 {{- end }}
 
-{{- if not .Values.app.secrets.PROVIDER_WEBHOOK_SECRET }}
-{{- fail "\n\nERROR: app.secrets.PROVIDER_WEBHOOK_SECRET is REQUIRED.\n   Set the provider webhook bearer token in the secrets section.\n" }}
+{{- if not .Values.app.secrets.BTG_WEBHOOK_SECRET }}
+{{- fail "\n\nERROR: app.secrets.BTG_WEBHOOK_SECRET is REQUIRED.\n   Set the BTG webhook bearer token in the secrets section.\n" }}
 {{- end }}
 
 {{/* Midaz Ledger URLs — required for production */}}

--- a/charts/plugin-br-payments/values-template.yaml
+++ b/charts/plugin-br-payments/values-template.yaml
@@ -31,9 +31,9 @@ app:
     # External PostgreSQL — leave empty here only if postgresql.enabled=true.
     POSTGRES_HOST: ""
     POSTGRES_SSLMODE: "require"
-    # Provider integration (REQUIRED)
-    PROVIDER_API_BASE_URL: ""
-    PROVIDER_AUTH_URL: ""
+    # BTG Provider integration (REQUIRED)
+    BTG_API_BASE_URL: ""
+    BTG_AUTH_URL: ""
     # Midaz Ledger (REQUIRED)
     MIDAZ_ONBOARDING_URL: ""
     MIDAZ_TRANSACTION_URL: ""
@@ -49,10 +49,10 @@ app:
   secrets:
     # Database
     POSTGRES_PASSWORD: ""        # REQUIRED
-    # Provider OAuth2 (REQUIRED)
-    PROVIDER_CLIENT_ID: ""
-    PROVIDER_CLIENT_SECRET: ""
-    PROVIDER_WEBHOOK_SECRET: ""
+    # BTG OAuth2 (REQUIRED)
+    BTG_CLIENT_ID: ""
+    BTG_CLIENT_SECRET: ""
+    BTG_WEBHOOK_SECRET: ""
     # Internal cross-pod API (REQUIRED for SERVICE_TYPE=both/worker)
     # Generate with: openssl rand -hex 32   (>=32 chars)
     INTERNAL_API_KEY: ""

--- a/charts/plugin-br-payments/values.yaml
+++ b/charts/plugin-br-payments/values.yaml
@@ -231,10 +231,10 @@ app:
     # Authentication (lib-auth + plugin-auth)
     PLUGIN_AUTH_ENABLED: "true"
     PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
-    # Provider Integration (REQUIRED - validated by helper)
-    PROVIDER_API_BASE_URL: ""
-    PROVIDER_AUTH_URL: ""
-    PROVIDER_TOKEN_REFRESH_INTERVAL: "1h"
+    # BTG Provider Integration (REQUIRED - validated by helper)
+    BTG_API_BASE_URL: ""
+    BTG_AUTH_URL: ""
+    BTG_TOKEN_REFRESH_INTERVAL: "1h"
     # Midaz Ledger URLs (REQUIRED for production - validated by helper)
     MIDAZ_ONBOARDING_URL: ""
     MIDAZ_TRANSACTION_URL: ""
@@ -271,10 +271,10 @@ app:
     # PostgreSQL credentials
     POSTGRES_PASSWORD: "lerian"
     # POSTGRES_REPLICA_PASSWORD: ""
-    # Provider OAuth2 (REQUIRED)
-    PROVIDER_CLIENT_ID: ""
-    PROVIDER_CLIENT_SECRET: ""
-    PROVIDER_WEBHOOK_SECRET: ""
+    # BTG OAuth2 (REQUIRED)
+    BTG_CLIENT_ID: ""
+    BTG_CLIENT_SECRET: ""
+    BTG_WEBHOOK_SECRET: ""
     # Internal cross-pod API (REQUIRED when SERVICE_TYPE includes worker, i.e. "both" or "worker").
     # Must be at least 32 characters. Generate with: openssl rand -hex 32
     INTERNAL_API_KEY: ""


### PR DESCRIPTION
## Summary

Renames the chart's provider integration value keys from `PROVIDER_*` to `BTG_*` across `charts/plugin-br-payments/` to match the env var names the deployed binary actually reads. Bumps chart version `1.0.0-beta.1` → `1.0.0-beta.2`.

## Motivation

The chart's `_helpers.tpl` declares the following keys as REQUIRED (fail-fast on `helm template`):

- `app.configmap.PROVIDER_API_BASE_URL`
- `app.configmap.PROVIDER_AUTH_URL`
- `app.secrets.PROVIDER_CLIENT_ID`
- `app.secrets.PROVIDER_CLIENT_SECRET`
- `app.secrets.PROVIDER_WEBHOOK_SECRET`

But the binary at `LerianStudio/plugin-br-payments/internal/bootstrap/config.go:286-293` reads only:

- `BTG_API_BASE_URL`
- `BTG_AUTH_URL`
- `BTG_CLIENT_ID`
- `BTG_CLIENT_SECRET`
- `BTG_WEBHOOK_SECRET`
- `BTG_TOKEN_REFRESH_INTERVAL`

The `PROVIDER_*` keys are emitted into the pod's ConfigMap/Secret as env vars, but the binary ignores them. As a result, the token reconciliation worker's `isProviderAuthComplete` gate fails fast on every startup and the worker has been silently idle in every environment that uses this chart.

There is exactly one known consumer today: `LerianStudio/midaz-firmino-gitops/environments/firmino/helmfile/applications/dev/plugin-br-payments/values.yaml`. A follow-up PR there will rename the keys in lockstep with bumping the helmfile chart version to `1.0.0-beta.2`.

## Files changed (7)

| File | Change |
|------|--------|
| `Chart.yaml` | `version: 1.0.0-beta.1` → `1.0.0-beta.2` |
| `values.yaml` | rename the 6 keys in `app.configmap` + `app.secrets`; update section comments |
| `values-template.yaml` | rename the 6 keys in the production overlay starter |
| `templates/_helpers.tpl` | rename the 6 keys in the validateRequired block; update error messages to refer to BTG names |
| `templates/NOTES.txt` | rename the 5 displayed keys in the operator hints block |
| `README.md` | rename the 5 entries in the required-configuration table |
| `CHANGELOG.md` | new \`## [1.0.0-beta.2] — Unreleased\` entry documenting the breaking key rename |

\`EXAMPLE_STATUS_PROVIDER_MODE\` in \`values.yaml:267\` is intentionally **not** renamed — it is unrelated (a resilience example flag, not a provider integration env var).

## Breaking change handling

This is a backward-incompatible chart values rename. The chart is in beta (\`1.0.0-beta.*\`), so the \`-beta.2\` bump is acceptable per semver-on-beta convention. Any deployment using the previous \`PROVIDER_*\` keys must rename in the same change set that pins the new chart version. Today that is one repo and one file (the gitops PR is already drafted).

## Linked / follow-up

- Follow-up: \`LerianStudio/midaz-firmino-gitops\` PR — rename \`PROVIDER_*\` → \`BTG_*\` in \`environments/firmino/helmfile/applications/dev/plugin-br-payments/values.yaml\` and bump \`version: "1.0.0-beta.1"\` → \`"1.0.0-beta.2"\` in \`helmfile.yaml\`. Must NOT merge before this one.