### PR TITLE
refactor(plugin-br-bank-transfer): trim chart to infrastructure-only (1.6.0-beta.1)

### DIFF
--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.0-beta.1]
+
+### Changed
+- Chart now only ships **infrastructure configuration**: database / Valkey
+  / RabbitMQ / MongoDB connection info, multi-tenant toggle + endpoints,
+  outbound adapter URLs + auth toggles, OpenTelemetry plumbing, and
+  inbound auth wiring. All operational tuning (timeouts, retries, circuit
+  breakers, cache TTLs, rate limit, idempotency window, reconciliation,
+  webhook retries, JD polling cadence, usage limits, operating hours,
+  CORS, routing UUIDs) is dropped from the chart and is now managed at
+  runtime via the systemplane admin API or covered by lib-commons
+  compiled defaults.
+
+### Removed env vars (now systemplane-managed or default-covered)
+- `LOG_LEVEL`, `CORS_ALLOWED_*`, `AUTH_CACHE_TTL_SEC`, `DB_METRICS_INTERVAL_SEC`
+- `RATE_LIMIT_*`, `IDEMPOTENCY_RETRY_WINDOW_SEC`, `IDEMPOTENCY_REQUIRE_REDIS`,
+  `DUPLICATE_GUARD_TTL_SEC`
+- `MIDAZ_TIMEOUT_MS`, `MIDAZ_MAX_RETRIES`, `MIDAZ_OTEL_ENABLED`, `MIDAZ_DEBUG`,
+  `MIDAZ_BREAKER_FAILURES`, `MIDAZ_BREAKER_TIMEOUT_SECONDS`
+- `CRM_TIMEOUT_MS`, `CRM_MAX_RETRIES`, `CRM_CACHE_TTL_MS`, `CRM_*_LOOKUP_PATH_TEMPLATE`
+- `FEES_TIMEOUT_MS`, `FEES_MAX_RETRIES`, `FEES_FAIL_CLOSED_DEFAULT`,
+  `FEES_MAX_FEE_AMOUNT_CENTS`, `FEES_REFUND_ON_DEVOLUCAO`
+- `JD_TIMEOUT_MS`, `JD_MAX_RETRIES`, `JD_SIGNATURE_REQUIRED`,
+  `JD_VALIDATE_EXTERNAL_SIGNATURE`, `JD_POLLING_ENABLED`, `JD_POLL_*`
+- `RABBITMQ_MAX_RETRIES`, `RABBITMQ_PUBLISH_TIMEOUT_MS`,
+  `RABBITMQ_RETRY_BACKOFF_MS`, `RABBITMQ_ROUTING_KEY_PREFIX`
+- `RECONCILIATION_PENDING_ALERT_THRESHOLD`, `BTF_RECONCILIATION_*`
+- `WEBHOOK_QUEUE_NAME`, `WEBHOOK_DLQ_NAME`, `WEBHOOK_CONSUMER_TAG`,
+  `WEBHOOK_PREFETCH_COUNT`, `WEBHOOK_TIMEOUT_MS`, `WEBHOOK_MAX_RETRIES`,
+  `WEBHOOK_RETRY_BACKOFF_MS`, `WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS`,
+  `WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC`, `WEBHOOK_ENDPOINT_URL`
+- `USAGE_LIMITS_ENABLED`, `USAGE_LIMIT_DAILY_CENTS`, `USAGE_LIMIT_MONTHLY_CENTS`
+- `TRANSFER_OPERATING_OPEN`, `TRANSFER_OPERATING_CLOSE`, `TRANSFER_OPERATING_TIMEZONE`
+- `BTF_FEE_ENABLED`, `BTF_MIDAZ_CB_ENABLED`
+- `SYSTEMPLANE_BACKEND`, `SYSTEMPLANE_POSTGRES_SCHEMA` (chart internals,
+  app reads these via lib-commons configuration loader)
+- `ALLOW_INSECURE_OTEL` (unused by app)
+- `MULTI_TENANT_MAX_TENANT_POOLS`, `MULTI_TENANT_IDLE_TIMEOUT_SEC`,
+  `MULTI_TENANT_TIMEOUT`, `MULTI_TENANT_CACHE_TTL_SEC`,
+  `MULTI_TENANT_CIRCUIT_BREAKER_*`, `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC`,
+  `MULTI_TENANT_REDIS_PORT` (chart default 6379)
+
+### Kept
+- All Postgres / Valkey / MongoDB / RabbitMQ connection configuration
+- Multi-tenant toggle + infra endpoints
+  (`MULTI_TENANT_ENABLED`, `MULTI_TENANT_URL`, `MULTI_TENANT_REDIS_HOST`,
+   `MULTI_TENANT_REDIS_TLS`, `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE`,
+   `AWS_REGION`)
+- Server / TLS wiring (`SERVER_*`, `TLS_TERMINATED_UPSTREAM`,
+  `HTTP_BODY_LIMIT_BYTES`, `ALLOW_PRIVATE_UPSTREAMS`)
+- Outbound adapter URLs + auth toggles (Midaz / CRM / Fees / JD)
+- Inbound auth wiring (`PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_ADDRESS`)
+- OpenTelemetry plumbing
+- All secrets (in `templates/secrets.yaml`)
+
+### Migration
+Consumers whose `values.yaml` set any of the removed keys should:
+1. Remove the entries from `values.yaml` (chart now ignores them).
+2. Pre-populate the equivalent systemplane key in Postgres before this
+   chart version rolls out, OR accept the lib-commons compiled default
+   (sane production values for retries, timeouts, etc.).
+3. Use the runtime admin API to tweak any value at any time without
+   restarting the pod.
+
 ## [1.0.0] - 2024-03-24
 
 ### Changed

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 1.5.0-beta.1
+version: 1.6.0-beta.1
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -5,26 +5,26 @@ metadata:
   name: {{ include "bank-transfer.fullname" . }}
   namespace: {{ include "global.namespace" . }}
 data:
-  # Application Settings
+  # =====================================================================
+  # APPLICATION IDENTITY
+  # =====================================================================
   ENV_NAME: {{ .Values.bankTransfer.configmap.ENV_NAME | default "production" | quote }}
   DEPLOYMENT_MODE: {{ .Values.bankTransfer.configmap.DEPLOYMENT_MODE | default "byoc" | quote }}
-  LOG_LEVEL: {{ .Values.bankTransfer.configmap.LOG_LEVEL | default "info" | quote }}
+  VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
+
+  # =====================================================================
+  # HTTP SERVER + TLS
+  # =====================================================================
   SERVER_ADDRESS: {{ .Values.bankTransfer.configmap.SERVER_ADDRESS | default ":4027" | quote }}
   HTTP_BODY_LIMIT_BYTES: {{ .Values.bankTransfer.configmap.HTTP_BODY_LIMIT_BYTES | default "1048576" | quote }}
-
-  # CORS Configuration
-  CORS_ALLOWED_ORIGINS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS | default "*" | quote }}
-  CORS_ALLOWED_METHODS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS | default "GET,POST,PUT,PATCH,DELETE,OPTIONS" | quote }}
-  CORS_ALLOWED_HEADERS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS | default "Origin,Content-Type,Accept,Authorization,X-Request-ID" | quote }}
-
-  # TLS Configuration
+  TLS_TERMINATED_UPSTREAM: {{ .Values.bankTransfer.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
+  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE }}
   SERVER_TLS_CERT_FILE: {{ .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.SERVER_TLS_KEY_FILE }}
   SERVER_TLS_KEY_FILE: {{ .Values.bankTransfer.configmap.SERVER_TLS_KEY_FILE | quote }}
   {{- end }}
