### PR TITLE
fix(plugin-br-bank-transfer): make migrations Job safe for ArgoCD first install

### DIFF
--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.10
+version: 2.0.0-beta.11
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/templates/migrations.yaml
+++ b/charts/plugin-br-bank-transfer/templates/migrations.yaml
@@ -1,91 +1,135 @@
-{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
-{{- if and .Values.bankTransfer.migrations.enabled (not $multiTenantEnabled) }}
+{{- $bankTransfer := .Values.bankTransfer | default dict }}
+{{- $migrations := get $bankTransfer "migrations" | default dict }}
+{{- $configmap := get $bankTransfer "configmap" | default dict }}
+{{- $postgresql := .Values.postgresql | default dict }}
+{{- $migrationImage := get $migrations "image" | default dict }}
+{{- $defaultMigrationResources := dict "requests" (dict "cpu" "50m" "memory" "64Mi") "limits" (dict "cpu" "250m" "memory" "256Mi") }}
+{{- $migrationsEnabled := and (eq (lower (toString (get $bankTransfer "enabled" | default false))) "true") (eq (lower (toString (get $migrations "enabled" | default false))) "true") }}
+{{- if $migrationsEnabled }}
+{{- if eq (lower (toString (get $configmap "MULTI_TENANT_ENABLED" | default "false"))) "true" }}
+{{- fail "bankTransfer.migrations.enabled cannot be true when bankTransfer.configmap.MULTI_TENANT_ENABLED=true; tenant-manager owns tenant database migrations" }}
+{{- end }}
+{{- if and (eq (lower (toString (get $postgresql "enabled" | default false))) "true") (not (eq (lower (toString (get $postgresql "external" | default false))) "true")) }}
+{{- fail "bankTransfer.migrations.enabled cannot be true when chart-managed postgresql.enabled=true; use an external PostgreSQL migration path instead" }}
+{{- end }}
+{{- if not (eq (lower (toString (get $migrations "useExistingSecret" | default false))) "true") }}
+{{- fail "bankTransfer.migrations.useExistingSecret must be true because migration hooks run before chart-managed Secrets exist" }}
+{{- end }}
+{{- $existingSecretName := required "bankTransfer.migrations.existingSecretName is required when bankTransfer.migrations.enabled=true" (get $migrations "existingSecretName") }}
+{{- $namespace := include "global.namespace" . }}
+{{- $migrationTag := "" }}
+{{- $migrationDigest := "" }}
+{{- if kindIs "string" $migrationImage }}
+{{- if not (regexMatch "(@sha256:[A-Fa-f0-9]{64}|:[^/:@]+)$" $migrationImage) }}
+{{- fail "bankTransfer.migrations.image string must include an explicit tag or sha256 digest when bankTransfer.migrations.enabled=true" }}
+{{- end }}
+{{- else }}
+{{- $migrationTag = get $migrationImage "tag" | default "" }}
+{{- $migrationDigest = get $migrationImage "digest" | default "" }}
+{{- if and (empty $migrationTag) (empty $migrationDigest) }}
+{{- fail "bankTransfer.migrations.image.tag or bankTransfer.migrations.image.digest is required when bankTransfer.migrations.enabled=true; migration images must not silently reuse the app tag" }}
+{{- end }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "bank-transfer.fullname" . }}-migrations
-  namespace: {{ include "global.namespace" . }}
+  name: {{ printf "%s-migrations" (include "bank-transfer.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $namespace }}
   labels:
-    {{- include "bank-transfer.labels" (dict "context" . "component" "migrations" "name" "migrations") | nindent 4 }}
+    {{- include "bank-transfer.labels" (dict "context" . "component" "migrations" "name" (get $bankTransfer "name") ) | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade,post-install
-    helm.sh/hook-delete-policy: before-hook-creation
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "argocd.argoproj.io/hook": PreSync
+    "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
+    {{- with (get $migrations "annotations") }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  backoffLimit: {{ .Values.bankTransfer.migrations.backoffLimit | default 3 }}
+  backoffLimit: {{ get $migrations "backoffLimit" | default 3 }}
+  activeDeadlineSeconds: {{ get $migrations "activeDeadlineSeconds" | default 600 }}
+  ttlSecondsAfterFinished: {{ get $migrations "ttlSecondsAfterFinished" | default 600 }}
   template:
     metadata:
       labels:
-        {{- include "bank-transfer.selectorLabels" (dict "context" . "component" "migrations" "name" "migrations") | nindent 8 }}
+        {{- include "bank-transfer.labels" (dict "context" . "component" "migrations" "name" (get $bankTransfer "name") ) | nindent 8 }}
+      {{- with (get $migrations "podAnnotations") }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
-      {{- with .Values.bankTransfer.imagePullSecrets }}
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with (get $bankTransfer "imagePullSecrets") }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: OnFailure
-      initContainers:
-        - name: wait-for-postgres
-          image: busybox:1.37
-          envFrom:
-            - configMapRef:
-                name: {{ include "bank-transfer.fullname" . }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              MAX_ATTEMPTS=60
-              SLEEP_SECONDS=5
-              ATTEMPTS=0
-              echo "Waiting for PostgreSQL at $POSTGRES_HOST:$POSTGRES_PORT..."
-              while ! nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
-                ATTEMPTS=$((ATTEMPTS + 1))
-                if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
-                  echo "Timeout waiting for PostgreSQL after $((MAX_ATTEMPTS * SLEEP_SECONDS))s"
-                  exit 1
-                fi
-                echo "PostgreSQL not ready, retrying in ${SLEEP_SECONDS}s... (attempt $ATTEMPTS/$MAX_ATTEMPTS)"
-                sleep $SLEEP_SECONDS
-              done
-              echo "PostgreSQL is ready."
+      {{- with (get $migrations "serviceAccountName") }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
       containers:
         - name: migrations
-          image: "{{ .Values.bankTransfer.migrations.image.repository }}:{{ .Values.bankTransfer.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.bankTransfer.migrations.image.pullPolicy | default "IfNotPresent" }}
+          {{- if kindIs "string" $migrationImage }}
+          image: {{ $migrationImage | quote }}
+          imagePullPolicy: Always
+          {{- else }}
+          {{- $migrationRepository := get $migrationImage "repository" | default "ghcr.io/lerianstudio/plugin-br-bank-transfer-migrations" }}
+          {{- if $migrationDigest }}
+          image: "{{ $migrationRepository }}@{{ $migrationDigest }}"
+          {{- else }}
+          image: "{{ $migrationRepository }}:{{ $migrationTag }}"
+          {{- end }}
+          imagePullPolicy: {{ get $migrationImage "pullPolicy" | default "IfNotPresent" }}
+          {{- end }}
           env:
+            - name: MIGRATIONS_PATH
+              value: {{ get $migrations "path" | default "/migrations" | quote }}
+            # The migrations runner refuses sslmode=disable unless this is set;
+            # mirror the app-level toggle so non-TLS Postgres targets work.
+            - name: ALLOW_INSECURE_TLS
+              value: {{ get $configmap "ALLOW_INSECURE_TLS" | default "false" | quote }}
             - name: POSTGRES_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_HOST
+              value: {{ get $configmap "POSTGRES_HOST" | default (printf "%s-postgresql-primary.%s.svc.cluster.local" .Release.Name $namespace) | quote }}
             - name: POSTGRES_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_PORT
+              value: {{ get $configmap "POSTGRES_PORT" | default "5432" | quote }}
             - name: POSTGRES_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_USER
+              value: {{ get $configmap "POSTGRES_USER" | default "plugin-br-bank-transfer" | quote }}
             - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_DB
+              value: {{ get $configmap "POSTGRES_DB" | default "plugin-br-bank-transfer" | quote }}
             - name: POSTGRES_SSLMODE
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_SSLMODE
+              value: {{ get $configmap "POSTGRES_SSLMODE" | default "require" | quote }}
             - name: POSTGRES_CONNECT_TIMEOUT_SEC
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_CONNECT_TIMEOUT_SEC
+              value: {{ get $configmap "POSTGRES_CONNECT_TIMEOUT_SEC" | default "10" | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.bankTransfer.useExistingSecret }}{{ required "bankTransfer.existingSecretName is required when bankTransfer.useExistingSecret is true" .Values.bankTransfer.existingSecretName }}{{ else }}{{ include "bank-transfer.fullname" . }}{{ end }}
+                  name: {{ $existingSecretName }}
                   key: POSTGRES_PASSWORD
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           resources:
-            {{- toYaml .Values.bankTransfer.migrations.resources | nindent 12 }}
+            {{- toYaml (get $migrations "resources" | default $defaultMigrationResources) | nindent 12 }}
+      {{- with (get $bankTransfer "nodeSelector") }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (get $bankTransfer "affinity") }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (get $bankTransfer "tolerations") }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -83,13 +83,26 @@ bankTransfer:
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
     tag: "2.4.0"
-  # -- PostgreSQL migrations job (pre-upgrade / post-install hook)
+  # -- PostgreSQL migrations job (Helm hook pre-install,pre-upgrade; ArgoCD PreSync).
+  # The Job references NO chart-managed ConfigMap/Secret (all env inline), so the
+  # PreSync hook works on first install. Requires an operator-provisioned Secret
+  # carrying POSTGRES_PASSWORD (useExistingSecret/existingSecretName below) and an
+  # explicit image tag or digest. Must stay disabled when MULTI_TENANT_ENABLED=true
+  # (tenant-manager owns tenant database migrations — template enforces this).
   migrations:
-    # -- Enable or disable the migrations job
-    enabled: true
+    # -- Enable or disable the migrations job. When enabling, you MUST set
+    # useExistingSecret=true, existingSecretName, and image.tag (or digest).
+    enabled: false
+    # -- Migration hooks run before chart-managed Secrets exist; the password
+    # must come from a pre-existing Secret with key POSTGRES_PASSWORD.
+    useExistingSecret: false
+    # -- Name of the pre-existing Secret containing POSTGRES_PASSWORD
+    existingSecretName: ""
     image:
       # -- Repository for the migrations init container image
       repository: ghcr.io/lerianstudio/plugin-br-bank-transfer-migrations
+      # -- Image tag (required when enabled; never silently reuses the app tag)
+      tag: ""
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Maximum number of retries before the Job is considered failed


### PR DESCRIPTION
## Problema

O Job de migrations publicado (chart **2.0.0-beta.10**) deadlocka o ArgoCD no primeiro install:

- `helm.sh/hook: pre-upgrade,post-install` mapeia para **PreSync + PostSync**
- O Job consome o ConfigMap/Secret **do próprio chart** (`configMapKeyRef` + `envFrom` no init container)
- **PreSync**: roda antes do ConfigMap existir → `CreateContainerConfigError`
- **PostSync**: nunca dispara — o `/readyz` do app exige `schema_migrations`, o sync nunca completa

Encontrado no primeiro install single-tenant via ArgoCD (beleriand). Nenhum ambiente gitops exercita esse caminho hoje (ST de staging removido em lerian-aws-gitops@9d145a0; MT pula migrations por design).

## Fix

- Todos os `POSTGRES_*` **inline** nos env (zero refs a recursos chart-managed)
- Password de **Secret pré-existente** provisionado pelo operador (`useExistingSecret=true` + `existingSecretName` obrigatórios via `fail`)
- `argocd.argoproj.io/hook: PreSync` explícito + `pre-install,pre-upgrade`
- Guards: recusa `MULTI_TENANT_ENABLED=true` (tenant-manager é dona das migrations de tenant) e `postgresql.enabled` chart-managed; exige `image.tag`/`digest` explícito
- `ALLOW_INSECURE_TLS` espelhado do configmap (o runner recusa `sslmode=disable` sem ele)
- `migrations.enabled` agora default **false** (contrato novo exige secret + tag → opt-in mantém render default e lint verdes)

## Validação

- `helm lint`: pass
- template defaults: nenhum Job renderizado
- template ST (migrations on): Job com PreSync, único `valueFrom` → secret pré-existente, sem `envFrom`, sem init containers
- MT + migrations on: `fail` correto
- enabled sem tag: `fail` correto

## Breaking (linha 2.0.x)

Quem habilitava `migrations.enabled=true` (era default) precisa agora provisionar o Secret (`POSTGRES_PASSWORD`) e setar `useExistingSecret`/`existingSecretName`/`image.tag`:

```bash
kubectl -n <ns> create secret generic bank-transfer-migrations-creds \
  --from-literal=POSTGRES_PASSWORD=<pass>
```

NB: a branch `fix/plugin-br-bank-transfer-migrations-envfrom` ataca o mesmo bug mas mantém o hook errado e a ref ao configmap — não resolve o ciclo; sugiro fechar em favor desta.