### PR TITLE
chore(plugin-br-bank-transfer): default rate-limit off, expose ALLOW_INSECURE_TLS toggle

### DIFF
--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.0-beta.2] - 2026-05-30
+
+### Changed
+- `RATE_LIMIT_ENABLED` default changed from `"true"` to `"false"` to match lib-commons v5.4.1 secure defaults
+
+### Added
+- `ALLOW_INSECURE_TLS` toggle (default `"false"`) exposed for per-env gitops overrides
+
 ## [1.0.0] - 2024-03-24
 
 ### Changed

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 1.5.0-beta.1
+version: 1.5.0-beta.2
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
   SERVER_TLS_KEY_FILE: {{ .Values.bankTransfer.configmap.SERVER_TLS_KEY_FILE | quote }}
   {{- end }}
   TLS_TERMINATED_UPSTREAM: {{ .Values.bankTransfer.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
+  ALLOW_INSECURE_TLS: {{ .Values.bankTransfer.configmap.ALLOW_INSECURE_TLS | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.SERVER_PROXY_HEADER }}
   SERVER_PROXY_HEADER: {{ .Values.bankTransfer.configmap.SERVER_PROXY_HEADER | quote }}
   {{- end }}
@@ -134,7 +135,7 @@ data:
   {{- end }}
 
   # Rate Limiting
-  RATE_LIMIT_ENABLED: {{ .Values.bankTransfer.configmap.RATE_LIMIT_ENABLED | default "true" | quote }}
+  RATE_LIMIT_ENABLED: {{ .Values.bankTransfer.configmap.RATE_LIMIT_ENABLED | default "false" | quote }}
   RATE_LIMIT_MAX: {{ .Values.bankTransfer.configmap.RATE_LIMIT_MAX | default "100" | quote }}
   RATE_LIMIT_EXPIRY_SEC: {{ .Values.bankTransfer.configmap.RATE_LIMIT_EXPIRY_SEC | default "60" | quote }}
 

--- a/charts/plugin-br-bank-transfer/values-template.yaml
+++ b/charts/plugin-br-bank-transfer/values-template.yaml
@@ -32,6 +32,8 @@ bankTransfer:
 
     # TLS Configuration
     TLS_TERMINATED_UPSTREAM: "true"
+    # Allow insecure TLS (skip cert verification). Secure default off; gitops sets per-env.
+    ALLOW_INSECURE_TLS: "false"
 
     # Multi-Tenancy
     DEFAULT_TENANT_ID: ""  # REQUIRED - Default tenant UUID
@@ -94,7 +96,7 @@ bankTransfer:
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
 
     # Rate Limiting
-    RATE_LIMIT_ENABLED: "true"
+    RATE_LIMIT_ENABLED: "false"
     RATE_LIMIT_MAX: "100"
     RATE_LIMIT_EXPIRY_SEC: "60"
 

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -194,6 +194,7 @@ bankTransfer:
     CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
     # TLS Configuration
     TLS_TERMINATED_UPSTREAM: "true"
+    ALLOW_INSECURE_TLS: "false"
     # Multi-Tenancy
     DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"
     DEFAULT_TENANT_SLUG: "default"
@@ -255,7 +256,7 @@ bankTransfer:
     # SYSTEMPLANE_BACKEND: "postgres"
     # SYSTEMPLANE_POSTGRES_SCHEMA: "system"
     # Rate Limiting
-    RATE_LIMIT_ENABLED: "true"
+    RATE_LIMIT_ENABLED: "false"
     RATE_LIMIT_MAX: "100"
     RATE_LIMIT_EXPIRY_SEC: "60"
     # Database Metrics & Observability


### PR DESCRIPTION
- **What:** Default `RATE_LIMIT_ENABLED` to `false` and expose a new `ALLOW_INSECURE_TLS` toggle (secure default `false`) in the plugin-br-bank-transfer chart.
- **Why:** Aligns with lib-commons v5.4.1 new security defaults (`RATE_LIMIT_ENABLED=false`, `ALLOW_INSECURE_TLS=false`).
- **Per-env:** gitops sets `ALLOW_INSECURE_TLS` per environment via values overrides; chart keeps the secure default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)