### PR TITLE
fix(templates): set go-boilerplate-ddd readinessProbe path to /readyz

### DIFF
--- a/charts/go-boilerplate-ddd/templates/deployment.yaml
+++ b/charts/go-boilerplate-ddd/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /readyz
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10


### PR DESCRIPTION
## Summary

- Chart's `readinessProbe` path was `/ready` but the boilerplate app only exposes `/readyz` (canonical Lerian Ring endpoint).
- Without this fix, pods never reach Ready state in any environment — readiness gating blocks first sync.

## Source-of-truth verification

Confirmed against `LerianStudio/go-boilerplate-ddd` repo:

- `internal/bootstrap/readyz.go:36` — `readyzPath = "/readyz"`
- `internal/bootstrap/routes.go:64` — `app.Get(readyzPath, svc.readyzHandler())`

Only health-like endpoints registered: `/health` (liveness — kept), `/readyz` (readiness — this fix), `/metrics`.

## Local validation

- `helm lint charts/go-boilerplate-ddd/` → 0 failures
- `helm template ...` renders all expected kinds (Deployment, Service, ConfigMap, Secret, Ingress, HPA, PDB, ServiceAccount) across `prd`/`dev`/`stg` values overlays

## Branch target

`develop` per repo policy — merge will trigger semantic-release to publish a new beta chart to `ghcr.io/lerianstudio` and `registry-1.docker.io/lerianstudio`.

## Test plan

- [x] helm lint passes
- [x] helm template renders cleanly
- [x] Readiness probe path correct in rendered Deployment
- [ ] CI passes
- [ ] semantic-release publishes new beta chart
- [ ] First Firmino deploy via separate gitops PR (chart consumer)