### PR TITLE
fix(plugin-br-bank-transfer): inject full ConfigMap into migrations container

### DIFF
--- a/charts/plugin-br-bank-transfer/templates/migrations.yaml
+++ b/charts/plugin-br-bank-transfer/templates/migrations.yaml
@@ -50,37 +50,15 @@ spec:
         - name: migrations
           image: "{{ .Values.bankTransfer.migrations.image.repository }}:{{ .Values.bankTransfer.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.bankTransfer.migrations.image.pullPolicy | default "IfNotPresent" }}
+          # Pull every value from the rendered ConfigMap so the migration
+          # runner sees the same configuration surface as the main
+          # bank-transfer Deployment (POSTGRES_HOST/PORT/USER/DB/SSLMODE/
+          # CONNECT_TIMEOUT, ALLOW_INSECURE_TLS, MIGRATIONS_PATH, etc.).
+          # POSTGRES_PASSWORD stays an explicit secretKeyRef.
+          envFrom:
+            - configMapRef:
+                name: {{ include "bank-transfer.fullname" . }}
           env:
-            - name: POSTGRES_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_HOST
-            - name: POSTGRES_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_PORT
-            - name: POSTGRES_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_USER
-            - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_DB
-            - name: POSTGRES_SSLMODE
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_SSLMODE
-            - name: POSTGRES_CONNECT_TIMEOUT_SEC
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_CONNECT_TIMEOUT_SEC
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Fixes the `plugin-br-bank-transfer` migrations Job so it actually sees the env vars exposed in the ConfigMap. The immediate symptom in production is the PreSync hook looping on `BackoffLimitExceeded` with `TLS required (set ALLOW_INSECURE_TLS=true to bypass)` even when `ALLOW_INSECURE_TLS=true` is set in values.

## Root cause

In `templates/migrations.yaml`, the migrations container wires env vars individually:

```yaml
env:
  - name: POSTGRES_HOST
    valueFrom:
      configMapKeyRef:
        name: {{ include "bank-transfer.fullname" . }}
        key: POSTGRES_HOST
  # ... POSTGRES_PORT, POSTGRES_USER, POSTGRES_DB, POSTGRES_SSLMODE,
  #     POSTGRES_CONNECT_TIMEOUT_SEC, POSTGRES_PASSWORD
```

When 4946cb50 (`feat(plugin-br-bank-transfer): default rate-limit off, expose ALLOW_INSECURE_TLS toggle`) added `ALLOW_INSECURE_TLS` to `templates/configmap.yaml`, it was not also added to the migrations Job's env list. Result: the rendered ConfigMap exposes `ALLOW_INSECURE_TLS: "true"` but the migration runner pod never receives it, so the runner enforces TLS and fails before applying any schema. The main `bank-transfer` Deployment then comes up against an empty/stale schema, `/readyz` returns 503 (`schema_migrations table not found`), and `bank-transfer-7dc7479c44-qqxsd`-style pods get stuck Ready=0/1 indefinitely.

This was reproduced live on lerian-eks-firmino, lerian-eks-clotilde, and lerian-eks-benedita dev clusters during sync of chart `2.0.0-beta.10` + app `3.3.0-beta.1`.

## Change

Switches the migrations container to `envFrom: configMapRef` (matching the existing `wait-for-postgres` init container in the same template). All ConfigMap keys now flow into the runner, so:

- `ALLOW_INSECURE_TLS` is delivered immediately.
- Any future env var added to `templates/configmap.yaml` automatically reaches the migrations runner — no need to remember to also patch this file.

`POSTGRES_PASSWORD` stays an explicit `secretKeyRef` (it's not in the ConfigMap).

## Diff size

`charts/plugin-br-bank-transfer/templates/migrations.yaml`: -30 / +8

## Verification

Rendered the chart against the firmino dev values from `midaz-firmino-gitops` and confirmed the Job now carries both `envFrom` (ConfigMap) and the explicit `POSTGRES_PASSWORD` secret entry. `helm lint charts/plugin-br-bank-transfer` passes (the only warnings are pre-existing `required` checks on JD/encryption-key values that the test values intentionally leave empty).

## Rollout plan

Once this merges to `develop` and semantic-release publishes `2.0.0-beta.11`:

1. Bump `version` in the three `midaz-firmino-gitops` `helmfile.yaml` files for firmino/clotilde/benedita `dev` from `2.0.0-beta.10` -> `2.0.0-beta.11`.
2. Argo will re-sync the migrations Job. The runner now sees `ALLOW_INSECURE_TLS=true`, the migration applies, the new `bank-transfer` Deployment passes `/readyz`, and the three apps move to `Synced/Healthy`.

The same fix unblocks any other consumer that depends on a configmap-only env that isn't enumerated in this Job's env list (none currently, but the surface is now self-syncing).
