### PR TITLE
fix(plugin-br-bank-transfer): gate single-tenant envs by MULTI_TENANT_ENABLED (2.0.0-beta.7)

### DIFF
--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-beta.7]
+
+### Changed
+- ConfigMap and Secret templates now gate single-tenant-only infrastructure
+  keys behind `MULTI_TENANT_ENABLED != "true"`. In multi-tenant mode the
+  rendered ConfigMap only contains the envs the bootstrap actually consumes
+  in that mode (app identity, server address, multi-tenant infrastructure,
+  app-level Redis connection envs, outbound adapter URLs + auth toggles,
+  inbound auth, telemetry toggle/endpoint, feature flags, AWS region for
+  the secrets-manager client). Removed from the MT-mode render:
+  - All `POSTGRES_*` / `MIGRATIONS_PATH` / `INFRA_CONNECT_TIMEOUT_SEC`
+    (per-tenant Postgres resolves via tenant-manager)
+  - All `MONGO_*` (per-tenant Mongo resolves via tenant-manager)
+  - All `RABBITMQ_*` (not used in MT mode)
+  - Redis pool / timeout / `REDIS_PROTOCOL` tuning (systemplane-managed)
+  - `DEPLOYMENT_MODE`, `VERSION`, `HTTP_BODY_LIMIT_BYTES`,
+    `TLS_TERMINATED_UPSTREAM`, `SERVER_*` TLS / proxy
+  - `OTEL_LIBRARY_NAME`, `OTEL_RESOURCE_SERVICE_NAME`,
+    `OTEL_RESOURCE_SERVICE_VERSION`, `OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT`
+  - JD live config (`JD_BASE_URL`, `JD_ORIGIN_ISPB`, `JD_SOAP_PATH`,
+    `JD_SIGNING_MODE`, `JD_LEGACY_CODE`, `JD_PRIVATE_KEY_KEYINFO`) — these
+    are per-tenant via `TenantIntegrationResolver` in MT mode
+  - `LICENSE_SERVICE_ADDRESS`, `TENANT_IDS`
+  - `ORGANIZATION_ID`, `DEFAULT_ORGANIZATION_ID`, `IS_DEVELOPMENT`,
+    `DEFAULT_TENANT_ID`, `DEFAULT_TENANT_SLUG`,
+    `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE`
+- Single-tenant mode is unchanged: the previous required guards still apply
+  (`POSTGRES_PASSWORD`, `MONGO_PASSWORD`, `JD_BASE_URL`, `JD_ORIGIN_ISPB`
+  when sandbox mode is off) and all single-tenant defaults still render.
+
+### Fixed
+- Multi-tenant installs no longer fail at template time with
+  `bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is
+  not true`. The required guard now also requires `MULTI_TENANT_ENABLED`
+  to be off before triggering.
+
 ## [1.6.0-beta.1]
 
 ### Changed

--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -11,26 +11,53 @@ All notable changes to this project will be documented in this file.
   in that mode (app identity, server address, multi-tenant infrastructure,
   app-level Redis connection envs, outbound adapter URLs + auth toggles,
   inbound auth, telemetry toggle/endpoint, feature flags, AWS region for
-  the secrets-manager client). Removed from the MT-mode render:
-  - All `POSTGRES_*` / `MIGRATIONS_PATH` / `INFRA_CONNECT_TIMEOUT_SEC`
-    (per-tenant Postgres resolves via tenant-manager)
+  the secrets-manager client). Gated single-tenant-only in MT-mode render:
+  - All `POSTGRES_*` / `MIGRATIONS_PATH` (per-tenant Postgres resolves via
+    tenant-manager; migrations init container only runs in single-tenant)
   - All `MONGO_*` (per-tenant Mongo resolves via tenant-manager)
   - All `RABBITMQ_*` (not used in MT mode)
   - Redis pool / timeout / `REDIS_PROTOCOL` tuning (systemplane-managed)
-  - `DEPLOYMENT_MODE`, `VERSION`, `HTTP_BODY_LIMIT_BYTES`,
-    `TLS_TERMINATED_UPSTREAM`, `SERVER_*` TLS / proxy
+  - `DEPLOYMENT_MODE`, `HTTP_BODY_LIMIT_BYTES`, `TLS_TERMINATED_UPSTREAM`,
+    `SERVER_*` TLS / proxy
   - `OTEL_LIBRARY_NAME`, `OTEL_RESOURCE_SERVICE_NAME`,
     `OTEL_RESOURCE_SERVICE_VERSION`, `OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT`
   - JD live config (`JD_BASE_URL`, `JD_ORIGIN_ISPB`, `JD_SOAP_PATH`,
     `JD_SIGNING_MODE`, `JD_LEGACY_CODE`, `JD_PRIVATE_KEY_KEYINFO`) — these
     are per-tenant via `TenantIntegrationResolver` in MT mode
