### PR TITLE
feat(plugins): initial chart for plugin-br-payments-fakebtg BTG mock

### DIFF
--- a/charts/plugin-br-payments-fakebtg/CHANGELOG.md
+++ b/charts/plugin-br-payments-fakebtg/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this chart adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — Unreleased
+
+### Added
+
+- Initial Helm chart for `plugin-br-payments-fakebtg`, a stand-in HTTP server
+  that mocks the BTG provider API surface for dev/staging environments without
+  access to the real BTG sandbox.
+- Single Deployment + Service (ClusterIP, port 8090). Optional Ingress for
+  external integrators reaching the `/admin/*` and `/inspect/*` endpoints.
+- HTTP `GET /health` wired to both readiness and liveness probes.
+- Distroless nonroot security context with read-only root filesystem and all
+  capabilities dropped.
+- ServiceAccount auto-created by default; override with `fakebtg.serviceAccount`.

--- a/charts/plugin-br-payments-fakebtg/Chart.yaml
+++ b/charts/plugin-br-payments-fakebtg/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: plugin-br-payments-fakebtg-helm
+description: A Helm chart for fakebtg, the BTG provider API stand-in used by plugin-br-payments dev/staging environments
+type: application
+home: https://github.com/LerianStudio/helm
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/plugin-br-payments-fakebtg
+  - https://github.com/LerianStudio/plugin-br-payments/tree/main/cmd/fakebtg
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+
+version: 0.1.0
+appVersion: "1.0.0-beta.20"
+
+keywords:
+  - midaz
+  - lerian
+  - plugins
+  - payments
+  - boleto
+  - mock
+  - test-double
+
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4