-  TLS_TERMINATED_UPSTREAM: {{ .Values.bankTransfer.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
   {{- if .Values.bankTransfer.configmap.SERVER_PROXY_HEADER }}
   SERVER_PROXY_HEADER: {{ .Values.bankTransfer.configmap.SERVER_PROXY_HEADER | quote }}
   {{- end }}
@@ -32,27 +32,25 @@ data:
   SERVER_TRUSTED_PROXIES: {{ .Values.bankTransfer.configmap.SERVER_TRUSTED_PROXIES | quote }}
   {{- end }}
 
-  # Multi-Tenancy
+  # =====================================================================
+  # MULTI-TENANCY (chart-managed: toggle + infrastructure endpoints only)
+  # All operational tuning (timeouts, pool sizes, circuit breaker) ships
+  # via lib-commons defaults or is hot-reloadable via systemplane.
+  # =====================================================================
+  MULTI_TENANT_ENABLED: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
   DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
   DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
-  MULTI_TENANT_ENABLED: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
   {{- if eq (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false") "true" }}
   MULTI_TENANT_URL: {{ .Values.bankTransfer.configmap.MULTI_TENANT_URL | default "" | quote }}
   AWS_REGION: {{ .Values.bankTransfer.configmap.AWS_REGION | default "" | quote }}
   MULTI_TENANT_REDIS_HOST: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | default "" | quote }}
-  MULTI_TENANT_REDIS_PORT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
-  MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | default "100" | quote }}
-  MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
-  MULTI_TENANT_TIMEOUT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT | default "30" | quote }}
-  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | default "5" | quote }}
-  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
   MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | default "tenants/{env}/{tenantId}/{applicationName}/integration/configuration" | quote }}
-  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
-  MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC | default "30" | quote }}
   {{- end }}
 
-  # PostgreSQL Primary
+  # =====================================================================
+  # POSTGRES (primary)
+  # =====================================================================
   {{- $namespace := include "global.namespace" . }}
   POSTGRES_HOST: {{ .Values.bankTransfer.configmap.POSTGRES_HOST | default (printf "%s-postgresql-primary.%s.svc.cluster.local" .Release.Name $namespace) | quote }}
   POSTGRES_PORT: {{ .Values.bankTransfer.configmap.POSTGRES_PORT | default "5432" | quote }}
@@ -65,8 +63,11 @@ data:
   POSTGRES_CONN_MAX_IDLE_TIME_MINS: {{ .Values.bankTransfer.configmap.POSTGRES_CONN_MAX_IDLE_TIME_MINS | default "5" | quote }}
   POSTGRES_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.POSTGRES_CONNECT_TIMEOUT_SEC | default "10" | quote }}
   MIGRATIONS_PATH: {{ .Values.bankTransfer.configmap.MIGRATIONS_PATH | default "migrations" | quote }}
+  INFRA_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.INFRA_CONNECT_TIMEOUT_SEC | default "30" | quote }}
 
-  # PostgreSQL Replica (optional - for CQRS read scaling)
+  # =====================================================================
+  # POSTGRES (replica — optional, for CQRS read scaling)
+  # =====================================================================
   {{- if .Values.bankTransfer.configmap.POSTGRES_REPLICA_HOST }}
   POSTGRES_REPLICA_HOST: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_HOST | quote }}
   POSTGRES_REPLICA_PORT: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_PORT | default "5432" | quote }}
@@ -75,10 +76,9 @@ data:
   POSTGRES_REPLICA_SSLMODE: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_SSLMODE | default "require" | quote }}
   {{- end }}
 
-  # Infrastructure Boot Timeout
-  INFRA_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.INFRA_CONNECT_TIMEOUT_SEC | default "30" | quote }}
-
-  # Redis/Valkey Configuration
+  # =====================================================================
+  # VALKEY / REDIS (app-level)
+  # =====================================================================
   REDIS_HOST: {{ .Values.bankTransfer.configmap.REDIS_HOST | default (printf "%s-valkey-primary.%s.svc.cluster.local:6379" .Release.Name $namespace) | quote }}
   REDIS_DB: {{ .Values.bankTransfer.configmap.REDIS_DB | default "0" | quote }}
   REDIS_PROTOCOL: {{ .Values.bankTransfer.configmap.REDIS_PROTOCOL | default "3" | quote }}
@@ -95,21 +95,33 @@ data:
   REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.REDIS_CA_CERT | quote }}
   {{- end }}
 
-  # MongoDB Configuration (mandatory for audit/event persistence)
-  # Note: MONGO_URI is in secrets.yaml to include the password securely
+  # =====================================================================
+  # MONGODB (audit/event persistence)
+  # =====================================================================
   MONGO_ENABLED: {{ .Values.bankTransfer.configmap.MONGO_ENABLED | default "true" | quote }}
   MONGO_DATABASE: {{ .Values.bankTransfer.configmap.MONGO_DATABASE | default "plugin_br_bank_transfer" | quote }}
   MONGO_MAX_POOL_SIZE: {{ .Values.bankTransfer.configmap.MONGO_MAX_POOL_SIZE | default "25" | quote }}
   MONGO_SERVER_SELECTION_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.MONGO_SERVER_SELECTION_TIMEOUT_MS | default "3000" | quote }}
   MONGO_HEARTBEAT_INTERVAL_MS: {{ .Values.bankTransfer.configmap.MONGO_HEARTBEAT_INTERVAL_MS | default "10000" | quote }}
 
-  # Authentication (plugin-auth)
-  # Note: PLUGIN_AUTH_CLIENT_ID is in secrets.yaml for secure Vault integration
+  # =====================================================================
+  # RABBITMQ (connection + toggle only — retries/timeouts via systemplane)
+  # =====================================================================
+  RABBITMQ_ENABLED: {{ .Values.bankTransfer.configmap.RABBITMQ_ENABLED | default "false" | quote }}
+  {{- if eq (toString .Values.bankTransfer.configmap.RABBITMQ_ENABLED) "true" }}
+  RABBITMQ_URL: {{ .Values.bankTransfer.configmap.RABBITMQ_URL | default (printf "amqp://bank_transfer:$(RABBITMQ_PASSWORD)@%s-rabbitmq.%s.svc.cluster.local:5672/" .Release.Name $namespace) | quote }}
+  RABBITMQ_EXCHANGE: {{ .Values.bankTransfer.configmap.RABBITMQ_EXCHANGE | default "bank_transfer.lifecycle" | quote }}
+  {{- end }}
+
+  # =====================================================================
+  # AUTHENTICATION (inbound)
+  # =====================================================================
   PLUGIN_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ENABLED | default "true" | quote }}
   PLUGIN_AUTH_ADDRESS: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ADDRESS | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000" | quote }}
-  AUTH_CACHE_TTL_SEC: {{ .Values.bankTransfer.configmap.AUTH_CACHE_TTL_SEC | default "300" | quote }}
 
-  # License Validation
+  # =====================================================================
+  # LICENSE GATEWAY (optional override of lib-license-go default)
+  # =====================================================================
   {{- if .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS }}
   LICENSE_SERVICE_ADDRESS: {{ .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS | quote }}
   {{- end }}
@@ -117,7 +129,9 @@ data:
   TENANT_IDS: {{ .Values.bankTransfer.configmap.TENANT_IDS | quote }}
   {{- end }}
 
-  # OpenTelemetry
+  # =====================================================================
+  # OPENTELEMETRY
+  # =====================================================================
   ENABLE_TELEMETRY: {{ .Values.bankTransfer.configmap.ENABLE_TELEMETRY | default "false" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.bankTransfer.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-bank-transfer" | quote }}
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-bank-transfer" | quote }}
@@ -125,149 +139,49 @@ data:
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.bankTransfer.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "production" | quote }}
 