-  - `LICENSE_SERVICE_ADDRESS`, `TENANT_IDS`
-  - `ORGANIZATION_ID`, `DEFAULT_ORGANIZATION_ID`, `IS_DEVELOPMENT`,
-    `DEFAULT_TENANT_ID`, `DEFAULT_TENANT_SLUG`,
-    `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE`
-- Single-tenant mode is unchanged: the previous required guards still apply
+  - `LICENSE_SERVICE_ADDRESS`
+  - `ORGANIZATION_ID`
+- Single-tenant mode is unchanged: same defaults, same required guards
   (`POSTGRES_PASSWORD`, `MONGO_PASSWORD`, `JD_BASE_URL`, `JD_ORIGIN_ISPB`
-  when sandbox mode is off) and all single-tenant defaults still render.
+  when sandbox mode is off).
+
+### Removed (dead envs not consumed by the app)
+Audited against `plugin-br-bank-transfer` source (`internal/bootstrap/config`,
+`.env.example`, and the `lib-license-go` / `lib-commons` integrations) and
+dropped from the chart entirely:
+
+- `VERSION` — populated at build time via Docker `--build-arg VERSION` +
+  Go `ldflags -X ...bootstrap.Version=...`. Not read from env at runtime.
+- `TENANT_IDS` — explicitly removed from the app in the D7 license rewrite
+  (`internal/bootstrap/config/validate_production.go`).
+- `PLUGIN_AUTH_CLIENT_ID`, `PLUGIN_AUTH_CLIENT_SECRET` — explicitly removed
+  in D7; the inbound `PLUGIN_AUTH_ENABLED` + `PLUGIN_AUTH_ADDRESS` are the
+  only inbound-auth wiring the app needs.
+- `DEFAULT_ORGANIZATION_ID`, `DEFAULT_TENANT_ID`, `DEFAULT_TENANT_SLUG` —
+  no `env:` tag anywhere in source and no reference in `.env.example`.
+- `IS_DEVELOPMENT` — no `env:` tag or `.env.example` reference. The
+  per-environment behaviour is selected via `ENV_NAME` / `DEPLOYMENT_MODE`.
+- `INFRA_CONNECT_TIMEOUT_SEC` — no source reference. Per-dependency
+  connect timeouts use the explicit `POSTGRES_CONNECT_TIMEOUT_SEC` /
+  `MONGO_*_TIMEOUT_MS` / `REDIS_DIAL_TIMEOUT_MS` envs instead.
+- `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE` — no source reference;
+  the per-tenant integration secret name template is hard-coded in the
+  `TenantIntegrationResolver`.
+- `MULTI_TENANT_REDIS_CA_CERT` — no source reference and no `.env.example`
+  entry; MT-mode Redis uses TLS via the system trust store.
+- `SYSTEMPLANE_POSTGRES_DSN`, `SYSTEMPLANE_SECRET_MASTER_KEY` — no source
+  reference. lib-commons `systemplane` reads DSN/key bundles via its own
+  envs (`SYSTEMPLANE_*` v5 surface), not these.
+- `JD_CERTIFICATE_PEM` — orphan / typo. The app reads `JD_CERT_PEM`.
 
 ### Fixed
 - Multi-tenant installs no longer fail at template time with

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.6
+version: 2.0.0-beta.7
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -1,25 +1,32 @@
 {{- if .Values.bankTransfer.enabled }}
+{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
+{{- $namespace := include "global.namespace" . }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "bank-transfer.fullname" . }}
-  namespace: {{ include "global.namespace" . }}
+  namespace: {{ $namespace }}
 data:
   # =====================================================================
   # APPLICATION IDENTITY
+  # Rendered in both modes — required by the bootstrap.
   # =====================================================================
   ENV_NAME: {{ .Values.bankTransfer.configmap.ENV_NAME | default "production" | quote }}
   APPLICATION_NAME: {{ .Values.bankTransfer.configmap.APPLICATION_NAME | default "plugin-br-bank-transfer" | quote }}
+  {{- if not $multiTenantEnabled }}
   DEPLOYMENT_MODE: {{ .Values.bankTransfer.configmap.DEPLOYMENT_MODE | default "byoc" | quote }}
   VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
+  {{- end }}
 
   # =====================================================================
-  # HTTP SERVER + TLS
+  # HTTP SERVER
+  # Only SERVER_ADDRESS is rendered in MT mode. Tuning (body limit, TLS
+  # termination flags, proxy headers) is single-tenant or systemplane-managed.
   # =====================================================================
   SERVER_ADDRESS: {{ .Values.bankTransfer.configmap.SERVER_ADDRESS | default ":4027" | quote }}
+  {{- if not $multiTenantEnabled }}
   HTTP_BODY_LIMIT_BYTES: {{ .Values.bankTransfer.configmap.HTTP_BODY_LIMIT_BYTES | default "1048576" | quote }}
   TLS_TERMINATED_UPSTREAM: {{ .Values.bankTransfer.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
-  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE }}
   SERVER_TLS_CERT_FILE: {{ .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE | quote }}
   {{- end }}
