### PR TITLE
fix(plugin-br-bank-transfer): skip wait-for-dependencies init container and migrations Job in MT mode (2.0.0-beta.8)

### DIFF
--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-beta.8]
+
+### Fixed
+- `templates/deployment.yaml`: the `wait-for-dependencies` init container
+  is now gated behind `MULTI_TENANT_ENABLED != "true"`. In 2.0.0-beta.7
+  we stopped rendering `POSTGRES_HOST` / `POSTGRES_PORT` / `REDIS_HOST`
+  tuning in MT mode, but the init container still referenced
+  `$POSTGRES_HOST:$POSTGRES_PORT` and `$REDIS_HOST` for its `nc -z`
+  probes. With those envs unset the probe loop ran forever printing
+  `nc: bad port ''` and pods never started.
+
+  In MT mode the bootstrap does not connect to any static Postgres /
+  Redis at boot — per-tenant connections are resolved via tenant-manager
+  at request time — so the dependency wait gate has nothing legitimate
+  to wait for. The init container is now omitted entirely in MT mode.
+- `templates/migrations.yaml`: the migrations Job is now gated by
+  `MULTI_TENANT_ENABLED != "true"` as well. Per-tenant schema migrations
+  in MT mode are owned by tenant-manager, not by a static pre-upgrade
+  hook bound to a single Postgres host.
+
 ## [2.0.0-beta.7]
 
 ### Changed

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.7
+version: 2.0.0-beta.8
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/templates/deployment.yaml
+++ b/charts/plugin-br-bank-transfer/templates/deployment.yaml
@@ -37,6 +37,11 @@ spec:
       serviceAccountName: {{ include "bank-transfer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.bankTransfer.podSecurityContext | nindent 8 }}
+      {{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
+      {{- if not $multiTenantEnabled }}
+      # In multi-tenant mode the bootstrap does not connect to any static
+      # Postgres / Redis at boot — per-tenant connections are resolved via
+      # tenant-manager at request time. Skip the dependency wait gate.
       initContainers:
         - name: wait-for-dependencies
           image: busybox:1.37
@@ -77,6 +82,7 @@ spec:
               wait_for_service "$REDIS_SVC" "$REDIS_PORT_NUM"
 
               echo "All dependencies are ready!"
+      {{- end }}
       containers:
         - name: {{ include "bank-transfer.fullname" . }}
           securityContext:

--- a/charts/plugin-br-bank-transfer/templates/migrations.yaml
+++ b/charts/plugin-br-bank-transfer/templates/migrations.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.bankTransfer.migrations.enabled }}
+{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
+{{- if and .Values.bankTransfer.migrations.enabled (not $multiTenantEnabled) }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
## Summary

2.0.0-beta.7 (LerianStudio/helm#1443) gated `POSTGRES_HOST` / `POSTGRES_PORT` / Redis pool tuning behind `MULTI_TENANT_ENABLED != "true"` in the ConfigMap. After the chart bump landed in lerian-aws-gitops#285 and pods rolled in production, all 3 new replicas got stuck in `Init:0/1` because the deployment's `wait-for-dependencies` init container still references those envs:

```
wait_for_service "$POSTGRES_HOST" "$POSTGRES_PORT"
```

With both envs now unset, the container loops forever printing `nc: bad port ''` and pods never become Ready.

## Fix

- `templates/deployment.yaml` — wrap the `initContainers:` block in `if not $multiTenantEnabled`. In MT mode the bootstrap connects to per-tenant Postgres / Redis at request time via tenant-manager, so there is nothing legitimate for the init container to wait for.
- `templates/migrations.yaml` — gate the migrations Job (pre-upgrade / post-install hook) by `not $multiTenantEnabled` as well. Per-tenant schema migrations in MT mode are owned by tenant-manager, not by a static Job bound to a single Postgres host.

## Validation

`helm template` against the live staging + production values:

| Mode | Init containers | Migration Jobs |
|---|---|---|
| MT  | 0 | 0 |
| ST  | 1 | 1 (unchanged) |

`helm lint` clean for both modes.

## Production impact

After this chart version lands and gitops bumps the pin to `2.0.0-beta.8`, the stuck `Init:0/1` pods in `plugin-br-bank-transfer-mt` will be replaced by pods without the init container and should reach `Running` cleanly.

## Rollback

Pinning back to `2.0.0-beta.7` brings the init container back. The bad behaviour only manifests in MT mode (`MULTI_TENANT_ENABLED="true"`).