-  # Systemplane Runtime Configuration (optional)
-  {{- if .Values.bankTransfer.configmap.SYSTEMPLANE_BACKEND }}
-  SYSTEMPLANE_BACKEND: {{ .Values.bankTransfer.configmap.SYSTEMPLANE_BACKEND | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.SYSTEMPLANE_POSTGRES_SCHEMA }}
-  SYSTEMPLANE_POSTGRES_SCHEMA: {{ .Values.bankTransfer.configmap.SYSTEMPLANE_POSTGRES_SCHEMA | quote }}
-  {{- end }}
+  # =====================================================================
+  # OUTBOUND ADAPTERS — URLs + auth toggles only.
+  # Timeouts, retries, circuit breakers, cache TTLs, and lookup path
+  # templates are managed by systemplane at runtime.
+  # =====================================================================
 
-  # Rate Limiting
-  RATE_LIMIT_ENABLED: {{ .Values.bankTransfer.configmap.RATE_LIMIT_ENABLED | default "true" | quote }}
-  RATE_LIMIT_MAX: {{ .Values.bankTransfer.configmap.RATE_LIMIT_MAX | default "100" | quote }}
-  RATE_LIMIT_EXPIRY_SEC: {{ .Values.bankTransfer.configmap.RATE_LIMIT_EXPIRY_SEC | default "60" | quote }}
-
-  # Database Metrics & Observability
-  DB_METRICS_INTERVAL_SEC: {{ .Values.bankTransfer.configmap.DB_METRICS_INTERVAL_SEC | default "15" | quote }}
-  RECONCILIATION_PENDING_ALERT_THRESHOLD: {{ .Values.bankTransfer.configmap.RECONCILIATION_PENDING_ALERT_THRESHOLD | default "20" | quote }}
-
-  # Idempotency
-  IDEMPOTENCY_RETRY_WINDOW_SEC: {{ .Values.bankTransfer.configmap.IDEMPOTENCY_RETRY_WINDOW_SEC | default "300" | quote }}
-  IDEMPOTENCY_REQUIRE_REDIS: {{ .Values.bankTransfer.configmap.IDEMPOTENCY_REQUIRE_REDIS | default "true" | quote }}
-  DUPLICATE_GUARD_TTL_SEC: {{ .Values.bankTransfer.configmap.DUPLICATE_GUARD_TTL_SEC | default "300" | quote }}
-
-  # Midaz Adapter
+  # Midaz
   MIDAZ_BASE_URL: {{ required "bankTransfer.configmap.MIDAZ_BASE_URL is required" .Values.bankTransfer.configmap.MIDAZ_BASE_URL | quote }}
   MIDAZ_TRANSACTION_URL: {{ .Values.bankTransfer.configmap.MIDAZ_TRANSACTION_URL | default .Values.bankTransfer.configmap.MIDAZ_BASE_URL | quote }}
-  MIDAZ_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.MIDAZ_TIMEOUT_MS | default "3000" | quote }}
-  MIDAZ_MAX_RETRIES: {{ .Values.bankTransfer.configmap.MIDAZ_MAX_RETRIES | default "3" | quote }}
-  MIDAZ_OTEL_ENABLED: {{ .Values.bankTransfer.configmap.MIDAZ_OTEL_ENABLED | default "true" | quote }}
-  MIDAZ_DEBUG: {{ .Values.bankTransfer.configmap.MIDAZ_DEBUG | default "false" | quote }}
   MIDAZ_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.MIDAZ_AUTH_ENABLED | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.MIDAZ_AUTH_ADDRESS }}
   MIDAZ_AUTH_ADDRESS: {{ .Values.bankTransfer.configmap.MIDAZ_AUTH_ADDRESS | quote }}
   {{- end }}
-  MIDAZ_BREAKER_FAILURES: {{ .Values.bankTransfer.configmap.MIDAZ_BREAKER_FAILURES | default "3" | quote }}
-  MIDAZ_BREAKER_TIMEOUT_SECONDS: {{ .Values.bankTransfer.configmap.MIDAZ_BREAKER_TIMEOUT_SECONDS | default "30" | quote }}
 
-  # CRM Adapter
-  # Note: CRM_CLIENT_ID is in secrets.yaml for secure Vault integration
+  # CRM
   CRM_BASE_URL: {{ required "bankTransfer.configmap.CRM_BASE_URL is required" .Values.bankTransfer.configmap.CRM_BASE_URL | quote }}
-  CRM_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.CRM_TIMEOUT_MS | default "2000" | quote }}
-  CRM_MAX_RETRIES: {{ .Values.bankTransfer.configmap.CRM_MAX_RETRIES | default "2" | quote }}
-  CRM_CACHE_TTL_MS: {{ .Values.bankTransfer.configmap.CRM_CACHE_TTL_MS | default "300000" | quote }}
   CRM_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.CRM_AUTH_ENABLED | default "false" | quote }}
-  {{- if .Values.bankTransfer.configmap.CRM_SENDER_LOOKUP_PATH_TEMPLATE }}
-  CRM_SENDER_LOOKUP_PATH_TEMPLATE: {{ .Values.bankTransfer.configmap.CRM_SENDER_LOOKUP_PATH_TEMPLATE | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.CRM_RECIPIENT_LOOKUP_PATH_TEMPLATE }}
-  CRM_RECIPIENT_LOOKUP_PATH_TEMPLATE: {{ .Values.bankTransfer.configmap.CRM_RECIPIENT_LOOKUP_PATH_TEMPLATE | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.CRM_HOLDER_LOOKUP_PATH_TEMPLATE }}
-  CRM_HOLDER_LOOKUP_PATH_TEMPLATE: {{ .Values.bankTransfer.configmap.CRM_HOLDER_LOOKUP_PATH_TEMPLATE | quote }}
-  {{- end }}
 
-  # Fees Adapter
-  # Note: FEES_CLIENT_ID is in secrets.yaml for secure Vault integration
+  # Fees
   FEES_BASE_URL: {{ required "bankTransfer.configmap.FEES_BASE_URL is required" .Values.bankTransfer.configmap.FEES_BASE_URL | quote }}
-  FEES_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.FEES_TIMEOUT_MS | default "2000" | quote }}
-  FEES_MAX_RETRIES: {{ .Values.bankTransfer.configmap.FEES_MAX_RETRIES | default "2" | quote }}
-  FEES_FAIL_CLOSED_DEFAULT: {{ .Values.bankTransfer.configmap.FEES_FAIL_CLOSED_DEFAULT | default "false" | quote }}
-  FEES_MAX_FEE_AMOUNT_CENTS: {{ .Values.bankTransfer.configmap.FEES_MAX_FEE_AMOUNT_CENTS | default "99999999" | quote }}
-  FEES_REFUND_ON_DEVOLUCAO: {{ .Values.bankTransfer.configmap.FEES_REFUND_ON_DEVOLUCAO | default "false" | quote }}
   FEES_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.FEES_AUTH_ENABLED | default "false" | quote }}
 
-  # JD Sandbox Mode (uses in-process fake adapter, cannot combine with live JD config)
+  # JD-SPB. Sandbox mode swaps the adapter; live config required otherwise.
   JD_SANDBOX_MODE: {{ .Values.bankTransfer.configmap.JD_SANDBOX_MODE | default "false" | quote }}