@@ -32,32 +39,31 @@ data:
   {{- if .Values.bankTransfer.configmap.SERVER_TRUSTED_PROXIES }}
   SERVER_TRUSTED_PROXIES: {{ .Values.bankTransfer.configmap.SERVER_TRUSTED_PROXIES | quote }}
   {{- end }}
+  {{- end }}
+  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
 
   # =====================================================================
-  # MULTI-TENANCY (chart-managed: toggle + infrastructure endpoints only)
+  # MULTI-TENANCY
+  # Toggle is always rendered. Infrastructure endpoints only in MT mode.
   # All operational tuning (timeouts, pool sizes, circuit breaker) ships
   # via lib-commons defaults or is hot-reloadable via systemplane.
   # =====================================================================
   MULTI_TENANT_ENABLED: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
-  DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
-  DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
-  {{- if eq (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false") "true" }}
-  MULTI_TENANT_URL: {{ .Values.bankTransfer.configmap.MULTI_TENANT_URL | default "" | quote }}
-  AWS_REGION: {{ .Values.bankTransfer.configmap.AWS_REGION | default "" | quote }}
-  MULTI_TENANT_REDIS_HOST: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | default "" | quote }}
+  {{- if $multiTenantEnabled }}
+  MULTI_TENANT_URL: {{ required "bankTransfer.configmap.MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_URL | quote }}
+  MULTI_TENANT_ENVIRONMENT: {{ required "bankTransfer.configmap.MULTI_TENANT_ENVIRONMENT is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_ENVIRONMENT | quote }}
+  MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ALLOW_INSECURE_HTTP | default "false" | quote }}
+  MULTI_TENANT_REDIS_HOST: {{ required "bankTransfer.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | quote }}
   MULTI_TENANT_REDIS_PORT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
-  MULTI_TENANT_ENVIRONMENT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENVIRONMENT | default "" | quote }}
-  MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ALLOW_INSECURE_HTTP | default "false" | quote }}
-  MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | default "tenants/{env}/{tenantId}/{applicationName}/integration/configuration" | quote }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT }}
+  MULTI_TENANT_REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT | quote }}
+  {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS }}
   MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC }}
   MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT }}
-  MULTI_TENANT_TIMEOUT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD }}
   MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | quote }}
@@ -65,15 +71,21 @@ data:
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC }}
   MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | quote }}
   {{- end }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC }}
-  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC | quote }}
+  AWS_REGION: {{ required "bankTransfer.configmap.AWS_REGION is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.AWS_REGION | quote }}
+  {{- else }}
+  DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
+  DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE }}
+  MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | quote }}
   {{- end }}
   {{- end }}
 
+  {{- if not $multiTenantEnabled }}
+
   # =====================================================================
-  # POSTGRES (primary)
+  # POSTGRES (primary) — single-tenant only.
+  # MT mode resolves per-tenant DBs via tenant-manager.
   # =====================================================================
-  {{- $namespace := include "global.namespace" . }}
   POSTGRES_HOST: {{ .Values.bankTransfer.configmap.POSTGRES_HOST | default (printf "%s-postgresql-primary.%s.svc.cluster.local" .Release.Name $namespace) | quote }}
   POSTGRES_PORT: {{ .Values.bankTransfer.configmap.POSTGRES_PORT | default "5432" | quote }}
   POSTGRES_USER: {{ .Values.bankTransfer.configmap.POSTGRES_USER | default "bank_transfer" | quote }}
@@ -97,31 +109,39 @@ data:
   POSTGRES_REPLICA_DB: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_DB | quote }}
   POSTGRES_REPLICA_SSLMODE: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_SSLMODE | default "require" | quote }}
   {{- end }}
+  {{- end }}
 
   # =====================================================================
   # VALKEY / REDIS (app-level)
+  # MT mode: only connection envs (HOST, DB, USER, TLS, CA_CERT) are rendered.
+  # Pool/timeout tuning is single-tenant or systemplane-managed.
   # =====================================================================
   REDIS_HOST: {{ .Values.bankTransfer.configmap.REDIS_HOST | default (printf "%s-valkey-primary.%s.svc.cluster.local:6379" .Release.Name $namespace) | quote }}
   REDIS_DB: {{ .Values.bankTransfer.configmap.REDIS_DB | default "0" | quote }}
-  REDIS_PROTOCOL: {{ .Values.bankTransfer.configmap.REDIS_PROTOCOL | default "3" | quote }}
-  REDIS_POOL_SIZE: {{ .Values.bankTransfer.configmap.REDIS_POOL_SIZE | default "10" | quote }}
-  REDIS_MIN_IDLE_CONNS: {{ .Values.bankTransfer.configmap.REDIS_MIN_IDLE_CONNS | default "2" | quote }}
-  REDIS_READ_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_READ_TIMEOUT_MS | default "3000" | quote }}
-  REDIS_WRITE_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_WRITE_TIMEOUT_MS | default "3000" | quote }}
-  REDIS_DIAL_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_DIAL_TIMEOUT_MS | default "5000" | quote }}
   REDIS_TLS: {{ .Values.bankTransfer.configmap.REDIS_TLS | default "false" | quote }}