--- a/charts/plugin-br-payments-fakebtg/README.md
+++ b/charts/plugin-br-payments-fakebtg/README.md
@@ -1,0 +1,96 @@
+# plugin-br-payments-fakebtg-helm
+
+A Helm chart for [fakebtg](https://github.com/LerianStudio/plugin-br-payments/tree/main/cmd/fakebtg) — a stand-in HTTP server that mocks the BTG provider API surface for use in dev/staging environments without access to the real BTG sandbox.
+
+> Dev/staging only. Do **not** install in production.
+
+## TL;DR
+
+```bash
+helm install fakebtg oci://ghcr.io/lerianstudio/plugin-br-payments-fakebtg-helm \
+  --namespace midaz-plugins --create-namespace
+```
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.10+
+
+## Architecture
+
+The chart deploys **one Deployment, one pod** running the `/fakebtg` binary on a distroless nonroot image. It listens on port `8090` by default (override with the `FAKEBTG_PORT` env var via `fakebtg.extraEnvVars`). There is no persistent state and no external dependency.
+
+## Endpoints
+
+- `GET /health` — liveness/readiness probe target (also `/fakebtg healthcheck` CLI subcommand)
+- BTG provider surface:
+  - `POST /oauth/token`
+  - `POST /{companyId}/banking/collections`
+  - `POST /{companyId}/banking/payments`
+  - `GET /{companyId}/banking/payments`
+- Chaos / scenario control (for external testers):
+  - `POST /admin/set-error`
+  - `POST /admin/set-latency`
+  - `POST /admin/clear-error`
+  - `POST /admin/clear-latency`
+  - `POST /admin/reset`
+- Inspection:
+  - `GET /inspect/calls`, `DELETE /inspect/calls`
+- Inbound webhook recording:
+  - `POST /webhook-receiver`, `GET /inspect/webhook-receiver`
+
+## Required configuration
+
+None. fakebtg starts with no env vars set and exposes `GET /health` on port `8090`.
+
+## Common values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `fakebtg.replicaCount` | `1` | Number of replicas. Keep at 1 — scenario state is in-memory. |
+| `fakebtg.image.repository` | `ghcr.io/lerianstudio/plugin-br-payments-fakebtg` | Container image. |
+| `fakebtg.image.tag` | `""` (Chart `appVersion`) | Image tag. |
+| `fakebtg.service.type` | `ClusterIP` | Service type. |
+| `fakebtg.service.port` | `8090` | Service port. |
+| `fakebtg.ingress.enabled` | `false` | Expose via Ingress for external testers. |
+| `fakebtg.extraEnvVars` | `{}` | Extra env vars (e.g., `FAKEBTG_PORT: ":9000"`). |
+
+See [`values.yaml`](./values.yaml) for the full list.
+
+## Ingress
+
+External integrators that need to hit `/admin/*` for chaos scenarios can expose fakebtg via Ingress:
+
+```yaml
+fakebtg:
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: fakebtg.staging.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+```
+
+## Probes
+
+| Probe | Path | Notes |
+|-------|------|-------|
+| Liveness | `/health` | Returns 200 once the HTTP server is up. |
+| Readiness | `/health` | Same endpoint; no external deps to gate on. |
+
+## Uninstall
+
+```bash
+helm uninstall fakebtg -n midaz-plugins
+```
+
+## Source
+
+- Binary source: https://github.com/LerianStudio/plugin-br-payments/tree/main/cmd/fakebtg
+- Chart source:  https://github.com/LerianStudio/helm/tree/main/charts/plugin-br-payments-fakebtg
+
+## License
+
+[Apache 2.0](../../LICENSE) (chart). The `plugin-br-payments` application itself is licensed under the [Elastic License 2.0](https://github.com/LerianStudio/plugin-br-payments/blob/main/LICENSE.md).

--- a/charts/plugin-br-payments-fakebtg/templates/NOTES.txt
+++ b/charts/plugin-br-payments-fakebtg/templates/NOTES.txt
@@ -1,0 +1,30 @@
+# Plugin BR Payments — fakebtg
+
+Thank you for installing {{ .Chart.Name }} v{{ .Chart.Version }} (appVersion {{ .Chart.AppVersion }}).
+
+The fakebtg service is reachable in-cluster at:
+
+  http://{{ include "plugin-br-payments-fakebtg.fullname" . }}.{{ include "global.namespace" . }}.svc.cluster.local:{{ .Values.fakebtg.service.port }}
+
+Probe target: GET /health
+
+
+# Chaos / Scenario Endpoints
+
+fakebtg exposes admin endpoints for runtime injection of errors and latency:
+
+  POST /admin/set-error      — inject a specific error response for a route
+  POST /admin/set-latency    — inject artificial latency
+  POST /admin/clear-error    — clear an injected error
+  POST /admin/clear-latency  — clear injected latency
+  POST /admin/reset          — reset all injected scenarios
+  GET  /inspect/calls        — list recorded inbound requests
+  DELETE /inspect/calls      — clear the request log
+
+
+# Reminder
+
+fakebtg is a test double for dev/staging only. Do NOT use this chart in
+production. The real BTG provider must be reached via plugin-br-payments'
+PROVIDER_API_BASE_URL configuration pointing at the actual BTG sandbox or
+production endpoints.

--- a/charts/plugin-br-payments-fakebtg/templates/_helpers.tpl
+++ b/charts/plugin-br-payments-fakebtg/templates/_helpers.tpl
@@ -1,0 +1,106 @@
+{{/*
+================================================================================
+PLUGIN BR PAYMENTS FAKEBTG - HELM TEMPLATE HELPERS
+================================================================================
+Stand-in HTTP server that mocks the BTG provider API surface for dev/staging.
+Single Deployment, single pod, no dependencies.
+================================================================================
+*/}}
+
+{{/*
+================================================================================
+NAME HELPERS
+================================================================================
+*/}}
+
+{{/*
+Top-level chart name.
+*/}}
+{{- define "plugin-br-payments-fakebtg.name" -}}
+{{- default "plugin-br-payments-fakebtg" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Application name (single deployment).
+*/}}
+{{- define "plugin-br-payments-fakebtg.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- default "plugin-br-payments-fakebtg" .Values.fakebtg.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+================================================================================
+CHART HELPERS
+================================================================================
+*/}}
+
+{{- define "plugin-br-payments-fakebtg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Resolve the application image tag (Chart.appVersion if fakebtg.image.tag is empty).
+*/}}
+{{- define "plugin-br-payments-fakebtg.defaultTag" -}}
+{{- default .Chart.AppVersion .Values.fakebtg.image.tag }}
+{{- end -}}
+
+{{/*
+Sanitize tag for use in app.kubernetes.io/version label.
+*/}}
+{{- define "plugin-br-payments-fakebtg.versionLabelValue" -}}
+{{ regexReplaceAll "[^-A-Za-z0-9_.]" (include "plugin-br-payments-fakebtg.defaultTag" .) "-" | trunc 63 | trimAll "-" | trimAll "_" | trimAll "." | quote }}
+{{- end -}}
+
+{{/*
+================================================================================
+LABEL HELPERS
+================================================================================
+*/}}
+
+{{/*
+Common labels.
+Usage: {{ include "plugin-br-payments-fakebtg.labels" (dict "context" .) }}
+*/}}
+{{- define "plugin-br-payments-fakebtg.labels" -}}
+helm.sh/chart: {{ include "plugin-br-payments-fakebtg.chart" .context }}
+{{ include "plugin-br-payments-fakebtg.selectorLabels" (dict "context" .context) }}
+app.kubernetes.io/version: {{ include "plugin-br-payments-fakebtg.versionLabelValue" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: plugin-br-payments
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "plugin-br-payments-fakebtg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "plugin-br-payments-fakebtg.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- end }}
+
+{{/*
+================================================================================
+SERVICE ACCOUNT HELPER
+================================================================================
+*/}}
+
+{{- define "plugin-br-payments-fakebtg.serviceAccountName" -}}
+{{- if .Values.fakebtg.serviceAccount.create }}
+{{- default (include "plugin-br-payments-fakebtg.fullname" .) .Values.fakebtg.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.fakebtg.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+================================================================================
+NAMESPACE HELPER
+================================================================================
+*/}}
+
+{{- define "global.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}

--- a/charts/plugin-br-payments-fakebtg/templates/deployment.yaml
+++ b/charts/plugin-br-payments-fakebtg/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "plugin-br-payments-fakebtg.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments-fakebtg.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.fakebtg.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.fakebtg.revisionHistoryLimit | default 5 }}
+  {{- with .Values.fakebtg.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  replicas: {{ .Values.fakebtg.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-payments-fakebtg.selectorLabels" (dict "context" .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "plugin-br-payments-fakebtg.labels" (dict "context" .) | nindent 8 }}
+      {{- with .Values.fakebtg.podAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- with .Values.fakebtg.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "plugin-br-payments-fakebtg.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.fakebtg.terminationGracePeriodSeconds | default 10 }}
+      {{- with .Values.fakebtg.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "plugin-br-payments-fakebtg.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.fakebtg.securityContext | nindent 12 }}
+          image: "{{ .Values.fakebtg.image.repository }}:{{ .Values.fakebtg.image.tag | default (include "plugin-br-payments-fakebtg.defaultTag" .) }}"
+          imagePullPolicy: {{ .Values.fakebtg.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.fakebtg.service.targetPort }}
+              protocol: TCP
+          {{- with .Values.fakebtg.extraEnvVars }}
+          env:
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.fakebtg.resources | nindent 12 }}
+          # fakebtg exposes a single GET /health endpoint used for both probes.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.fakebtg.readinessProbe.initialDelaySeconds | default 2 }}
+            periodSeconds: {{ .Values.fakebtg.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ .Values.fakebtg.readinessProbe.timeoutSeconds | default 2 }}
+            successThreshold: {{ .Values.fakebtg.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.fakebtg.readinessProbe.failureThreshold | default 2 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.fakebtg.livenessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.fakebtg.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.fakebtg.livenessProbe.timeoutSeconds | default 2 }}
+            successThreshold: {{ .Values.fakebtg.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.fakebtg.livenessProbe.failureThreshold | default 3 }}
+      {{- with .Values.fakebtg.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.fakebtg.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.fakebtg.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/plugin-br-payments-fakebtg/templates/ingress.yaml
+++ b/charts/plugin-br-payments-fakebtg/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.fakebtg.ingress.enabled -}}
+{{- $fullName := include "plugin-br-payments-fakebtg.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments-fakebtg.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.fakebtg.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.fakebtg.ingress.className }}
+  ingressClassName: {{ .Values.fakebtg.ingress.className }}
+  {{- end }}
+  {{- with .Values.fakebtg.ingress.tls }}
+  tls:
+    {{- range . }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.fakebtg.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/plugin-br-payments-fakebtg/templates/service.yaml
+++ b/charts/plugin-br-payments-fakebtg/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "plugin-br-payments-fakebtg.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments-fakebtg.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.fakebtg.service.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.fakebtg.service.type }}
+  ports:
+    - port: {{ .Values.fakebtg.service.port }}
+      targetPort: {{ .Values.fakebtg.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "plugin-br-payments-fakebtg.selectorLabels" (dict "context" .) | nindent 4 }}

--- a/charts/plugin-br-payments-fakebtg/templates/serviceaccount.yaml
+++ b/charts/plugin-br-payments-fakebtg/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.fakebtg.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "plugin-br-payments-fakebtg.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-payments-fakebtg.labels" (dict "context" .) | nindent 4 }}
+  {{- with .Values.fakebtg.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-payments-fakebtg/values.yaml
+++ b/charts/plugin-br-payments-fakebtg/values.yaml
@@ -1,0 +1,143 @@
+# Default values for plugin-br-payments-fakebtg.
+# A stand-in HTTP server that mocks the BTG provider API surface for use in
+# dev/staging environments without access to the real BTG sandbox. Single
+# Deployment, single replica, no persistent state, ClusterIP service. The
+# admin/* endpoints support runtime injection of errors and latency for
+# chaos/scenario testing by external integrators.
+
+# -- Override the chart top-level name
+nameOverride: "plugin-br-payments-fakebtg"
+# -- Override the fully generated name
+fullnameOverride: ""
+# -- Override the namespace used by templates
+namespaceOverride: ""
+
+# ==============================================================================
+# APPLICATION
+# Single Deployment running the /fakebtg binary on a distroless nonroot image.
+# No required env vars; defaults to listening on :8090.
+# ==============================================================================
+fakebtg:
+  # -- Service name
+  name: "plugin-br-payments-fakebtg"
+  # -- Number of replicas (fakebtg holds in-memory scenario state; keep at 1)
+  replicaCount: 1
+  # -- Number of old ReplicaSets to retain for rollback
+  revisionHistoryLimit: 5
+
+  # -- Container image
+  image:
+    # -- Image repository
+    repository: ghcr.io/lerianstudio/plugin-br-payments-fakebtg
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+    # -- Image tag (defaults to Chart.appVersion when empty)
+    tag: ""
+  # -- Image pull secrets for private registries
+  imagePullSecrets: []
+
+  # -- Annotations applied to the Deployment resource
+  annotations: {}
+  # -- Annotations applied to the pods
+  podAnnotations: {}
+
+  # -- Termination grace period; fakebtg has no drain, short window is enough
+  terminationGracePeriodSeconds: 10
+
+  # -- Pod-level securityContext
+  podSecurityContext: {}
+  # -- Container-level securityContext
+  # Distroless nonroot UID/GID is 65532; the binary does not need to write
+  # to the filesystem, so the root FS is mounted read-only.
+  securityContext:
+    runAsGroup: 65532
+    runAsUser: 65532
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+
+  # -- Rolling update strategy
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  # -- Service configuration (ClusterIP only by default)
+  service:
+    # -- Service type
+    type: ClusterIP
+    # -- Service port
+    port: 8090
+    # -- Container target port
+    targetPort: 8090
+    # -- Annotations applied to the Service
+    annotations: {}
+
+  # -- Optional Ingress for external integrators reaching /admin/* and /inspect/*
+  ingress:
+    # -- Enable Ingress
+    enabled: false
+    # -- IngressClass name (e.g., "nginx")
+    className: ""
+    # -- Ingress annotations
+    annotations: {}
+    # -- Ingress hosts
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    # -- Ingress TLS
+    tls: []
+
+  # -- Container resource requests/limits
+  resources:
+    limits:
+      cpu: 200m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+  # -- Readiness probe against GET /health
+  readinessProbe:
+    initialDelaySeconds: 2
+    periodSeconds: 5
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 2
+  # -- Liveness probe against GET /health
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 2
+    successThreshold: 1
+    failureThreshold: 3
+
+  # -- Pod nodeSelector
+  nodeSelector: {}
+  # -- Pod tolerations
+  tolerations: []
+  # -- Pod affinity rules
+  affinity: {}
+
+  # -- Extra environment variables (e.g., FAKEBTG_PORT to override the default :8090)
+  extraEnvVars: {}
+
+  # -- ServiceAccount used by the pod
+  serviceAccount:
+    # -- Create a dedicated ServiceAccount
+    create: true
+    # -- Annotations applied to the ServiceAccount
+    annotations: {}
+    # -- Override the generated ServiceAccount name
+    name: ""
+
+# Tag block at end of file for image-update tooling (mirrors plugin-br-payments).
+plugin-br-payments-fakebtg:
+  image:
+    tag: 1.0.0-beta.20


### PR DESCRIPTION
## Summary

Adds a new Helm chart `plugin-br-payments-fakebtg` that deploys `cmd/fakebtg` from [LerianStudio/plugin-br-payments](https://github.com/LerianStudio/plugin-br-payments/tree/main/cmd/fakebtg) as a stand-in for the real BTG provider API. Auto-publishes to `oci://ghcr.io/lerianstudio/plugin-br-payments-fakebtg-helm` via the existing release pipeline.

## Motivation

Several upcoming dev/staging onboarding scenarios need a deployable BTG mock:
- External integrators (next up: Taura) need to test plugin-br-payments before real BTG sandbox access is provisioned
- Smoke testing in environments where the real BTG sandbox is not reachable or has rate limits
- Chaos / scenario testing via fakebtg's `/admin/set-error`, `/admin/set-latency`, `/admin/reset` endpoints

The fakebtg image was already buildable from `cmd/fakebtg/Dockerfile` for the e2e docker-compose stack but had no published image until [plugin-br-payments PR #138](https://github.com/LerianStudio/plugin-br-payments/pull/138) added the CI `build-fakebtg` job. With the image being published on every beta tag, this chart is the deployment surface that completes the loop.

## Chart shape

| Aspect | Choice |
|--------|--------|
| Workload | 1 Deployment, 1 replica |
| Service | ClusterIP, port 8090 (matches `cmd/fakebtg/main.go` default) |
| Ingress | Optional, disabled by default. Enable when integrators need to reach `/admin/*` directly |
| Probes | HTTP `GET /health` for both readiness and liveness |
| Security | Distroless nonroot UID/GID 65532, read-only rootfs, all capabilities dropped |
| Required values | None — chart renders cleanly with defaults |
| Image tag default | `Chart.appVersion` (`1.0.0-beta.20`) — overridable via `fakebtg.image.tag` |
| Resource requests | 50m CPU / 64Mi memory — generous headroom for a stateless mock |
| Dependencies | None (no postgres subchart, no HPA, no PDB — single replica is intentional) |

## Files added (10)

```
charts/plugin-br-payments-fakebtg/
├── Chart.yaml
├── values.yaml
├── README.md
├── CHANGELOG.md
└── templates/
    ├── _helpers.tpl
    ├── deployment.yaml
    ├── service.yaml
    ├── serviceaccount.yaml
    ├── ingress.yaml
    └── NOTES.txt
```

No changes to any existing chart.

## Open question for reviewers

`values.yaml` ends with a trailing image-update marker block (mirrors the pattern from `charts/plugin-br-payments/values.yaml`):

```yaml
plugin-br-payments-fakebtg:
  image:
    tag: 1.0.0-beta.20
```

I kept this for consistency with the neighbouring chart, but I am not certain which image-update tooling reads this block versus the `fakebtg.image.tag` key. If the image bumper only updates the latter, this block is dead. Please flag during review and I will remove it (or, if it is needed, both keys should be bumped together — confirm please).

## Test plan

- [ ] `helm template charts/plugin-br-payments-fakebtg` renders cleanly with default values
- [ ] `helm template charts/plugin-br-payments-fakebtg --set fakebtg.ingress.enabled=true --set fakebtg.ingress.hosts[0].host=fakebtg.dev.example.com --set fakebtg.ingress.hosts[0].paths[0].path=/ --set fakebtg.ingress.hosts[0].paths[0].pathType=Prefix` renders the Ingress resource
- [ ] `helm lint charts/plugin-br-payments-fakebtg` passes
- [ ] After merge, confirm the OCI image at `oci://ghcr.io/lerianstudio/plugin-br-payments-fakebtg-helm` is published by the existing `release.yml` workflow
- [ ] Follow-up: gitops PR in `LerianStudio/midaz-firmino-gitops` will pin to the first published version and wire the plugin to consume it (already drafted locally; opens after this PR publishes)

## Linked / follow-up

- Upstream: [plugin-br-payments PR #138](https://github.com/LerianStudio/plugin-br-payments/pull/138) (merged) — the CI that publishes the fakebtg image
- Follow-up: gitops PR adding the `fakebtg` application in `environments/firmino/helmfile/applications/dev/` (drafted locally, pending this merge + image publication)
- Related: [LerianStudio/helm#1403](https://github.com/LerianStudio/helm/pull/1403) — independent chart fix (PROVIDER_* → BTG_* rename in plugin-br-payments chart). Orthogonal to this PR; merge order does not matter between the two.