### PR TITLE
fix(plugin-br-pix-indirect-btg): use health readiness probe

### DIFF
--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -37,7 +37,8 @@ global:
           db: "plugin-br-pix-indirect-btg-db"
 pix:
   # -- Readiness probe configuration. All fields override chart defaults.
-  readinessProbe: {}
+  readinessProbe:
+    path: /health
   # -- Liveness probe configuration. All fields override chart defaults.
   livenessProbe: {}
   replicaCount: 1
@@ -209,7 +210,8 @@ pix:
   existingSecretName: ""
 inbound:
   # -- Readiness probe configuration. All fields override chart defaults.
-  readinessProbe: {}
+  readinessProbe:
+    path: /health
   # -- Liveness probe configuration. All fields override chart defaults.
   livenessProbe: {}
   replicaCount: 1
@@ -345,7 +347,8 @@ inbound:
   existingSecretName: "plugin-br-pix-indirect-btg-inbound"
 outbound:
   # -- Readiness probe configuration. All fields override chart defaults.
-  readinessProbe: {}
+  readinessProbe:
+    path: /health
   # -- Liveness probe configuration. All fields override chart defaults.
   livenessProbe: {}
   replicaCount: 1
@@ -497,7 +500,8 @@ outbound:
   existingSecretName: ""
 reconciliation:
   # -- Readiness probe configuration. All fields override chart defaults.
-  readinessProbe: {}
+  readinessProbe:
+    path: /health
   # -- Liveness probe configuration. All fields override chart defaults.
   livenessProbe: {}
   replicaCount: 1


### PR DESCRIPTION
## Summary
- Set plugin-br-pix-indirect-btg readiness probes to /health for pix, inbound, outbound, and reconciliation components.
- Avoid the chart defaulting to /readyz for this plugin version, which does not expose that endpoint yet.

## Validation
- Not run: helm CLI is not installed in this environment.

Requested by: @brunognovaes