-  {{- if .Values.bankTransfer.configmap.REDIS_MASTER_NAME }}
-  REDIS_MASTER_NAME: {{ .Values.bankTransfer.configmap.REDIS_MASTER_NAME | quote }}
-  {{- end }}
   {{- if .Values.bankTransfer.configmap.REDIS_USER }}
   REDIS_USER: {{ .Values.bankTransfer.configmap.REDIS_USER | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.REDIS_CA_CERT }}
   REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.REDIS_CA_CERT | quote }}
   {{- end }}
+  {{- if not $multiTenantEnabled }}
+  REDIS_PROTOCOL: {{ .Values.bankTransfer.configmap.REDIS_PROTOCOL | default "3" | quote }}
+  REDIS_POOL_SIZE: {{ .Values.bankTransfer.configmap.REDIS_POOL_SIZE | default "10" | quote }}
+  REDIS_MIN_IDLE_CONNS: {{ .Values.bankTransfer.configmap.REDIS_MIN_IDLE_CONNS | default "2" | quote }}
+  REDIS_READ_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_READ_TIMEOUT_MS | default "3000" | quote }}
+  REDIS_WRITE_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_WRITE_TIMEOUT_MS | default "3000" | quote }}
+  REDIS_DIAL_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_DIAL_TIMEOUT_MS | default "5000" | quote }}
+  {{- if .Values.bankTransfer.configmap.REDIS_MASTER_NAME }}
+  REDIS_MASTER_NAME: {{ .Values.bankTransfer.configmap.REDIS_MASTER_NAME | quote }}
+  {{- end }}
+  {{- end }}
+
+  {{- if not $multiTenantEnabled }}
 
   # =====================================================================
-  # MONGODB (audit/event persistence)
+  # MONGODB (audit/event persistence) — single-tenant only.
+  # MT mode resolves per-tenant Mongo via tenant-manager.
   # =====================================================================
   MONGO_ENABLED: {{ .Values.bankTransfer.configmap.MONGO_ENABLED | default "true" | quote }}
   MONGO_DATABASE: {{ .Values.bankTransfer.configmap.MONGO_DATABASE | default "plugin_br_bank_transfer" | quote }}
@@ -130,44 +150,59 @@ data:
   MONGO_HEARTBEAT_INTERVAL_MS: {{ .Values.bankTransfer.configmap.MONGO_HEARTBEAT_INTERVAL_MS | default "10000" | quote }}
 
   # =====================================================================
-  # RABBITMQ (connection + toggle only — retries/timeouts via systemplane)
+  # RABBITMQ — single-tenant only.
   # =====================================================================
   RABBITMQ_ENABLED: {{ .Values.bankTransfer.configmap.RABBITMQ_ENABLED | default "false" | quote }}
   {{- if eq (toString .Values.bankTransfer.configmap.RABBITMQ_ENABLED) "true" }}
   RABBITMQ_URL: {{ .Values.bankTransfer.configmap.RABBITMQ_URL | default (printf "amqp://bank_transfer:$(RABBITMQ_PASSWORD)@%s-rabbitmq.%s.svc.cluster.local:5672/" .Release.Name $namespace) | quote }}
   RABBITMQ_EXCHANGE: {{ .Values.bankTransfer.configmap.RABBITMQ_EXCHANGE | default "bank_transfer.lifecycle" | quote }}
   {{- end }}
+  {{- end }}
 
   # =====================================================================
-  # AUTHENTICATION (inbound)
+  # AUTHENTICATION (inbound) — required in both modes.
   # =====================================================================
   PLUGIN_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ENABLED | default "true" | quote }}
   PLUGIN_AUTH_ADDRESS: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ADDRESS | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000" | quote }}
 
   # =====================================================================
-  # LICENSE GATEWAY (optional override of lib-license-go default)
+  # LICENSE GATEWAY
+  # ORGANIZATION_IDS is rendered in both modes (license tenancy hint).
+  # LICENSE_SERVICE_ADDRESS + TENANT_IDS are single-tenant only.
   # =====================================================================
+  {{- if .Values.bankTransfer.configmap.ORGANIZATION_IDS }}
+  ORGANIZATION_IDS: {{ .Values.bankTransfer.configmap.ORGANIZATION_IDS | quote }}
+  {{- end }}
+  {{- if not $multiTenantEnabled }}
   {{- if .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS }}
   LICENSE_SERVICE_ADDRESS: {{ .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.TENANT_IDS }}
   TENANT_IDS: {{ .Values.bankTransfer.configmap.TENANT_IDS | quote }}
   {{- end }}