-
-  # JD SPB Adapter (only when NOT in sandbox mode)
   {{- if ne (toString .Values.bankTransfer.configmap.JD_SANDBOX_MODE) "true" }}
   JD_BASE_URL: {{ required "bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_BASE_URL | quote }}
-  JD_SOAP_PATH: {{ .Values.bankTransfer.configmap.JD_SOAP_PATH | default "/soap" | quote }}
   JD_ORIGIN_ISPB: {{ required "bankTransfer.configmap.JD_ORIGIN_ISPB is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_ORIGIN_ISPB | quote }}
+  JD_SOAP_PATH: {{ .Values.bankTransfer.configmap.JD_SOAP_PATH | default "/soap" | quote }}
+  JD_SIGNING_MODE: {{ .Values.bankTransfer.configmap.JD_SIGNING_MODE | default "local_pem" | quote }}
   {{- if .Values.bankTransfer.configmap.JD_LEGACY_CODE }}
   JD_LEGACY_CODE: {{ .Values.bankTransfer.configmap.JD_LEGACY_CODE | quote }}
   {{- end }}
-  JD_SIGNING_MODE: {{ .Values.bankTransfer.configmap.JD_SIGNING_MODE | default "local_pem" | quote }}
-  JD_SIGNATURE_REQUIRED: {{ .Values.bankTransfer.configmap.JD_SIGNATURE_REQUIRED | default "true" | quote }}
-  JD_VALIDATE_EXTERNAL_SIGNATURE: {{ .Values.bankTransfer.configmap.JD_VALIDATE_EXTERNAL_SIGNATURE | default "true" | quote }}
-  JD_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.JD_TIMEOUT_MS | default "8000" | quote }}
-  JD_MAX_RETRIES: {{ .Values.bankTransfer.configmap.JD_MAX_RETRIES | default "3" | quote }}
   {{- end }}
 
-  # JD Polling (TED IN ingestion)
-  JD_POLLING_ENABLED: {{ .Values.bankTransfer.configmap.JD_POLLING_ENABLED | default "false" | quote }}
-  JD_POLL_INTERVAL_SECONDS: {{ .Values.bankTransfer.configmap.JD_POLL_INTERVAL_SECONDS | default "30" | quote }}
-  JD_POLL_MAX_MESSAGES_PER_CYCLE: {{ .Values.bankTransfer.configmap.JD_POLL_MAX_MESSAGES_PER_CYCLE | default "50" | quote }}
-  JD_POLL_MAX_RETRIES: {{ .Values.bankTransfer.configmap.JD_POLL_MAX_RETRIES | default "3" | quote }}
-  JD_POLL_RECOVERY_BATCH_SIZE: {{ .Values.bankTransfer.configmap.JD_POLL_RECOVERY_BATCH_SIZE | default "200" | quote }}
-  JD_POLL_DISABLE_OPERATING_HOURS_WINDOW: {{ .Values.bankTransfer.configmap.JD_POLL_DISABLE_OPERATING_HOURS_WINDOW | default "true" | quote }}
-
-  # RabbitMQ Event Bus (optional)
-  RABBITMQ_ENABLED: {{ .Values.bankTransfer.configmap.RABBITMQ_ENABLED | default "false" | quote }}
-  {{- if eq (toString .Values.bankTransfer.configmap.RABBITMQ_ENABLED) "true" }}
-  RABBITMQ_URL: {{ .Values.bankTransfer.configmap.RABBITMQ_URL | default (printf "amqp://bank_transfer:$(RABBITMQ_PASSWORD)@%s-rabbitmq.%s.svc.cluster.local:5672/" .Release.Name $namespace) | quote }}
-  RABBITMQ_EXCHANGE: {{ .Values.bankTransfer.configmap.RABBITMQ_EXCHANGE | default "bank_transfer.lifecycle" | quote }}
-  RABBITMQ_ROUTING_KEY_PREFIX: {{ .Values.bankTransfer.configmap.RABBITMQ_ROUTING_KEY_PREFIX | default "transfer" | quote }}
-  RABBITMQ_PUBLISH_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.RABBITMQ_PUBLISH_TIMEOUT_MS | default "5000" | quote }}
-  RABBITMQ_MAX_RETRIES: {{ .Values.bankTransfer.configmap.RABBITMQ_MAX_RETRIES | default "3" | quote }}
-  RABBITMQ_RETRY_BACKOFF_MS: {{ .Values.bankTransfer.configmap.RABBITMQ_RETRY_BACKOFF_MS | default "200" | quote }}
-  {{- end }}
-
-  # Webhook Delivery Worker (optional)
-  WEBHOOK_ENABLED: {{ .Values.bankTransfer.configmap.WEBHOOK_ENABLED | default "false" | quote }}
-  {{- if eq (toString .Values.bankTransfer.configmap.WEBHOOK_ENABLED) "true" }}
-  WEBHOOK_ENDPOINT_URL: {{ required "bankTransfer.configmap.WEBHOOK_ENDPOINT_URL is required when WEBHOOK_ENABLED=true" .Values.bankTransfer.configmap.WEBHOOK_ENDPOINT_URL | quote }}
-  WEBHOOK_QUEUE_NAME: {{ .Values.bankTransfer.configmap.WEBHOOK_QUEUE_NAME | default "transfer.webhook.delivery" | quote }}
-  WEBHOOK_DLQ_NAME: {{ .Values.bankTransfer.configmap.WEBHOOK_DLQ_NAME | default "transfer.webhook.dlq" | quote }}
-  WEBHOOK_CONSUMER_TAG: {{ .Values.bankTransfer.configmap.WEBHOOK_CONSUMER_TAG | default "plugin-br-bank-transfer-webhook" | quote }}
-  WEBHOOK_PREFETCH_COUNT: {{ .Values.bankTransfer.configmap.WEBHOOK_PREFETCH_COUNT | default "20" | quote }}
-  WEBHOOK_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.WEBHOOK_TIMEOUT_MS | default "5000" | quote }}
-  WEBHOOK_MAX_RETRIES: {{ .Values.bankTransfer.configmap.WEBHOOK_MAX_RETRIES | default "3" | quote }}
-  WEBHOOK_RETRY_BACKOFF_MS: {{ .Values.bankTransfer.configmap.WEBHOOK_RETRY_BACKOFF_MS | default "500" | quote }}
-  WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS: {{ .Values.bankTransfer.configmap.WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS | default "false" | quote }}
-  WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC: {{ .Values.bankTransfer.configmap.WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC | default "0" | quote }}
-  {{- end }}
-
-  # Usage Limits
-  USAGE_LIMITS_ENABLED: {{ .Values.bankTransfer.configmap.USAGE_LIMITS_ENABLED | default "false" | quote }}
-  {{- if eq (toString .Values.bankTransfer.configmap.USAGE_LIMITS_ENABLED) "true" }}
-  USAGE_LIMIT_DAILY_CENTS: {{ .Values.bankTransfer.configmap.USAGE_LIMIT_DAILY_CENTS | default "0" | quote }}
-  USAGE_LIMIT_MONTHLY_CENTS: {{ .Values.bankTransfer.configmap.USAGE_LIMIT_MONTHLY_CENTS | default "0" | quote }}
-  {{- end }}
-
-  # Operating Hours
-  TRANSFER_OPERATING_OPEN: {{ .Values.bankTransfer.configmap.TRANSFER_OPERATING_OPEN | default "06:30" | quote }}
-  TRANSFER_OPERATING_CLOSE: {{ .Values.bankTransfer.configmap.TRANSFER_OPERATING_CLOSE | default "17:00" | quote }}
-  TRANSFER_OPERATING_TIMEZONE: {{ .Values.bankTransfer.configmap.TRANSFER_OPERATING_TIMEZONE | default "America/Sao_Paulo" | quote }}
-
-  # Application Version (for logs/telemetry)
-  VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
-
-  BTF_RECONCILIATION_ENABLED: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_ENABLED | default "true" | quote }}
-  BTF_RECONCILIATION_INTERVAL_SEC: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_INTERVAL_SEC | default "30" | quote }}
-  BTF_RECONCILIATION_BATCH_SIZE: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_BATCH_SIZE | default "20" | quote }}
-  BTF_RECONCILIATION_MAX_ATTEMPTS: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_MAX_ATTEMPTS | default "5" | quote }}
-  BTF_RECONCILIATION_STALE_AFTER_SEC: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_STALE_AFTER_SEC | default "60" | quote }}
-
-  BTF_FEE_ENABLED: {{ .Values.bankTransfer.configmap.BTF_FEE_ENABLED | default "false" | quote }}
-  BTF_MIDAZ_CB_ENABLED: {{ .Values.bankTransfer.configmap.BTF_MIDAZ_CB_ENABLED | default "false" | quote }}
+  # =====================================================================
+  # SINGLE-TENANT DEFAULTS (ignored when MULTI_TENANT_ENABLED=true)
+  # =====================================================================
+  ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.ORGANIZATION_ID | default "" | quote }}
   DEFAULT_ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.DEFAULT_ORGANIZATION_ID | default "" | quote }}
