### PR TITLE
feat(tracer): template ENV_NAME in configmap

### DIFF
--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "tracer.labels" (dict "context" . "component" .Values.tracer.name "name" .Values.tracer.name) | nindent 4 }}
 data:
   # Application Configuration
+  ENV_NAME: {{ .Values.tracer.configmap.ENV_NAME | default "production" | quote }}
   SERVER_PORT: {{ .Values.tracer.configmap.SERVER_PORT | default "4020" | quote }}
   SERVER_ADDRESS: {{ .Values.tracer.configmap.SERVER_ADDRESS | default ":4020" | quote }}
 

--- a/charts/tracer/values-template.yaml
+++ b/charts/tracer/values-template.yaml
@@ -57,6 +57,7 @@ tracer:
     targetMemoryUtilizationPercentage: 80
 
   configmap:
+    ENV_NAME: "production"
     SERVER_ADDRESS: ":4020"
     LOG_LEVEL: "info"
     DB_HOST: ""

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -170,6 +170,11 @@ tracer:
   # @default -- templates/configmap.yaml
   configmap:
     # Application Settings
+    # ENV_NAME selects the deployment environment. lib-commons v4.6.3+
+    # TenantEventListener fails fast at boot if this (or ENVIRONMENT_NAME) is
+    # unset — must be "staging" or "production". GitOps overrides this to
+    # "staging" per non-prod environment.
+    ENV_NAME: "production"
     # SERVER_PORT/SERVER_ADDRESS default to 4020 to match the tracer source
     # convention (Dockerfile EXPOSE 4020 + .env.example + Dockerfile.dev). The
     # app reads SERVER_ADDRESS first; if empty, falls back to SERVER_PORT.


### PR DESCRIPTION
## What

Template `ENV_NAME` as a first-class env var in the **tracer** chart ConfigMap, in the Application Configuration section:

```yaml
ENV_NAME: {{ .Values.tracer.configmap.ENV_NAME | default "production" | quote }}
```

- Rendered in **both** single-tenant and multi-tenant modes (outside the `MULTI_TENANT` block), mirroring the `plugin-br-bank-transfer` chart exactly.
- Default `production`; exposed/overridable under `tracer.configmap.ENV_NAME` in `values.yaml` and `values-template.yaml`.

## Why

The tracer app now runs **lib-commons v4.6.3**, whose `TenantEventListener` fails fast at boot when `ENV_NAME` (or `ENVIRONMENT_NAME`) is unset:

```
tenant event listener cannot start: ENVIRONMENT_NAME (or ENV_NAME) is required: must be "staging" or "production"
```

The tracer ConfigMap did not template `ENV_NAME`, so the Deployment (`envFrom: configMapRef`) never received it → crash-loop in multi-tenant mode. This exposes it as a first-class, defaulted, overridable value.

## Versioning

The chart uses **automated semantic-release** (`.github/workflows/release.yml` → `cycjimmy/semantic-release-action` + `semantic-release-helm3`, which updates `Chart.yaml` via `prepareCmd`). Per convention, `Chart.yaml` `version` was **not** edited manually. This `feat:` commit will cut the next prerelease — expected **`2.0.0-beta.7`** (current `2.0.0-beta.6`).

## Deployment note

GitOps sets `ENV_NAME=staging` per non-production environment via per-env values override; default `production` covers prod.

## Validation

- `helm lint charts/tracer` → 0 failed
- `helm template charts/tracer` (MULTI_TENANT off **and** on) renders; ConfigMap shows `ENV_NAME: "production"` (and `"staging"` when overridden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)