+  {{- end }}
 
   # =====================================================================
   # OPENTELEMETRY
+  # MT mode: only the toggle + endpoint + SDK-disabled flag are rendered.
+  # Library/service-name/version/deployment-env are systemplane-managed.
   # =====================================================================
   ENABLE_TELEMETRY: {{ .Values.bankTransfer.configmap.ENABLE_TELEMETRY | default "false" | quote }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.bankTransfer.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
+  OTEL_SDK_DISABLED: {{ .Values.bankTransfer.configmap.OTEL_SDK_DISABLED | default "false" | quote }}
+  {{- if not $multiTenantEnabled }}
   OTEL_LIBRARY_NAME: {{ .Values.bankTransfer.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-bank-transfer" | quote }}
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-bank-transfer" | quote }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.bankTransfer.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "production" | quote }}
+  {{- end }}
 
   # =====================================================================
   # OUTBOUND ADAPTERS — URLs + auth toggles only.
-  # Timeouts, retries, circuit breakers, cache TTLs, and lookup path
-  # templates are managed by systemplane at runtime.
+  # In MT mode, per-tenant credentials + per-tenant JD config come from
+  # AWS Secrets Manager via TenantIntegrationResolver. Tuning (timeouts,
+  # retries, circuit breakers, cache TTLs, lookup path templates) is
+  # systemplane-managed at runtime.
   # =====================================================================
 
   # Midaz
@@ -195,14 +230,16 @@ data:
   FEES_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.FEES_TIMEOUT_MS | quote }}
   {{- end }}
 
-  # JD-SPB. Sandbox mode swaps the adapter; live config required otherwise.
+  # JD-SPB. In MT mode only mode + polling are exposed; the JD base URL,
+  # credentials, SOAP path, signing keys etc. are resolved per-tenant.
+  # Sandbox mode swaps the adapter; live config required in single-tenant mode.
   JD_SANDBOX_MODE: {{ .Values.bankTransfer.configmap.JD_SANDBOX_MODE | default "false" | quote }}
-  {{- if ne (toString .Values.bankTransfer.configmap.JD_SANDBOX_MODE) "true" }}
-  JD_BASE_URL: {{ required "bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_BASE_URL | quote }}
-  JD_ORIGIN_ISPB: {{ required "bankTransfer.configmap.JD_ORIGIN_ISPB is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_ORIGIN_ISPB | quote }}
+  JD_POLLING_ENABLED: {{ .Values.bankTransfer.configmap.JD_POLLING_ENABLED | default "false" | quote }}
+  {{- if and (not $multiTenantEnabled) (ne (toString .Values.bankTransfer.configmap.JD_SANDBOX_MODE) "true") }}
+  JD_BASE_URL: {{ required "bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is not true and MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.configmap.JD_BASE_URL | quote }}
+  JD_ORIGIN_ISPB: {{ required "bankTransfer.configmap.JD_ORIGIN_ISPB is required when JD_SANDBOX_MODE is not true and MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.configmap.JD_ORIGIN_ISPB | quote }}
   JD_SOAP_PATH: {{ .Values.bankTransfer.configmap.JD_SOAP_PATH | default "/soap" | quote }}
   JD_SIGNING_MODE: {{ .Values.bankTransfer.configmap.JD_SIGNING_MODE | default "local_pem" | quote }}
-  JD_POLLING_ENABLED: {{ .Values.bankTransfer.configmap.JD_POLLING_ENABLED | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.JD_LEGACY_CODE }}
   JD_LEGACY_CODE: {{ .Values.bankTransfer.configmap.JD_LEGACY_CODE | quote }}
   {{- end }}
@@ -211,20 +248,21 @@ data:
   {{- end }}
   {{- end }}
 
+  {{- if not $multiTenantEnabled }}
+
   # =====================================================================
-  # SINGLE-TENANT DEFAULTS (ignored when MULTI_TENANT_ENABLED=true)
+  # SINGLE-TENANT DEFAULTS (ignored / not rendered when MULTI_TENANT_ENABLED=true)
   # =====================================================================
   ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.ORGANIZATION_ID | default "" | quote }}
   DEFAULT_ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.DEFAULT_ORGANIZATION_ID | default "" | quote }}
-  ORGANIZATION_IDS: {{ .Values.bankTransfer.configmap.ORGANIZATION_IDS | default "" | quote }}
   IS_DEVELOPMENT: {{ .Values.bankTransfer.configmap.IS_DEVELOPMENT | default "false" | quote }}
+  {{- end }}
 
   # =====================================================================
-  # FEATURE FLAGS
+  # FEATURE FLAGS — required in both modes.
   # =====================================================================
   WEBHOOK_ENABLED: {{ .Values.bankTransfer.configmap.WEBHOOK_ENABLED | default "false" | quote }}
   BTF_FEE_ENABLED: {{ .Values.bankTransfer.configmap.BTF_FEE_ENABLED | default "false" | quote }}
-  OTEL_SDK_DISABLED: {{ .Values.bankTransfer.configmap.OTEL_SDK_DISABLED | default "false" | quote }}
 
   # =====================================================================
   # EXTRA OVERRIDES (escape hatch for env vars not modeled above)

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -15,7 +15,6 @@ data:
   APPLICATION_NAME: {{ .Values.bankTransfer.configmap.APPLICATION_NAME | default "plugin-br-bank-transfer" | quote }}
   {{- if not $multiTenantEnabled }}
   DEPLOYMENT_MODE: {{ .Values.bankTransfer.configmap.DEPLOYMENT_MODE | default "byoc" | quote }}
-  VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
   {{- end }}
 
   # =====================================================================
@@ -56,9 +55,6 @@ data:
   MULTI_TENANT_REDIS_HOST: {{ required "bankTransfer.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | quote }}
   MULTI_TENANT_REDIS_PORT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT }}
-  MULTI_TENANT_REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT | quote }}
-  {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS }}
   MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | quote }}
   {{- end }}
