### PR TITLE
chore(bank-transfer): expose JD polling in values template

### DIFF
--- a/charts/plugin-br-bank-transfer/values-template.yaml
+++ b/charts/plugin-br-bank-transfer/values-template.yaml
@@ -149,6 +149,7 @@ bankTransfer:
     JD_ORIGIN_ISPB: ""  # REQUIRED when JD_SANDBOX_MODE=false
     # JD_LEGACY_CODE: ""
     JD_SIGNING_MODE: "local_pem"  # local_pem | external_provided | disabled
+    JD_POLLING_ENABLED: "false"
 
   secrets:
     # PostgreSQL - REQUIRED


### PR DESCRIPTION
## Summary
- Add `JD_POLLING_ENABLED: "false"` to `plugin-br-bank-transfer` values template
- Keep existing configmap rendering and default values aligned with the template

## Validation
- Parsed `charts/plugin-br-bank-transfer/values-template.yaml` and `values.yaml` as YAML
- Verified `JD_POLLING_ENABLED` exists in the values template, default values, and configmap template

Requested by: @jeffersonrodrigues92
