### PR TITLE
fix(plugins): add plugin-br-payments-fakebtg to README version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ For implementation and configuration details, see the [README](https://charts.le
 | `1.0.0` | 1.0.0-beta.9 |
 -----------------
 
+### Plugin BR Payments Fakebtg
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/plugin-br-payments-fakebtg).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `0.1.0` | 1.0.0-beta.22 |
+-----------------
+
 ### Fetcher
 
 See the [official documentation](https://docs.lerian.studio/en/fetcher) for details.

--- a/charts/plugin-br-payments-fakebtg/Chart.yaml
+++ b/charts/plugin-br-payments-fakebtg/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
     email: "support@lerian.studio"
 
 version: 0.1.0
-appVersion: "1.0.0-beta.20"
+appVersion: "1.0.0-beta.22"
 
 keywords:
   - midaz


### PR DESCRIPTION
## Summary

Adds the missing README.md section for `plugin-br-payments-fakebtg` so the helm Release pipeline can actually publish the chart added in #1404.

## Background

#1404 added `charts/plugin-br-payments-fakebtg/` but did not update the root `README.md` version-matrix index. The Release workflow's `prepareCmd` runs `.github/scripts/update-chart-version-readme --chart plugin-br-payments-fakebtg --version 1.0.0` which calls `tableutil.ParseTableForChart(lines, *chart)`; with no section for the chart in README.md, that returned `tableStart == -1` and the script exited with:

```
WARNING: Could not find section for chart 'plugin-br-payments-fakebtg'
ERROR: Could not find version matrix table in README.md
```

Failed Release run: [26306471317](https://github.com/LerianStudio/helm/actions/runs/26306471317). The semantic-release publish step never ran, so the chart was never pushed to `oci://ghcr.io/lerianstudio/plugin-br-payments-fakebtg-helm` and no `plugin-br-payments-fakebtg-v*` git tag exists.

## Changes (2 files, +12 / −1)

| File | Change |
|------|--------|
| `README.md` | New `### Plugin BR Payments Fakebtg` section placed immediately after the sibling `### Plugin BR Payments` block, using the same Application Version Mapping table shape every other chart uses |
| `charts/plugin-br-payments-fakebtg/Chart.yaml` | `appVersion: "1.0.0-beta.20"` → `"1.0.0-beta.22"` so the chart's default image tag aligns with the latest published `plugin-br-payments-fakebtg` image (built in plugin-br-payments tag `v1.0.0-beta.22`) |

## Why both files

The Chart.yaml bump is necessary for the workflow to actually trigger. `release.yml` has `paths-ignore: README.md`, so a README-only PR would not fire the Release workflow. Touching Chart.yaml takes the change out of the path-ignore set; the appVersion bump is also a legitimate update since 1.0.0-beta.22 is now the latest fakebtg image in GHCR.

## Expected behaviour after merge

1. Push triggers Release workflow on `main`
2. `update-chart-version-readme` finds the new section → succeeds
3. Semantic-release analyzes commits affecting the chart (including the original `feat:` from #1404 — the chart has no prior tag, so initial release is `1.0.0`)
4. `helm push plugin-br-payments-fakebtg-helm-1.0.0.tgz oci://ghcr.io/lerianstudio` → chart published
5. Git tag `plugin-br-payments-fakebtg-v1.0.0` created

After this PR merges and `1.0.0` is in OCI, the gitops PR (next step) can pin to that version.

## Test plan

- [ ] PR validation passes
- [ ] After merge, Release workflow fires and reaches semantic-release publish step (does NOT fail at prepareCmd)
- [ ] `oci://ghcr.io/lerianstudio/plugin-br-payments-fakebtg-helm:1.0.0` published
- [ ] Tag `plugin-br-payments-fakebtg-v1.0.0` exists