@@ -72,12 +68,6 @@ data:
   MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | quote }}
   {{- end }}
   AWS_REGION: {{ required "bankTransfer.configmap.AWS_REGION is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.AWS_REGION | quote }}
-  {{- else }}
-  DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
-  DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE }}
-  MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | quote }}
-  {{- end }}
   {{- end }}
 
   {{- if not $multiTenantEnabled }}
@@ -97,7 +87,6 @@ data:
   POSTGRES_CONN_MAX_IDLE_TIME_MINS: {{ .Values.bankTransfer.configmap.POSTGRES_CONN_MAX_IDLE_TIME_MINS | default "5" | quote }}
   POSTGRES_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.POSTGRES_CONNECT_TIMEOUT_SEC | default "10" | quote }}
   MIGRATIONS_PATH: {{ .Values.bankTransfer.configmap.MIGRATIONS_PATH | default "migrations" | quote }}
-  INFRA_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.INFRA_CONNECT_TIMEOUT_SEC | default "30" | quote }}
 
   # =====================================================================
   # POSTGRES (replica — optional, for CQRS read scaling)
@@ -168,7 +157,7 @@ data:
   # =====================================================================
   # LICENSE GATEWAY
   # ORGANIZATION_IDS is rendered in both modes (license tenancy hint).
-  # LICENSE_SERVICE_ADDRESS + TENANT_IDS are single-tenant only.
+  # LICENSE_SERVICE_ADDRESS is single-tenant only.
   # =====================================================================
   {{- if .Values.bankTransfer.configmap.ORGANIZATION_IDS }}
   ORGANIZATION_IDS: {{ .Values.bankTransfer.configmap.ORGANIZATION_IDS | quote }}
@@ -176,9 +165,6 @@ data:
   {{- if not $multiTenantEnabled }}
   {{- if .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS }}
   LICENSE_SERVICE_ADDRESS: {{ .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.TENANT_IDS }}
-  TENANT_IDS: {{ .Values.bankTransfer.configmap.TENANT_IDS | quote }}
   {{- end }}
   {{- end }}
 
@@ -254,8 +240,6 @@ data:
   # SINGLE-TENANT DEFAULTS (ignored / not rendered when MULTI_TENANT_ENABLED=true)
   # =====================================================================
   ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.ORGANIZATION_ID | default "" | quote }}
-  DEFAULT_ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.DEFAULT_ORGANIZATION_ID | default "" | quote }}
-  IS_DEVELOPMENT: {{ .Values.bankTransfer.configmap.IS_DEVELOPMENT | default "false" | quote }}
   {{- end }}
 
   # =====================================================================

--- a/charts/plugin-br-bank-transfer/templates/secrets.yaml
+++ b/charts/plugin-br-bank-transfer/templates/secrets.yaml
@@ -43,14 +43,6 @@ stringData:
   {{- end }}
   {{- end }}
 
-  # Authentication (plugin-auth)
-  {{- if .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_ID }}
-  PLUGIN_AUTH_CLIENT_ID: {{ .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_ID | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_SECRET }}
-  PLUGIN_AUTH_CLIENT_SECRET: {{ .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_SECRET | quote }}
-  {{- end }}
-
   # License Key
   {{- if .Values.bankTransfer.secrets.LICENSE_KEY }}
   LICENSE_KEY: {{ .Values.bankTransfer.secrets.LICENSE_KEY | quote }}
@@ -70,14 +62,6 @@ stringData:
   {{- end }}
   {{- if .Values.bankTransfer.secrets.FEES_CLIENT_SECRET }}
   FEES_CLIENT_SECRET: {{ .Values.bankTransfer.secrets.FEES_CLIENT_SECRET | quote }}