-  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
 
-  
-  # Extra Env Vars (must be a map of key: value pairs)
+  # =====================================================================
+  # EXTRA OVERRIDES (escape hatch for env vars not modeled above)
+  # =====================================================================
   {{- range $key, $value := .Values.bankTransfer.extraEnvVars }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/plugin-br-bank-transfer/values-template.yaml
+++ b/charts/plugin-br-bank-transfer/values-template.yaml
@@ -19,26 +19,38 @@ bankTransfer:
     tls: []
 
   configmap:
-    # Application Settings
+    # Chart scope (as of 1.6.0): infrastructure connection + multi-tenant
+    # toggle + outbound URLs / auth toggles only. Operational tuning
+    # (timeouts, retries, circuit breakers, polling cadence, rate limit,
+    # idempotency, reconciliation, webhook config, usage limits,
+    # operating hours, CORS, routing UUIDs) is managed via the
+    # systemplane admin API at runtime or covered by lib-commons
+    # compiled defaults.
+
+    # =================================================================
+    # Application identity
+    # =================================================================
     ENV_NAME: ""  # REQUIRED - Environment name (e.g., production, staging)
-    LOG_LEVEL: "info"
     SERVER_ADDRESS: ":4027"
     HTTP_BODY_LIMIT_BYTES: "1048576"
-
-    # CORS Configuration
-    CORS_ALLOWED_ORIGINS: "*"
-    CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
-
-    # TLS Configuration
     TLS_TERMINATED_UPSTREAM: "true"
 
-    # Multi-Tenancy
+    # =================================================================
+    # Multi-tenancy
+    # =================================================================
     DEFAULT_TENANT_ID: ""  # REQUIRED - Default tenant UUID
     DEFAULT_TENANT_SLUG: ""  # REQUIRED - Default tenant slug
     MULTI_TENANT_ENABLED: "false"
+    # When MULTI_TENANT_ENABLED=true, also set:
+    # MULTI_TENANT_URL: ""
+    # AWS_REGION: ""
+    # MULTI_TENANT_REDIS_HOST: ""
+    # MULTI_TENANT_REDIS_TLS: "false"
+    # MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: "tenants/{env}/{tenantId}/{applicationName}/integration/configuration"
 
-    # PostgreSQL Primary - REQUIRED
+    # =================================================================
+    # PostgreSQL primary - REQUIRED
+    # =================================================================
     POSTGRES_HOST: ""  # REQUIRED - PostgreSQL primary host
     POSTGRES_PORT: "5432"
     POSTGRES_USER: "bank_transfer"
@@ -50,16 +62,19 @@ bankTransfer:
     POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
     POSTGRES_CONNECT_TIMEOUT_SEC: "10"
     MIGRATIONS_PATH: "migrations"
-
-    # PostgreSQL Replica (optional - for CQRS read scaling)
-    # POSTGRES_REPLICA_HOST: ""
-    # POSTGRES_REPLICA_PORT: "5432"
-
-    # Infrastructure Boot Timeout
     INFRA_CONNECT_TIMEOUT_SEC: "30"
 
-    # Redis/Valkey - REQUIRED
-    REDIS_HOST: ""  # REQUIRED - Redis/Valkey host:port (e.g., bank-transfer-valkey:6379)
+    # PostgreSQL replica (optional - CQRS read scaling)
+    # POSTGRES_REPLICA_HOST: ""
+    # POSTGRES_REPLICA_PORT: "5432"
+    # POSTGRES_REPLICA_USER: ""
+    # POSTGRES_REPLICA_DB: ""
+    # POSTGRES_REPLICA_SSLMODE: "require"
+
+    # =================================================================
+    # Redis/Valkey (app-level) - REQUIRED
+    # =================================================================
+    REDIS_HOST: ""  # REQUIRED - Redis/Valkey host:port
     REDIS_DB: "0"
     REDIS_PROTOCOL: "3"
     REDIS_POOL_SIZE: "10"
@@ -69,108 +84,71 @@ bankTransfer:
     REDIS_DIAL_TIMEOUT_MS: "5000"
     REDIS_TLS: "false"
 
-    # MongoDB - REQUIRED for audit/event persistence
+    # =================================================================
+    # MongoDB (audit/event persistence) - REQUIRED
+    # MONGO_URI is in secrets.
+    # =================================================================
     MONGO_ENABLED: "true"
-    MONGO_URI: ""  # REQUIRED - MongoDB connection URI
-    MONGO_DATABASE: "plugin_br_bank_transfer_jd"
+    MONGO_DATABASE: "plugin_br_bank_transfer"
     MONGO_MAX_POOL_SIZE: "25"
     MONGO_SERVER_SELECTION_TIMEOUT_MS: "3000"
     MONGO_HEARTBEAT_INTERVAL_MS: "10000"
 
-    # Authentication - REQUIRED for production
-    AUTH_ENABLED: "true"
-    AUTH_SERVICE_ADDRESS: ""  # REQUIRED when AUTH_ENABLED=true
-    AUTH_CACHE_TTL_SEC: "300"
+    # =================================================================
+    # RabbitMQ (event bus, optional)
+    # =================================================================
+    RABBITMQ_ENABLED: "false"
+    # RABBITMQ_URL: ""  # Required if RABBITMQ_ENABLED=true
+    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
 
-    # License Validation (required for production)
+    # =================================================================
+    # Authentication (inbound)
+    # =================================================================
+    PLUGIN_AUTH_ENABLED: "true"
+    PLUGIN_AUTH_ADDRESS: ""  # REQUIRED when PLUGIN_AUTH_ENABLED=true
+
+    # =================================================================
+    # License gateway override (optional)
+    # =================================================================
     # LICENSE_SERVICE_ADDRESS: ""
-    # ORGANIZATION_IDS: ""
+    # TENANT_IDS: ""
 
+    # =================================================================
     # OpenTelemetry
+    # =================================================================
     ENABLE_TELEMETRY: "false"
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-bank-transfer"
     OTEL_RESOURCE_SERVICE_NAME: "plugin-br-bank-transfer"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""  # Set if ENABLE_TELEMETRY=true
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
 
-    # Rate Limiting
-    RATE_LIMIT_ENABLED: "true"
-    RATE_LIMIT_MAX: "100"
-    RATE_LIMIT_EXPIRY_SEC: "60"
+    # =================================================================
+    # Outbound adapters - URLs + auth toggles only
+    # Timeouts, retries, circuit breakers, cache TTLs are
+    # systemplane-managed at runtime.
+    # =================================================================
 
-    # Observability & Metrics
-    DB_METRICS_INTERVAL_SEC: "15"
-    RECONCILIATION_PENDING_ALERT_THRESHOLD: "20"
-
-    # Idempotency
-    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
-    IDEMPOTENCY_REQUIRE_REDIS: "true"
-
-    # Midaz Adapter - REQUIRED
+    # Midaz - REQUIRED
     MIDAZ_BASE_URL: ""  # REQUIRED - Midaz API endpoint
     MIDAZ_TRANSACTION_URL: ""  # REQUIRED - Midaz transaction endpoint
-    MIDAZ_TIMEOUT_MS: "3000"
-    MIDAZ_MAX_RETRIES: "3"
-    MIDAZ_OTEL_ENABLED: "true"
-    MIDAZ_DEBUG: "false"
     MIDAZ_AUTH_ENABLED: "false"
     # MIDAZ_AUTH_ADDRESS: ""  # Required if MIDAZ_AUTH_ENABLED=true
-    MIDAZ_BREAKER_FAILURES: "3"
-    MIDAZ_BREAKER_TIMEOUT_SECONDS: "30"
 
-    # CRM Adapter - REQUIRED
+    # CRM - REQUIRED
     CRM_BASE_URL: ""  # REQUIRED - CRM API endpoint
-    CRM_TIMEOUT_MS: "2000"
-    CRM_MAX_RETRIES: "2"
-    CRM_CACHE_TTL_MS: "300000"
+    CRM_AUTH_ENABLED: "false"
 
-    # Fees Adapter - REQUIRED
+    # Fees - REQUIRED
     FEES_BASE_URL: ""  # REQUIRED - Fees API endpoint
-    FEES_TIMEOUT_MS: "2000"
-    FEES_MAX_RETRIES: "2"
-    FEES_FAIL_CLOSED_DEFAULT: "false"
-    FEES_MAX_FEE_AMOUNT_CENTS: "99999999"
+    FEES_AUTH_ENABLED: "false"
 
-    # JD SPB Adapter - REQUIRED
-    JD_BASE_URL: ""  # REQUIRED - JD SOAP endpoint
+    # JD-SPB
+    JD_SANDBOX_MODE: "false"
+    JD_BASE_URL: ""  # REQUIRED when JD_SANDBOX_MODE=false
     JD_SOAP_PATH: "/soap"
-    JD_ORIGIN_ISPB: ""  # REQUIRED - Origin ISPB code
+    JD_ORIGIN_ISPB: ""  # REQUIRED when JD_SANDBOX_MODE=false
     # JD_LEGACY_CODE: ""
     JD_SIGNING_MODE: "local_pem"  # local_pem | external_provided | disabled
-    JD_SIGNATURE_REQUIRED: "true"
-    JD_VALIDATE_EXTERNAL_SIGNATURE: "true"
-    JD_TIMEOUT_MS: "8000"
-    JD_MAX_RETRIES: "3"
-
-    # JD Sandbox Mode (must be false in production)
-    JD_SANDBOX_MODE: "false"
-
-    # JD Polling (TED IN ingestion)
-    JD_POLLING_ENABLED: "false"
-    JD_POLL_INTERVAL_SECONDS: "30"
-    JD_POLL_MAX_MESSAGES_PER_CYCLE: "50"
-    JD_POLL_MAX_RETRIES: "3"
-    JD_POLL_RECOVERY_BATCH_SIZE: "200"
-
-    # RabbitMQ Event Bus (optional)
-    RABBITMQ_ENABLED: "false"
-    # RABBITMQ_URL: ""  # Required if RABBITMQ_ENABLED=true
-    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
-    RABBITMQ_ROUTING_KEY_PREFIX: "transfer"
-
-    # Webhook Delivery Worker (optional)
-    WEBHOOK_ENABLED: "false"
-    # WEBHOOK_ENDPOINT_URL: ""  # Required if WEBHOOK_ENABLED=true
-    WEBHOOK_QUEUE_NAME: "transfer.webhook.delivery"
-    WEBHOOK_DLQ_NAME: "transfer.webhook.dlq"
-
-    # Usage Limits
-    USAGE_LIMITS_ENABLED: "false"
-
-    # Operating Hours
-    TRANSFER_OPERATING_OPEN: "06:30"
-    TRANSFER_OPERATING_CLOSE: "17:00"
-    TRANSFER_OPERATING_TIMEZONE: "America/Sao_Paulo"
 
   secrets:
     # PostgreSQL - REQUIRED

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -183,23 +183,37 @@ bankTransfer:
   # -- ConfigMap for environment variables and configurations
   # @default -- templates/configmap.yaml
   configmap:
-    # Application Settings
+    # =================================================================
+    # Application identity
+    # =================================================================
     ENV_NAME: "production"
-    LOG_LEVEL: "info"
     SERVER_ADDRESS: ":4027"
     HTTP_BODY_LIMIT_BYTES: "1048576"
-    # CORS Configuration
-    CORS_ALLOWED_ORIGINS: "*"
-    CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
-    # TLS Configuration
+
+    # =================================================================
+    # TLS / proxy
+    # =================================================================
     TLS_TERMINATED_UPSTREAM: "true"
-    # Multi-Tenancy
+
+    # =================================================================
+    # Multi-tenancy
+    # Only the toggle, the DEFAULT_TENANT_* identifiers, and the
+    # infrastructure endpoints live in the chart. Operational tuning
+    # (pool sizes, timeouts, circuit breaker) is hot-reloadable via
+    # systemplane or covered by lib-commons compiled defaults.
+    # =================================================================
     DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"
     DEFAULT_TENANT_SLUG: "default"
     MULTI_TENANT_ENABLED: "false"
-    # PostgreSQL Primary (host defaults to {{ .Release.Name }}-postgresql-primary.{{ .Release.Namespace }}.svc.cluster.local)
-    # POSTGRES_HOST: ""  # Leave empty to use dynamic default based on release name
+    # When MULTI_TENANT_ENABLED=true the chart also emits:
+    #   MULTI_TENANT_URL, AWS_REGION, MULTI_TENANT_REDIS_HOST,
+    #   MULTI_TENANT_REDIS_TLS, MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE
+    # Set those under .configmap as needed.
+
+    # =================================================================
+    # PostgreSQL (primary)
+    # POSTGRES_HOST defaults to "<release>-postgresql-primary.<ns>.svc.cluster.local"
+    # =================================================================
     POSTGRES_PORT: "5432"
     POSTGRES_USER: "bank_transfer"
     POSTGRES_DB: "bank_transfer"
@@ -210,17 +224,18 @@ bankTransfer:
     POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
     POSTGRES_CONNECT_TIMEOUT_SEC: "10"
     MIGRATIONS_PATH: "migrations"
-    # PostgreSQL Replica (optional - for CQRS read scaling)
+    INFRA_CONNECT_TIMEOUT_SEC: "30"
+    # PostgreSQL replica (optional — CQRS read scaling)
     # POSTGRES_REPLICA_HOST: ""
     # POSTGRES_REPLICA_PORT: "5432"
     # POSTGRES_REPLICA_USER: ""
     # POSTGRES_REPLICA_DB: ""
     # POSTGRES_REPLICA_SSLMODE: "require"
 
-    # Infrastructure Boot Timeout
-    INFRA_CONNECT_TIMEOUT_SEC: "30"
-    # Redis/Valkey Configuration (host defaults to {{ .Release.Name }}-valkey-primary.{{ .Release.Namespace }}.svc.cluster.local:6379)
-    # REDIS_HOST: ""  # Leave empty to use dynamic default based on release name
+    # =================================================================
+    # Valkey / Redis (app-level)
+    # REDIS_HOST defaults to "<release>-valkey-primary.<ns>.svc.cluster.local:6379"
+    # =================================================================
     REDIS_DB: "0"
     REDIS_PROTOCOL: "3"
     REDIS_POOL_SIZE: "10"
@@ -229,113 +244,76 @@ bankTransfer:
     REDIS_WRITE_TIMEOUT_MS: "3000"
     REDIS_DIAL_TIMEOUT_MS: "5000"
     REDIS_TLS: "false"
-    # MongoDB Configuration (mandatory for audit/event persistence)
+
+    # =================================================================
+    # MongoDB (audit/event persistence)
+    # MONGO_URI is in templates/secrets.yaml.
+    # =================================================================
     MONGO_ENABLED: "true"
-    # MONGO_URI is constructed from secrets if not explicitly set
     MONGO_DATABASE: "plugin_br_bank_transfer"
     MONGO_MAX_POOL_SIZE: "25"
     MONGO_SERVER_SELECTION_TIMEOUT_MS: "3000"
     MONGO_HEARTBEAT_INTERVAL_MS: "10000"
-    # Authentication (plugin-auth)
+
+    # =================================================================
+    # RabbitMQ (event bus, optional)
+    # RABBITMQ_URL is rendered from chart defaults when empty.
+    # Retries / timeouts / routing-key prefix are systemplane-managed.
+    # =================================================================
+    RABBITMQ_ENABLED: "false"
+    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
+
+    # =================================================================
+    # Authentication (inbound — plugin-access-manager)
+    # =================================================================
     PLUGIN_AUTH_ENABLED: "true"
     PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
-    PLUGIN_AUTH_CLIENT_ID: "plugin-br-bank-transfer"
-    AUTH_CACHE_TTL_SEC: "300"
-    # License Validation
+
+    # =================================================================
+    # License gateway override (optional — defaults to lib-license-go's
+    # hard-coded endpoint when LICENSE_SERVICE_ADDRESS is unset)
+    # =================================================================
     # LICENSE_SERVICE_ADDRESS: ""
     # TENANT_IDS: ""
 
+    # =================================================================
     # OpenTelemetry
+    # =================================================================
     ENABLE_TELEMETRY: "false"
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-bank-transfer"
     OTEL_RESOURCE_SERVICE_NAME: "plugin-br-bank-transfer"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
-    # Systemplane Runtime Configuration (optional)
-    # SYSTEMPLANE_BACKEND: "postgres"
-    # SYSTEMPLANE_POSTGRES_SCHEMA: "system"
-    # Rate Limiting
-    RATE_LIMIT_ENABLED: "true"
-    RATE_LIMIT_MAX: "100"
-    RATE_LIMIT_EXPIRY_SEC: "60"
-    # Database Metrics & Observability
-    DB_METRICS_INTERVAL_SEC: "15"
-    RECONCILIATION_PENDING_ALERT_THRESHOLD: "20"
-    # Idempotency
-    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
-    IDEMPOTENCY_REQUIRE_REDIS: "true"
-    # Midaz Adapter (REQUIRED)
+
+    # =================================================================
+    # Outbound adapters — endpoints + auth toggles only.
+    # Timeouts, retries, circuit breakers, cache TTLs, and lookup
+    # path templates are systemplane-managed at runtime.
+    # =================================================================
+
+    # Midaz (REQUIRED)
     MIDAZ_BASE_URL: "http://midaz.midaz.svc.cluster.local.:3001"
     MIDAZ_TRANSACTION_URL: "http://midaz.midaz.svc.cluster.local.:3001"
-    MIDAZ_TIMEOUT_MS: "3000"
-    MIDAZ_MAX_RETRIES: "3"
-    MIDAZ_OTEL_ENABLED: "true"
-    MIDAZ_DEBUG: "false"
     MIDAZ_AUTH_ENABLED: "false"
     # MIDAZ_AUTH_ADDRESS: ""
-    MIDAZ_BREAKER_FAILURES: "3"
-    MIDAZ_BREAKER_TIMEOUT_SECONDS: "30"
-    # CRM Adapter (REQUIRED)
+
+    # CRM (REQUIRED)
     CRM_BASE_URL: "http://plugin-crm.midaz-plugins.svc.cluster.local:4003"
-    CRM_TIMEOUT_MS: "2000"
-    CRM_MAX_RETRIES: "2"
-    CRM_CACHE_TTL_MS: "300000"
     CRM_AUTH_ENABLED: "false"
-    # CRM_CLIENT_ID: ""
-    # Fees Adapter (REQUIRED)
+
+    # Fees (REQUIRED)
     FEES_BASE_URL: "http://plugin-fees.midaz-plugins.svc.cluster.local:4004"
-    FEES_TIMEOUT_MS: "2000"
-    FEES_MAX_RETRIES: "2"
-    FEES_FAIL_CLOSED_DEFAULT: "false"
-    FEES_MAX_FEE_AMOUNT_CENTS: "99999999"
     FEES_AUTH_ENABLED: "false"
-    # FEES_CLIENT_ID: ""
-    # JD SPB Adapter (REQUIRED)
-    JD_BASE_URL: "" # MUST BE SET - JD SOAP endpoint
-    JD_SOAP_PATH: "/soap"
-    JD_ORIGIN_ISPB: "" # MUST BE SET - Origin ISPB code
-    # JD_LEGACY_CODE: ""
-    JD_SIGNING_MODE: "local_pem"  # local_pem | external_provided | disabled
-    JD_SIGNATURE_REQUIRED: "true"
-    JD_VALIDATE_EXTERNAL_SIGNATURE: "true"
-    JD_TIMEOUT_MS: "8000"
-    JD_MAX_RETRIES: "3"
-    # JD Sandbox Mode (must be false in production)
+
+    # JD-SPB
+    # JD sandbox mode swaps the adapter; when false, JD_BASE_URL and
+    # JD_ORIGIN_ISPB are required by the chart.
     JD_SANDBOX_MODE: "false"
-    # JD Polling (TED IN ingestion)
-    JD_POLLING_ENABLED: "false"
-    JD_POLL_INTERVAL_SECONDS: "30"
-    JD_POLL_MAX_MESSAGES_PER_CYCLE: "50"
-    JD_POLL_MAX_RETRIES: "3"
-    JD_POLL_RECOVERY_BATCH_SIZE: "200"
-    # RabbitMQ Event Bus (optional)
-    RABBITMQ_ENABLED: "false"
-    # RABBITMQ_URL: "amqp://bank_transfer:password@plugin-br-bank-transfer-jd-rabbitmq:5672/"
-    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
-    RABBITMQ_ROUTING_KEY_PREFIX: "transfer"
-    RABBITMQ_PUBLISH_TIMEOUT_MS: "5000"
-    RABBITMQ_MAX_RETRIES: "3"
-    RABBITMQ_RETRY_BACKOFF_MS: "200"
-    # Webhook Delivery Worker (optional)
-    WEBHOOK_ENABLED: "false"
-    # WEBHOOK_ENDPOINT_URL: "https://example.com/webhooks/transfers"
-    WEBHOOK_QUEUE_NAME: "transfer.webhook.delivery"
-    WEBHOOK_DLQ_NAME: "transfer.webhook.dlq"
-    WEBHOOK_CONSUMER_TAG: "plugin-br-bank-transfer-webhook"
-    WEBHOOK_PREFETCH_COUNT: "20"
-    WEBHOOK_TIMEOUT_MS: "5000"
-    WEBHOOK_MAX_RETRIES: "3"
-    WEBHOOK_RETRY_BACKOFF_MS: "500"
-    WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS: "false"
-    WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC: "0"
-    # Usage Limits
-    USAGE_LIMITS_ENABLED: "false"
-    USAGE_LIMIT_DAILY_CENTS: "0"
-    USAGE_LIMIT_MONTHLY_CENTS: "0"
-    # Operating Hours
-    TRANSFER_OPERATING_OPEN: "06:30"
-    TRANSFER_OPERATING_CLOSE: "17:00"
-    TRANSFER_OPERATING_TIMEZONE: "America/Sao_Paulo"
+    JD_BASE_URL: "" # MUST BE SET — JD SOAP endpoint
+    JD_SOAP_PATH: "/soap"
+    JD_ORIGIN_ISPB: "" # MUST BE SET — Origin ISPB code
+    # JD_LEGACY_CODE: ""
+    JD_SIGNING_MODE: "local_pem" # local_pem | external_provided | disabled
   # -- Secrets for storing sensitive data
   # @default -- templates/secrets.yaml
   secrets:


### PR DESCRIPTION
## What

Bumps the `plugin-br-bank-transfer` chart to **1.6.0-beta.1** and trims the chart down to **infrastructure-only configuration**. ~80 operational tuning env vars are removed from `values.yaml`, `values-template.yaml`, and `templates/configmap.yaml`.

## Rationale

The app now uses **systemplane** (runtime config plane backed by Postgres + admin API) for all hot-reloadable operational knobs. Continuing to ship those same values via the chart's ConfigMap creates a stale, duplicated source of truth: env vars seed systemplane on first boot but are never re-read at runtime. Operators end up tweaking systemplane via the admin API while the chart still appears to "own" the value — confusing.

After this change, the chart is the source of truth ONLY for:

| Category | Examples |
|---|---|
| **Database connection** | Postgres primary+replica, Valkey/Redis, MongoDB |
| **Message broker** | RabbitMQ (URL, exchange, toggle) |
| **Multi-tenant infrastructure** | `MULTI_TENANT_ENABLED`, `MULTI_TENANT_URL`, `MULTI_TENANT_REDIS_HOST`, `AWS_REGION`, integration secret template |
| **Outbound adapters** | URLs + auth toggles for Midaz, CRM, Fees, JD-SPB |
| **Server/TLS** | Listen address, body limit, TLS certs, proxy headers |
| **OpenTelemetry** | Exporter endpoint + resource attributes |
| **Inbound auth** | `PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_ADDRESS` |
| **Secrets** | All credentials (unchanged, in `templates/secrets.yaml`) |

## Removed env vars (now systemplane-managed)

- Log level + CORS: `LOG_LEVEL`, `CORS_ALLOWED_*`
- Rate limit: `RATE_LIMIT_ENABLED`, `RATE_LIMIT_MAX`, `RATE_LIMIT_EXPIRY_SEC`
- Idempotency: `IDEMPOTENCY_RETRY_WINDOW_SEC`, `IDEMPOTENCY_REQUIRE_REDIS`, `DUPLICATE_GUARD_TTL_SEC`
- Outbound adapter timeouts/retries/circuit breakers for **Midaz, CRM, Fees, JD-SPB**: all `*_TIMEOUT_MS`, `*_MAX_RETRIES`, `*_CACHE_TTL_MS`, `MIDAZ_BREAKER_*`, `MIDAZ_OTEL_ENABLED`, `MIDAZ_DEBUG`
- Fees behavior: `FEES_FAIL_CLOSED_DEFAULT`, `FEES_MAX_FEE_AMOUNT_CENTS`, `FEES_REFUND_ON_DEVOLUCAO`
- JD signing/polling: `JD_SIGNATURE_REQUIRED`, `JD_VALIDATE_EXTERNAL_SIGNATURE`, `JD_POLLING_ENABLED`, `JD_POLL_*`
- Reconciliation: `RECONCILIATION_PENDING_ALERT_THRESHOLD`, `BTF_RECONCILIATION_*`
- Webhook delivery: `WEBHOOK_QUEUE_NAME`, `WEBHOOK_DLQ_NAME`, `WEBHOOK_TIMEOUT_MS`, `WEBHOOK_MAX_RETRIES`, `WEBHOOK_RETRY_BACKOFF_MS`, `WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS`, `WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC`, `WEBHOOK_ENDPOINT_URL`, `WEBHOOK_CONSUMER_TAG`, `WEBHOOK_PREFETCH_COUNT`
- Usage limits: `USAGE_LIMITS_ENABLED`, `USAGE_LIMIT_DAILY_CENTS`, `USAGE_LIMIT_MONTHLY_CENTS`
- Operating hours: `TRANSFER_OPERATING_OPEN/CLOSE/TIMEZONE`
- RabbitMQ tuning: `RABBITMQ_MAX_RETRIES`, `RABBITMQ_PUBLISH_TIMEOUT_MS`, `RABBITMQ_RETRY_BACKOFF_MS`, `RABBITMQ_ROUTING_KEY_PREFIX`
- Multi-tenant tuning (matches lib-commons compiled default): `MULTI_TENANT_MAX_TENANT_POOLS`, `MULTI_TENANT_IDLE_TIMEOUT_SEC`, `MULTI_TENANT_TIMEOUT`, `MULTI_TENANT_CACHE_TTL_SEC`, `MULTI_TENANT_CIRCUIT_BREAKER_*`, `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC`, `MULTI_TENANT_REDIS_PORT`
- Misc: `AUTH_CACHE_TTL_SEC`, `DB_METRICS_INTERVAL_SEC`, `BTF_FEE_ENABLED`, `BTF_MIDAZ_CB_ENABLED`, `SYSTEMPLANE_BACKEND`, `SYSTEMPLANE_POSTGRES_SCHEMA`, `ALLOW_INSECURE_OTEL`

## Validation

\`\`\`
helm template test-release . \
  --set bankTransfer.configmap.MIDAZ_BASE_URL=http://midaz \
  --set bankTransfer.configmap.CRM_BASE_URL=http://crm \
  --set bankTransfer.configmap.FEES_BASE_URL=http://fees \
  --set bankTransfer.configmap.JD_BASE_URL=http://jd \
  --set bankTransfer.configmap.JD_ORIGIN_ISPB=12345678 \
  --set bankTransfer.secrets.JD_INCOMING_RAW_XML_ENCRYPTION_KEY=...
  --set bankTransfer.secrets.RECIPIENT_DETAILS_ENCRYPTION_KEY=...
  --set bankTransfer.secrets.POSTGRES_PASSWORD=...
  --set bankTransfer.secrets.MONGO_URI=mongodb://...
  --set bankTransfer.secrets.JD_PRIVATE_KEY_PEM=...
  --set bankTransfer.secrets.JD_PUBLIC_KEY_PEM=...
  --set bankTransfer.secrets.JD_USER_CODE=...
  --set bankTransfer.secrets.JD_PASSWORD=...
\`\`\`

Renders 1955 lines of valid YAML across all templates. Rendered ConfigMap shrank from 158 lines (~150 env vars) to 81 lines (~60 env vars).

## Migration

Existing consumers can:
1. Drop the removed entries from their `values.yaml` (chart now ignores them).
2. Pre-populate the equivalent **systemplane** key in Postgres before this chart version rolls out — OR accept the lib-commons compiled default (sane production values for retries/timeouts).
3. Use the systemplane admin API at runtime to override any value without restarting the pod.

This PR is a **non-breaking minor bump** (`1.5.0-beta.1` → `1.6.0-beta.1`): the app still consumes env vars when present, the chart just no longer emits the operational subset. All existing deployments continue to work without changes.

See CHANGELOG.md for the full keep/remove split and migration notes.