### PR TITLE
fix(plugins): emit k8s.pod.ip OTLP resource attribute

### DIFF
--- a/charts/plugin-br-bank-transfer/templates/deployment.yaml
+++ b/charts/plugin-br-bank-transfer/templates/deployment.yaml
@@ -94,8 +94,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - name: "POD_IP"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
             value: "$(HOST_IP):4317"
+          - name: "OTEL_RESOURCE_ATTRIBUTES"
+            value: "k8s.pod.ip=$(POD_IP)"
           {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
## Problema

As métricas de aplicação (`btf_*`, `http_server_*`) e traces do `plugin-br-bank-transfer` chegam ao `otel-collector-client` (DaemonSet) via `$(HOST_IP):4317`, exposto por **hostPort**. O hostPort aplica **SNAT**, então o IP de origem da conexão visto pelo collector é o **IP do nó**, não o do pod.

Resultado: o `pod_association` do processor `k8sattributes` no collector não consegue casar o pod, e os labels **`k8s_namespace_name` / `k8s_pod_name` / `k8s_deployment_name` ficam vazios** nas métricas de app e spanmetrics. (Confirmado em `aws-staging`: `btf_*` chega, mas sem labels k8s.)

## Correção

Injetar o IP do pod via downward API (`status.podIP`) e anunciá-lo como resource attribute OTLP `k8s.pod.ip`:

```yaml
- name: "POD_IP"
  valueFrom:
    fieldRef:
      fieldPath: status.podIP
- name: "OTEL_RESOURCE_ATTRIBUTES"
  value: "k8s.pod.ip=$(POD_IP)"
```

O `pod_association` do collector lista `k8s.pod.ip` como **primeiro source**. Com o IP viajando **dentro do payload OTLP** (e não na camada de conexão TCP), ele sobrevive ao SNAT do hostPort, e o k8sattributes enriquece os metadados k8s corretamente.

## Escopo

- Apenas `charts/plugin-br-bank-transfer/templates/deployment.yaml`.
- Dentro do bloco existente `{{- if ENABLE_TELEMETRY }}`, então só afeta quando telemetria está ligada.
- `POD_IP` é declarado **antes** de `OTEL_RESOURCE_ATTRIBUTES` para a expansão `$(POD_IP)` funcionar.
- **Não** alterei `Chart.yaml` (version) — bump é feito pela pipeline.

## Não afetado

Métricas de cluster/nó (`k8s_*`) vêm dos receivers `k8s_cluster`/`kubeletstats` (leem a API do K8s direto) e **já** carregam os labels — não dependem desta mudança.

## Validação pós-deploy (staging)

Após o chart subir, verificar no Mimir que os labels passam a aparecer:
```promql
count by (k8s_namespace_name)(btf_worker_idle_seconds_total{client_id="aws-staging"})
count by (k8s_namespace_name)(traces_spanmetrics_calls_total{client_id="aws-staging", service="plugin-br-bank-transfer"})
```

## Nota

Piloto com o btf primeiro. O mesmo padrão (`HOST_IP` + `OTEL_EXPORTER_OTLP_ENDPOINT` via hostPort) existe em outros charts (`tracer`, `plugin-br-pix-*`, etc.) e precisará do mesmo ajuste se quisermos labels k8s em todos os serviços.

🤖 Generated with [Claude Code](https://claude.com/claude-code)