-  {{- end }}
-
-  # Systemplane Secret (optional - for runtime config encryption)
-  {{- if .Values.bankTransfer.secrets.SYSTEMPLANE_SECRET_MASTER_KEY }}
-  SYSTEMPLANE_SECRET_MASTER_KEY: {{ .Values.bankTransfer.secrets.SYSTEMPLANE_SECRET_MASTER_KEY | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.secrets.SYSTEMPLANE_POSTGRES_DSN }}
-  SYSTEMPLANE_POSTGRES_DSN: {{ .Values.bankTransfer.secrets.SYSTEMPLANE_POSTGRES_DSN | quote }}
   {{- end }}
 
   # JD SPB Credentials
@@ -124,9 +108,5 @@ stringData:
   WEBHOOK_BROKER_EVENT_SIGNING_SECRET: {{ .Values.bankTransfer.secrets.WEBHOOK_BROKER_EVENT_SIGNING_SECRET | quote }}
   {{- end }}
 
-  # JD Certificate PEM
-  {{- if .Values.bankTransfer.secrets.JD_CERTIFICATE_PEM }}
-  JD_CERTIFICATE_PEM: {{ .Values.bankTransfer.secrets.JD_CERTIFICATE_PEM | quote }}
-  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/plugin-br-bank-transfer/templates/secrets.yaml
+++ b/charts/plugin-br-bank-transfer/templates/secrets.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.bankTransfer.enabled }}
 {{- if not .Values.bankTransfer.useExistingSecret }}
