### PR TITLE
fix(plugin-access-manager): handle https URLs in wait-for-dependencies initContainer

### DIFF
--- a/charts/plugin-access-manager/Chart.yaml
+++ b/charts/plugin-access-manager/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 8.0.1
+version: 8.0.2
 # This is the version number of the application being deployed.
 appVersion: "2.6.7"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/plugin-access-manager/templates/identity/deployment.yaml
+++ b/charts/plugin-access-manager/templates/identity/deployment.yaml
@@ -36,9 +36,10 @@ spec:
               for svc in "$PLUGIN_AUTH_ADDRESS";
               do
                 echo "Checking $svc...";
-                hostport=$(echo "$svc" | sed 's|http://||');
+                case "$svc" in https://*) default_port=443;; *) default_port=80;; esac;
+                hostport=$(echo "$svc" | sed -E 's|^https?://||' | cut -d/ -f1);
                 host=$(echo "$hostport" | cut -d: -f1);
-                port=$(echo "$hostport" | cut -d: -f2);
+                case "$hostport" in *:*) port=$(echo "$hostport" | cut -d: -f2);; *) port=$default_port;; esac;
                 while ! nc -z "$host" "$port"; do
                   echo "$svc is not ready yet, waiting...";
                   sleep 5;

--- a/charts/plugin-bc-correios/Chart.yaml
+++ b/charts/plugin-bc-correios/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 1.1.0-beta.1
+version: 1.1.0-beta.2
 appVersion: "1.2.0"
 keywords:
   - bc-correios

--- a/charts/plugin-bc-correios/templates/deployment.yaml
+++ b/charts/plugin-bc-correios/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
 
               {{- if .Values.seaweedfs.enabled }}
               # Wait for SeaweedFS S3 API
-              SEAWEEDFS_HOST=$(echo "$OBJECT_STORAGE_ENDPOINT" | sed 's|http://||' | cut -d: -f1)
+              SEAWEEDFS_HOST=$(echo "$OBJECT_STORAGE_ENDPOINT" | sed -E 's|^https?://||' | cut -d/ -f1 | cut -d: -f1)
               wait_for_service "$SEAWEEDFS_HOST" "8333"
               {{- end }}
 


### PR DESCRIPTION
## Bug

The `wait-for-dependencies` initContainer stripped the URL scheme with `sed 's|http://||'`, which only matches plain `http`. An `https://` dependency URL kept its `https://` prefix, so:

- `cut -d: -f1` returned `https` as the host
- `cut -d: -f2` returned `//<host>` as the port

breaking the TCP probe:

```
nc: bad port '//auth-st.beleriand.lerian.net'
```

### Live repro
Observed on `plugin-access-manager` chart 6.1.1, `beleriand` cluster, identity deployment:

```
PLUGIN_AUTH_ADDRESS=https://auth-st.beleriand.lerian.net
# initContainer crashloops with: nc: bad port '//auth-st.beleriand.lerian.net'
```

## Fix (POSIX sh / busybox `nc`)

- Strip scheme with `sed -E 's|^https?://||'`
- Strip any path suffix with `cut -d/ -f1`
- **plugin-access-manager** (identity): derive port from the host:port when it contains `:`, else default `443` when the original URL is `https://`, otherwise `80`
- **plugin-bc-correios**: isolate host only — the SeaweedFS S3 port stays hardcoded `8333`

### Verified parse behavior
| input | host | port |
|---|---|---|
| `https://auth-st.beleriand.lerian.net` | `auth-st.beleriand.lerian.net` | `443` |
| `http://auth:8080` | `auth` | `8080` |
| `https://x.y/path` | `x.y` | `443` |
| `auth:9000` | `auth` | `9000` |
| `plain-host` | `plain-host` | `80` |

## Scope

Repo-wide grep for the `sed 's|http://||'` + `nc -z` pattern found exactly two affected charts (both fixed here). The `matcher` and `reporter` initContainers also use `nc -z` but build probe targets from `$HOST:$PORT` configmap pairs (never scheme-bearing URLs), so they are not affected and were intentionally left untouched.

## Validation

- `helm template` for both charts with an `https` dependency URL (no explicit port) renders the corrected script
- Parse logic exercised standalone under `sh` (table above)
- `helm lint` passes for both charts

## Version bumps

- `plugin-access-manager`: 8.0.1 -> 8.0.2
- `plugin-bc-correios`: 1.1.0-beta.1 -> 1.1.0-beta.2

Note: the release pipeline uses semantic-release, which derives the published version from the conventional commit and overwrites `Chart.yaml`; these manual bumps follow the convention but the shipped numbers are computed by CI.