### PR TITLE
feat(plugin-br-bank-transfer): template CORS_ALLOWED_ORIGINS/METHODS/HEADERS in configmap

### DIFF
--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -42,6 +42,28 @@ data:
   ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
 
   # =====================================================================
+  # CORS POLICY
+  # CORS_ALLOWED_ORIGINS is rendered in both modes. The plugin's
+  # production validator (internal/bootstrap/config/validate_production.go)
+  # rejects wildcard "*" and any origin containing localhost / 127.0.0.1 /
+  # [::1], so production deployments MUST set this to a concrete public
+  # hostname allowlist. When unset, the in-code dev safety net falls back
+  # to "http://localhost:3000" which trips that production validator.
+  # CORS_ALLOWED_METHODS and CORS_ALLOWED_HEADERS are optional: only
+  # rendered when explicitly set so operators can rely on the plugin's
+  # own sensible defaults until they need to override.
+  # =====================================================================
+  {{- if .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS }}
+  CORS_ALLOWED_ORIGINS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS }}
+  CORS_ALLOWED_METHODS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS }}
+  CORS_ALLOWED_HEADERS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS | quote }}
+  {{- end }}
+
+  # =====================================================================
   # MULTI-TENANCY
   # Toggle is always rendered. Infrastructure endpoints only in MT mode.
   # All operational tuning (timeouts, pool sizes, circuit breaker) ships

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -215,6 +215,20 @@ bankTransfer:
     TLS_TERMINATED_UPSTREAM: "true"
 
     # =================================================================
+    # CORS policy
+    # In production the plugin's validator rejects wildcard "*" and any
+    # localhost / 127.0.0.1 / [::1] origin. Leave empty in single-tenant
+    # dev defaults; production deployments MUST override CORS_ALLOWED_ORIGINS
+    # with the API's public ingress hostname (e.g.
+    # "https://bank-transfer.sa-east-1.lerian.io"). When unset, the app's
+    # in-code safety net defaults to http://localhost:3000 — fine for dev,
+    # fatal in production.
+    # =================================================================
+    CORS_ALLOWED_ORIGINS: ""
+    CORS_ALLOWED_METHODS: ""
+    CORS_ALLOWED_HEADERS: ""
+
+    # =================================================================
     # Multi-tenancy
     # Only the toggle, the DEFAULT_TENANT_* identifiers, and the
     # infrastructure endpoints live in the chart. Operational tuning


### PR DESCRIPTION
## What

Add `CORS_ALLOWED_ORIGINS`, `CORS_ALLOWED_METHODS`, and `CORS_ALLOWED_HEADERS` to the `plugin-br-bank-transfer` chart's rendered `ConfigMap` (guarded by `{{ if }}` blocks so they only emit when explicitly set in `values.yaml`).

Mirrors the existing `ORGANIZATION_IDS` and `LICENSE_SERVICE_ADDRESS` patterns at lines 162-168 of `templates/configmap.yaml`.

## Why

The plugin's production config validator rejects insecure CORS configurations at boot:

`internal/bootstrap/config/validate_production.go:170-176`:
- Wildcard `"*"` rejected
- Any origin containing `localhost`, `127.0.0.1`, or `[::1]` rejected

When `CORS_ALLOWED_ORIGINS` is unset, the app falls through to a dev-mode safety net at `internal/bootstrap/config/env_loader.go:239-240`:

```go
if strings.TrimSpace(cfg.Server.CORSAllowedOrigins) == "" {
    cfg.Server.CORSAllowedOrigins = "http://localhost:3000"
}
```

That default trips the production validator and the pod crashloops:

```
ASSERTION FAILED: CORS_ALLOWED_ORIGINS cannot include localhost or loopback origins in production
```

Production MT deployments must set `CORS_ALLOWED_ORIGINS` to a concrete non-localhost value. But the current chart **does not template the key at all** — setting it under `bankTransfer.configmap.CORS_ALLOWED_ORIGINS` in values.yaml is silently ignored because no corresponding template line exists. This PR closes that gap.

## How

`templates/configmap.yaml`: new "CORS POLICY" section after `ALLOW_PRIVATE_UPSTREAMS`, before the multi-tenancy block:

```yaml
{{- if .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS }}
CORS_ALLOWED_ORIGINS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS | quote }}
{{- end }}
{{- if .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS }}
CORS_ALLOWED_METHODS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS | quote }}
{{- end }}
{{- if .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS }}
CORS_ALLOWED_HEADERS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS | quote }}
{{- end }}
```

`values.yaml`: empty defaults under the new `# CORS policy` block, after `TLS / proxy`:

```yaml
CORS_ALLOWED_ORIGINS: ""
CORS_ALLOWED_METHODS: ""
CORS_ALLOWED_HEADERS: ""
```

## Design choices

| Choice | Why |
|---|---|
| Guarded with `{{ if }}` (no `\| default`) | Mirrors the `ORGANIZATION_IDS` pattern — no implicit fallback that could leak dev defaults into production configmaps. Operators explicitly opt in. |
| All three CORS fields supported | `ORIGINS` is required for production-validator compliance. `METHODS` and `HEADERS` are operationally useful and trivially cheap to add — same template shape. |
| Empty defaults in values.yaml | Documents the keys exist + makes them grep-able for operators; rendered output is unchanged when left empty. |
| Rendered in both MT and ST modes | CORS applies to the HTTP server regardless of tenancy model. |

## Verified via `helm template`

| Test case | Expected | Actual |
|---|---|---|
| `CORS_ALLOWED_ORIGINS` + `CORS_ALLOWED_METHODS` set, `CORS_ALLOWED_HEADERS` empty | first two rendered, headers omitted | ✓ |
| All three empty (default values.yaml) | none rendered, no localhost fallback | ✓ |
| `ALLOW_PRIVATE_UPSTREAMS` rendering | unchanged | ✓ |

`helm lint` passes (pre-existing JD/encryption-key warnings unrelated to this change).

## Related

- Downstream: `lerian-aws-gitops` PR #291 sets `CORS_ALLOWED_ORIGINS` in production helmfile values. That PR was a no-op until this chart change ships — once a release including this commit is pinned in the helmfile, the value will flow through to the configmap.
- Upstream context: plugin-br-bank-transfer v2 production rollout (PRs #288 / #289 / #290 in `lerian-aws-gitops` addressed ENV_NAME, ORGANIZATION_IDS, ALLOW_PRIVATE_UPSTREAMS gaps respectively).