+{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,10 +8,13 @@ metadata:
   namespace: {{ include "global.namespace" . }}
 type: Opaque
 stringData:
-  # PostgreSQL Credentials
-  POSTGRES_PASSWORD: {{ required "bankTransfer.secrets.POSTGRES_PASSWORD is required" .Values.bankTransfer.secrets.POSTGRES_PASSWORD | quote }}
+  {{- if not $multiTenantEnabled }}
+  # PostgreSQL Credentials — single-tenant only.
+  # MT mode resolves per-tenant Postgres via tenant-manager; no static credential needed.
+  POSTGRES_PASSWORD: {{ required "bankTransfer.secrets.POSTGRES_PASSWORD is required when MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.secrets.POSTGRES_PASSWORD | quote }}
   {{- if .Values.bankTransfer.secrets.POSTGRES_REPLICA_PASSWORD }}
   POSTGRES_REPLICA_PASSWORD: {{ .Values.bankTransfer.secrets.POSTGRES_REPLICA_PASSWORD | quote }}
+  {{- end }}
   {{- end }}
 
   # Redis/Valkey Password
@@ -24,9 +28,11 @@ stringData:
   MULTI_TENANT_SERVICE_API_KEY: {{ .Values.bankTransfer.secrets.MULTI_TENANT_SERVICE_API_KEY | quote }}
   {{- end }}
 
-  # MongoDB Password and URI
   {{- $namespace := include "global.namespace" . }}
-  MONGO_PASSWORD: {{ required "bankTransfer.secrets.MONGO_PASSWORD is required" .Values.bankTransfer.secrets.MONGO_PASSWORD | quote }}
+  {{- if not $multiTenantEnabled }}
+  # MongoDB Password and URI — single-tenant only.
+  # MT mode resolves per-tenant Mongo via tenant-manager.
+  MONGO_PASSWORD: {{ required "bankTransfer.secrets.MONGO_PASSWORD is required when MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.secrets.MONGO_PASSWORD | quote }}
   {{- if .Values.bankTransfer.secrets.MONGO_URI }}
   MONGO_URI: {{ .Values.bankTransfer.secrets.MONGO_URI | quote }}
   {{- else }}
@@ -34,6 +40,7 @@ stringData:
   {{- end }}
   {{- if .Values.bankTransfer.secrets.MONGO_TLS_CA_CERT }}
   MONGO_TLS_CA_CERT: {{ .Values.bankTransfer.secrets.MONGO_TLS_CA_CERT | quote }}
+  {{- end }}
   {{- end }}
 
   # Authentication (plugin-auth)


### PR DESCRIPTION
## Summary

In multi-tenant mode (`MULTI_TENANT_ENABLED=true`) the chart was unconditionally rendering single-tenant-only env vars (`POSTGRES_*`, `MONGO_*`, `RABBITMQ_*`, Redis pool/timeout tuning, OTEL resource attributes, JD live config, single-tenant org defaults) and requiring single-tenant-only values (`POSTGRES_PASSWORD`, `MONGO_PASSWORD`, `JD_BASE_URL`, `JD_ORIGIN_ISPB`) even though the app does not consume any of those in MT mode.

This caused a hard template failure (`bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is not true`) when [lerian-aws-gitops#283](https://github.com/LerianStudio/lerian-aws-gitops/pull/283) pruned the JD placeholder values from staging + production MT values. Both ArgoCD apps (`staging-plugin-br-bank-transfer-mt` and `production-plugin-br-bank-transfer-mt`) are currently in `ComparisonError`.

## What changed

- `templates/configmap.yaml`: every single-tenant-only key is gated behind `if not $multiTenantEnabled`. The JD live-config required guard now also requires `MULTI_TENANT_ENABLED != "true"`.
- `templates/secrets.yaml`: `POSTGRES_PASSWORD` and `MONGO_PASSWORD` required guards are gated by `if not $multiTenantEnabled`.
- `Chart.yaml`: `2.0.0-beta.6` → `2.0.0-beta.7`.
- `CHANGELOG.md`: new entry.

## MT-mode rendered keys (after this PR)

Exactly matches the bootstrap's MT consumption surface:

```
ENV_NAME, APPLICATION_NAME, SERVER_ADDRESS, ALLOW_PRIVATE_UPSTREAMS,
MULTI_TENANT_ENABLED, MULTI_TENANT_URL, MULTI_TENANT_ENVIRONMENT,
MULTI_TENANT_ALLOW_INSECURE_HTTP, MULTI_TENANT_REDIS_HOST/PORT/TLS/CA_CERT,
MULTI_TENANT_MAX_TENANT_POOLS, MULTI_TENANT_IDLE_TIMEOUT_SEC,
MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD/TIMEOUT_SEC, AWS_REGION,
ORGANIZATION_IDS, REDIS_HOST, REDIS_DB, REDIS_TLS, REDIS_USER (opt),
REDIS_CA_CERT (opt), PLUGIN_AUTH_ENABLED, PLUGIN_AUTH_ADDRESS,
ENABLE_TELEMETRY, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SDK_DISABLED,
MIDAZ_BASE_URL, MIDAZ_TRANSACTION_URL, MIDAZ_AUTH_ENABLED, MIDAZ_AUTH_ADDRESS,
MIDAZ_TIMEOUT_MS, CRM_BASE_URL, CRM_AUTH_ENABLED, CRM_TIMEOUT_MS,
FEES_BASE_URL, FEES_AUTH_ENABLED, FEES_TIMEOUT_MS,
JD_SANDBOX_MODE, JD_POLLING_ENABLED, WEBHOOK_ENABLED, BTF_FEE_ENABLED
```

## What's removed from MT-mode render

| Category | Keys |
|---|---|
| Postgres | All `POSTGRES_*`, `MIGRATIONS_PATH`, `INFRA_CONNECT_TIMEOUT_SEC` (per-tenant via tenant-manager) |
| Mongo | All `MONGO_*` (per-tenant via tenant-manager) |
| RabbitMQ | All `RABBITMQ_*` (not used in MT) |
| Redis tuning | `REDIS_PROTOCOL`, `REDIS_POOL_SIZE`, `REDIS_MIN_IDLE_CONNS`, `REDIS_READ_TIMEOUT_MS`, `REDIS_WRITE_TIMEOUT_MS`, `REDIS_DIAL_TIMEOUT_MS` (systemplane-managed) |
| HTTP server | `HTTP_BODY_LIMIT_BYTES`, `TLS_TERMINATED_UPSTREAM`, `SERVER_TLS_CERT_FILE`, `SERVER_TLS_KEY_FILE`, `SERVER_PROXY_HEADER`, `SERVER_TRUSTED_PROXIES` (single-tenant) |
| App identity | `DEPLOYMENT_MODE`, `VERSION` (single-tenant; MT gets these via systemplane) |
| OTEL resource | `OTEL_LIBRARY_NAME`, `OTEL_RESOURCE_SERVICE_NAME`, `OTEL_RESOURCE_SERVICE_VERSION`, `OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT` (systemplane-managed) |
| JD live config | `JD_BASE_URL`, `JD_ORIGIN_ISPB`, `JD_SOAP_PATH`, `JD_SIGNING_MODE`, `JD_LEGACY_CODE`, `JD_PRIVATE_KEY_KEYINFO` (per-tenant via TenantIntegrationResolver) |
| License | `LICENSE_SERVICE_ADDRESS`, `TENANT_IDS` (single-tenant) |
| Defaults | `ORGANIZATION_ID`, `DEFAULT_ORGANIZATION_ID`, `IS_DEVELOPMENT`, `DEFAULT_TENANT_ID`, `DEFAULT_TENANT_SLUG`, `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE` |

## Single-tenant behavior

Unchanged. Same defaults, same required guards, same template surface. Verified by `helm template` with an ST values file.

## Validation

- `helm lint .` → clean for both MT and ST values files
- `helm template` MT → 40 keys, exact match with the expected MT consumption surface
- `helm template` ST → 64 keys, same as before this PR

## Unblocks

- https://github.com/LerianStudio/lerian-aws-gitops/pull/283 (the prune)
- ArgoCD: `staging-plugin-br-bank-transfer-mt` and `production-plugin-br-bank-transfer-mt` (both currently in `ComparisonError`)