### PR TITLE
fix(otel-collector): temporary HTTP status code attribute shim (palliative; real fix in lib-observability)

### DIFF
--- a/charts/otel-collector-lerian/Chart.yaml
+++ b/charts/otel-collector-lerian/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 3.1.0-beta.2
+version: 3.1.0-beta.3
 
 # This is the version number of the application being deployed.
 appVersion: "0.1.0"

--- a/charts/otel-collector-lerian/docs/UPGRADE-3.1.md
+++ b/charts/otel-collector-lerian/docs/UPGRADE-3.1.md
@@ -5,6 +5,7 @@
 - **[Overview](#overview)**
 - **[Features](#features)**
   - [1. Chart version bump to 3.1.0-beta.2](#1-chart-version-bump-to-310-beta2)
+  - [2. HTTP status code attribute normalization — temporary workaround (3.1.0-beta.3)](#2-http-status-code-attribute-normalization--temporary-workaround-310-beta3)
 - **[Configuration Changes](#configuration-changes)**
 - **[Migration Steps](#migration-steps)**
 - **[Preview changes before upgrading](#preview-changes-before-upgrading)**
@@ -12,9 +13,9 @@
 
 ## Overview
 
-This guide covers the `otel-collector-lerian` chart upgrade from `3.0.0` to `3.1.0-beta.2`. It is a maintenance release that bumps the chart version only. The application version (`appVersion: 0.1.0`) and all rendered manifests are unchanged.
+This guide covers the `otel-collector-lerian` chart upgrade from `3.0.0` to `3.1.0-beta.3`. `3.1.0-beta.2` was a maintenance version bump only; `3.1.0-beta.3` adds a **temporary** span attribute normalization step to keep `calls_total` status labels working while services migrate to the new OTel semantic convention (`http.response.status_code`). The permanent fix belongs in `lib-observability` and will replace this workaround once released and rolled out.
 
-There are no breaking changes, no new values, no removed values, and no template changes. Existing `values.yaml` overrides remain compatible.
+There are no breaking changes, no new values, and no removed values. Existing `values.yaml` overrides remain compatible.
 
 ## Features
 
@@ -34,36 +35,60 @@ Files modified between `3.0.0` and `3.1.0-beta.2`:
 
 > **Note:** `3.1.0-beta.2` is a pre-release. Pin the exact version when upgrading and validate in a non-production environment before promoting.
 
+### 2. HTTP status code attribute normalization — temporary workaround (3.1.0-beta.3)
+
+> **Temporary palliative.** The real fix belongs in `lib-observability` (emit `http.status_code` alongside `http.response.status_code` at source). This collector-side normalization exists only to keep dashboards/alerts working until that library fix is released and adopted, and will be removed afterwards.
+
+`lib-observability` v1.1.0-beta.3 emits the OTel semantic convention span attribute `http.response.status_code` instead of the legacy `http.status_code`. The collector's `spanmetrics` connector still has `http.status_code` as a dimension, so without normalization the `calls_total` metric loses its status label for any service using the new lib.
+
+As a compatibility shim, `3.1.0-beta.3` adds a `transform/normalize_http_status_code` processor in the `traces` pipeline (before the `spanmetrics` and `otlphttp/server` exporters) that:
+
+- Copies `http.response.status_code` into `http.status_code` when only the new attribute is present.
+- Mirrors `http.status_code` into `http.response.status_code` when only the legacy attribute is present.
+
+Both attributes are preserved on the trace, and the existing `spanmetrics` dimension keeps working unchanged. No dashboards or alerts need to be updated.
+
+| Field | v3.1.0-beta.2 | v3.1.0-beta.3 |
+|-------|---------------|---------------|
+| Chart version | `3.1.0-beta.2` | `3.1.0-beta.3` |
+| Traces pipeline processors | k8sattributes, resource/add_client_id, transform/remove_sensitive_attributes | + transform/normalize_http_status_code (last, before exporters) |
+
+Files modified between `3.1.0-beta.2` and `3.1.0-beta.3`:
+
+- `charts/otel-collector-lerian/Chart.yaml`
+- `charts/otel-collector-lerian/values.yaml`
+- `charts/otel-collector-lerian/docs/UPGRADE-3.1.md`
+
 ## Configuration Changes
 
-No configuration changes are required. All existing `values.yaml` settings remain compatible with `3.1.0-beta.2`.
+No configuration changes are required. All existing `values.yaml` overrides remain compatible with `3.1.0-beta.3`. The new `transform/normalize_http_status_code` processor is added under `opentelemetry-collector.config.processors` and referenced in `service.pipelines.traces.processors`.
 
-| Setting | v3.0.0 | v3.1.0-beta.2 |
+| Setting | v3.0.0 | v3.1.0-beta.3 |
 |---------|--------|---------------|
-| `values.yaml` keys | (unchanged) | (unchanged) |
+| `values.yaml` processors | (existing set) | + `transform/normalize_http_status_code` |
 | Templates | (unchanged) | (unchanged) |
 | Image references | (unchanged) | (unchanged) |
 
 ## Migration Steps
 
-This upgrade requires no manual migration steps. The Helm upgrade will produce no changes to rendered manifests, so no rollout should occur.
+This upgrade requires no manual migration steps. The collector ConfigMap will change to include the new processor, so the collector pods will be rolled.
 
 **Recommended upgrade process:**
 
-1. Review the rendered diff using the helm-diff plugin (see [Preview changes before upgrading](#preview-changes-before-upgrading)). Expect an empty diff.
+1. Review the rendered diff using the helm-diff plugin (see [Preview changes before upgrading](#preview-changes-before-upgrading)). Expect changes only to the collector ConfigMap.
 2. Run the upgrade command during a normal change window.
-3. Verify pod state is unchanged after the upgrade:
+3. Verify pod state after the upgrade:
 
 ```bash
 kubectl get pods -n otel-collector-lerian
 ```
 
-> **Note:** Because no manifest fields change, Kubernetes should not perform a rollout. If a rollout occurs, capture the diff and report it before proceeding in production.
+4. Verify that `calls_total` continues to carry `http_status_code` labels after services upgrade to `lib-observability` v1.1.0-beta.3 or newer.
 
 ## Preview changes before upgrading
 
 ```bash
-helm diff upgrade otel-collector-lerian oci://registry-1.docker.io/lerianstudio/otel-collector-lerian-helm --version 3.1.0-beta.2 -n otel-collector-lerian
+helm diff upgrade otel-collector-lerian oci://registry-1.docker.io/lerianstudio/otel-collector-lerian-helm --version 3.1.0-beta.3 -n otel-collector-lerian
 ```
 
 > **Note:** Requires the [helm-diff plugin](https://github.com/databus23/helm-diff). Install with: `helm plugin install https://github.com/databus23/helm-diff`
@@ -71,5 +96,5 @@ helm diff upgrade otel-collector-lerian oci://registry-1.docker.io/lerianstudio/
 ## Command to upgrade
 
 ```bash
-helm upgrade otel-collector-lerian oci://registry-1.docker.io/lerianstudio/otel-collector-lerian-helm --version 3.1.0-beta.2 -n otel-collector-lerian
+helm upgrade otel-collector-lerian oci://registry-1.docker.io/lerianstudio/otel-collector-lerian-helm --version 3.1.0-beta.3 -n otel-collector-lerian
 ```

--- a/charts/otel-collector-lerian/values.yaml
+++ b/charts/otel-collector-lerian/values.yaml
@@ -154,6 +154,31 @@ opentelemetry-collector:
           - context: span
             statements:
               - delete_key(attributes, "app.request.payload")
+
+      # TEMPORARY compatibility workaround. The real fix belongs in lib-observability,
+      # which should emit `http.status_code` alongside the OTel semantic convention
+      # attribute `http.response.status_code` at source. Until that library fix is
+      # released and rolled out across services, this processor keeps the spanmetrics
+      # connector's `http.status_code` dimension populated so `calls_total` retains
+      # its status label.
+      # Remove this processor (and its entry in the traces pipeline below) once the
+      # lib-observability fix has shipped and all consumers have upgraded.
+      # - If only `http.response.status_code` exists, copy it to `http.status_code`.
+      # - If only `http.status_code` exists, mirror it to `http.response.status_code`
+      #   so traces carry both forms during the migration window.
+      transform/normalize_http_status_code:
+        error_mode: ignore
+        trace_statements:
+          - context: span
+            conditions:
+              - attributes["http.response.status_code"] != nil and attributes["http.status_code"] == nil
+            statements:
+              - set(attributes["http.status_code"], attributes["http.response.status_code"])
+          - context: span
+            conditions:
+              - attributes["http.status_code"] != nil and attributes["http.response.status_code"] == nil
+            statements:
+              - set(attributes["http.response.status_code"], attributes["http.status_code"])
             
       transform/mask_body_sensitive_data_replace_1:
         error_mode: ignore
@@ -331,6 +356,9 @@ opentelemetry-collector:
               - k8sattributes
               - resource/add_client_id
               - transform/remove_sensitive_attributes
+              # Must run before the spanmetrics connector so its `http.status_code`
+              # dimension is populated for services emitting `http.response.status_code`.
+              - transform/normalize_http_status_code
           exporters: [spanmetrics, otlphttp/server]
 
         # Pipeline for span-derived metrics, sent to central backend.


### PR DESCRIPTION
Requested by: @victorlazari

> **Note for reviewers.** This PR is a **temporary compatibility workaround at the collector layer**, not the final fix.
>
> The proper fix belongs in `lib-observability` (the library should emit `http.status_code` alongside `http.response.status_code` at source). Per @gauchito, that library-side fix is the durable solution. This collector transform exists only as a palliative so `calls_total` status labels keep working until the library fix is released and rolled out — at which point this processor (and its pipeline entry) should be removed.

## What changed

`lib-observability` v1.1.0-beta.3 emits the OTel semantic convention span
attribute `http.response.status_code` instead of the legacy `http.status_code`.
The `otel-collector-lerian` chart's `spanmetrics` connector still has
`http.status_code` as a dimension, so without normalization the `calls_total`
metric loses its status label for any service running the new lib — which
also breaks dashboards/alerts keyed off that label.

As a **temporary shim**, this PR adds a `transform/normalize_http_status_code`
processor in `charts/otel-collector-lerian/values.yaml` that runs in the
`traces` pipeline right before the `[spanmetrics, otlphttp/server]` exporters:

- If `http.response.status_code` is present and `http.status_code` is missing,
  it copies the value into `http.status_code`. This is what keeps the
  spanmetrics dimension populated.
- If `http.status_code` is present and `http.response.status_code` is missing,
  it mirrors the value into `http.response.status_code`. This keeps traces
  carrying both forms during the migration window, so any downstream consumer
  that has already migrated to the new attribute name still works for
  un-migrated services.

The processor uses `error_mode: ignore` and only sets a target attribute when
it is missing, so it is idempotent and safe to run on every span.

## Removal plan

Once the lib-observability fix ships and services have rolled forward:

1. Remove `transform/normalize_http_status_code` from
   `charts/otel-collector-lerian/values.yaml` (processor block + traces
   pipeline entry).
2. Remove the corresponding section from
   `charts/otel-collector-lerian/docs/UPGRADE-3.1.md`.
3. Bump chart version accordingly.

The values.yaml comment and the UPGRADE-3.1 doc both call this removal out
explicitly so it does not get lost.

### Files

- `charts/otel-collector-lerian/values.yaml` — new processor + pipeline entry
  (clearly marked TEMPORARY in the comment).
- `charts/otel-collector-lerian/Chart.yaml` — version bump `3.1.0-beta.2` →
  `3.1.0-beta.3`.
- `charts/otel-collector-lerian/docs/UPGRADE-3.1.md` — added a section for
  `3.1.0-beta.3` framed as a temporary palliative, with removal expectation.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on `values.yaml` and
  `Chart.yaml` — both parse cleanly.
- `helm lint` and `helm template` were **not** run: `helm` is not installed
  on this workstation, and the chart depends on
  `opentelemetry-collector 0.142.0` from the upstream Helm repo which would
  require a network-attached dependency build. Recommend CI helm-lint /
  `helm template` to confirm rendering, and a staging deploy to confirm the
  processor wires through the upstream subchart's config merge as expected.
- OTTL syntax matches the existing transform processors in this same chart
  (same `context: span` / `conditions` / `statements` shape).

## Rollout notes

- Collector ConfigMap will change; collector pods will be rolled.
- No values changes are required from operators.
- After services upgrade to `lib-observability` v1.1.0-beta.3+,
  `calls_total{http_status_code="..."}` should keep working with no
  dashboard / alert updates.
- This processor is expected to be removed once the lib-observability-side
  fix is released and rolled out.
