### PR TITLE
feat(plugins): parameterize probe paths in plugin-bc-correios chart

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 - [ ] Plugin BR PIX Direct JD
 - [ ] Plugin BR PIX Indirect BTG
 - [ ] Plugin BR PIX Switch
+- [ ] Plugin BR Bank Transfer
 - [ ] Otel Collector
 - [ ] Pipeline
 - [ ] Documentation

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -39,6 +39,7 @@ jobs:
             plugin-br-pix-direct-jd
             plugin-br-pix-indirect-btg
             plugin-br-pix-switch
+            plugin-br-bank-transfer
             lerian-notification
             plugin-br-bank-transfer-jd
             templates
@@ -54,4 +55,6 @@ jobs:
             matcher
             tracer
             new
+            charts
+            common
           requireScope: true

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.6` | 1.0.0-beta.1 |
+| `2.0.0-beta.7` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.11` | 1.0.0-beta.1 |
+| `2.0.0-beta.12` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.2` | 1.0.0-beta.1 |
+| `2.0.0-beta.3` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | Tracer Version |
 | :---: | :---: |
-| `2.0.0-beta.6` | 1.0.0 |
+| `2.0.0-beta.7` | 1.0.0 |
 -----------------
 
 ### Otel Collector Lerian

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `1.1.0-beta.1` | 1.0.0 |
+| `2.0.0-beta.1` | 1.0.0 |
 -----------------
 
 ### Go Boilerplate DDD

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.4` | 1.0.0-beta.1 |
+| `2.0.0-beta.5` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `1.5.0-beta.1` | 1.0.0-beta.1 |
+| `2.0.0-beta.1` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.1` | 1.0.0-beta.1 |
+| `2.0.0-beta.2` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | Auth Version | Identity Version |
 | :---: | :---: | :---: |
-| `8.0.1` | 2.6.7 | 2.4.5 |
+| `8.1.0-beta.1` | 2.6.7 | 2.4.5 |
 -----------------
 
 ### Plugin Fees Helm Chart

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.10` | 1.0.0-beta.1 |
+| `2.0.0-beta.11` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.3` | 1.0.0-beta.1 |
+| `2.0.0-beta.4` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.9` | 1.0.0-beta.1 |
+| `2.0.0-beta.10` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | Ledger Version | CRM Version |
 | :---: | :---: | :---: |
-| `8.0.0` | 3.7.2 | 3.7.2 |
+| `8.1.0-beta.1` | 3.7.2 | 3.7.3 |
 -----------------
 
 ### Plugin Access Manager Helm Chart

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.7` | 1.0.0-beta.1 |
+| `2.0.0-beta.8` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.8` | 1.0.0-beta.1 |
+| `2.0.0-beta.9` | 1.0.0-beta.1 |
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `2.0.0-beta.5` | 1.0.0-beta.1 |
+| `2.0.0-beta.6` | 1.0.0-beta.1 |
 
 
 

--- a/charts/midaz/Chart.yaml
+++ b/charts/midaz/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to he chart and its templates, including the app version.
-version: 8.0.0
+version: 8.1.0-beta.1
 # This is the version number of the application being deployed.
 appVersion: "3.7.3"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/midaz/Chart.yaml
+++ b/charts/midaz/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 # to he chart and its templates, including the app version.
 version: 8.0.0
 # This is the version number of the application being deployed.
-appVersion: "3.7.2"
+appVersion: "3.7.3"
 # A list of keywords about the chart. This helps others discover the chart.
 keywords:
   - midaz

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -338,7 +338,7 @@ crm:
     # -- Image pull policy
     pullPolicy: Always
     # -- Image tag used for deployment
-    tag: "3.7.2"
+    tag: "3.7.3"
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
   # -- Overrides the default generated name by Helm

--- a/charts/plugin-access-manager/Chart.yaml
+++ b/charts/plugin-access-manager/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 8.0.2
+version: 8.1.0-beta.1
 # This is the version number of the application being deployed.
 appVersion: "2.6.7"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/plugin-access-manager/Chart.yaml
+++ b/charts/plugin-access-manager/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 8.0.1
+version: 8.0.2
 # This is the version number of the application being deployed.
 appVersion: "2.6.7"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/plugin-access-manager/templates/identity/deployment.yaml
+++ b/charts/plugin-access-manager/templates/identity/deployment.yaml
@@ -36,9 +36,10 @@ spec:
               for svc in "$PLUGIN_AUTH_ADDRESS";
               do
                 echo "Checking $svc...";
-                hostport=$(echo "$svc" | sed 's|http://||');
+                case "$svc" in https://*) default_port=443;; *) default_port=80;; esac;
+                hostport=$(echo "$svc" | sed -E 's|^https?://||' | cut -d/ -f1);
                 host=$(echo "$hostport" | cut -d: -f1);
-                port=$(echo "$hostport" | cut -d: -f2);
+                case "$hostport" in *:*) port=$(echo "$hostport" | cut -d: -f2);; *) port=$default_port;; esac;
                 while ! nc -z "$host" "$port"; do
                   echo "$svc is not ready yet, waiting...";
                   sleep 5;

--- a/charts/plugin-bc-correios/Chart.yaml
+++ b/charts/plugin-bc-correios/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 1.1.0-beta.2
+version: 2.0.0-beta.1
 appVersion: "1.2.0"
 keywords:
   - bc-correios

--- a/charts/plugin-bc-correios/Chart.yaml
+++ b/charts/plugin-bc-correios/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 1.1.0-beta.1
+version: 1.1.0-beta.2
 appVersion: "1.2.0"
 keywords:
   - bc-correios

--- a/charts/plugin-bc-correios/templates/deployment.yaml
+++ b/charts/plugin-bc-correios/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
 
               {{- if .Values.seaweedfs.enabled }}
               # Wait for SeaweedFS S3 API
-              SEAWEEDFS_HOST=$(echo "$OBJECT_STORAGE_ENDPOINT" | sed 's|http://||' | cut -d: -f1)
+              SEAWEEDFS_HOST=$(echo "$OBJECT_STORAGE_ENDPOINT" | sed -E 's|^https?://||' | cut -d/ -f1 | cut -d: -f1)
               wait_for_service "$SEAWEEDFS_HOST" "8333"
               {{- end }}
 

--- a/charts/plugin-bc-correios/templates/deployment.yaml
+++ b/charts/plugin-bc-correios/templates/deployment.yaml
@@ -114,7 +114,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: {{ $component.probes.livenessPath | default "/health/live" }}
               port: http
             initialDelaySeconds: 15
             periodSeconds: 20
@@ -122,7 +122,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health/ready
+              path: {{ $component.probes.readinessPath | default "/health/ready" }}
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -130,7 +130,7 @@ spec:
             failureThreshold: 3
           startupProbe:
             httpGet:
-              path: /health/live
+              path: {{ $component.probes.startupPath | default "/health/live" }}
               port: http
             failureThreshold: 30
             periodSeconds: 10

--- a/charts/plugin-bc-correios/values-template.yaml
+++ b/charts/plugin-bc-correios/values-template.yaml
@@ -28,6 +28,16 @@ bc-correios:
             pathType: Prefix
     tls: []
 
+  # Health probe HTTP paths.
+  # Override when the deployed app version exposes different endpoints.
+  # Defaults below match plugin-bc-correios >= 1.2.0 (separate live/ready).
+  # For older or simpler app versions exposing a single endpoint,
+  # set all three to "/health".
+  probes:
+    livenessPath: "/health/live"
+    readinessPath: "/health/ready"
+    startupPath: "/health/live"
+
   configmap:
     # Application Settings
     APP_ENV: ""       # REQUIRED - e.g., production, staging

--- a/charts/plugin-bc-correios/values.yaml
+++ b/charts/plugin-bc-correios/values.yaml
@@ -172,6 +172,18 @@ bc-correios:
   #     hostnames:
   #       - "correios.com.br"
   hostAliases: []
+  # -- Health probe HTTP paths
+  # Override these per-environment when the application exposes different
+  # endpoints. Defaults match plugin-bc-correios >= 1.2.0 (separate live/ready).
+  # For applications exposing only a single `/health` endpoint, set all three
+  # to "/health" in your values override.
+  probes:
+    # -- HTTP path for the livenessProbe
+    livenessPath: "/health/live"
+    # -- HTTP path for the readinessProbe
+    readinessPath: "/health/ready"
+    # -- HTTP path for the startupProbe
+    startupPath: "/health/live"
   # -- ConfigMap for environment variables and configurations
   # @default -- templates/configmap.yaml
   configmap:

--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-beta.7]
+
+### Changed
+- ConfigMap and Secret templates now gate single-tenant-only infrastructure
+  keys behind `MULTI_TENANT_ENABLED != "true"`. In multi-tenant mode the
+  rendered ConfigMap only contains the envs the bootstrap actually consumes
+  in that mode (app identity, server address, multi-tenant infrastructure,
+  app-level Redis connection envs, outbound adapter URLs + auth toggles,
+  inbound auth, telemetry toggle/endpoint, feature flags, AWS region for
+  the secrets-manager client). Removed from the MT-mode render:
+  - All `POSTGRES_*` / `MIGRATIONS_PATH` / `INFRA_CONNECT_TIMEOUT_SEC`
+    (per-tenant Postgres resolves via tenant-manager)
+  - All `MONGO_*` (per-tenant Mongo resolves via tenant-manager)
+  - All `RABBITMQ_*` (not used in MT mode)
+  - Redis pool / timeout / `REDIS_PROTOCOL` tuning (systemplane-managed)
+  - `DEPLOYMENT_MODE`, `VERSION`, `HTTP_BODY_LIMIT_BYTES`,
+    `TLS_TERMINATED_UPSTREAM`, `SERVER_*` TLS / proxy
+  - `OTEL_LIBRARY_NAME`, `OTEL_RESOURCE_SERVICE_NAME`,
+    `OTEL_RESOURCE_SERVICE_VERSION`, `OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT`
+  - JD live config (`JD_BASE_URL`, `JD_ORIGIN_ISPB`, `JD_SOAP_PATH`,
+    `JD_SIGNING_MODE`, `JD_LEGACY_CODE`, `JD_PRIVATE_KEY_KEYINFO`) — these
+    are per-tenant via `TenantIntegrationResolver` in MT mode
+  - `LICENSE_SERVICE_ADDRESS`, `TENANT_IDS`
+  - `ORGANIZATION_ID`, `DEFAULT_ORGANIZATION_ID`, `IS_DEVELOPMENT`,
+    `DEFAULT_TENANT_ID`, `DEFAULT_TENANT_SLUG`,
+    `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE`
+- Single-tenant mode is unchanged: the previous required guards still apply
+  (`POSTGRES_PASSWORD`, `MONGO_PASSWORD`, `JD_BASE_URL`, `JD_ORIGIN_ISPB`
+  when sandbox mode is off) and all single-tenant defaults still render.
+
+### Fixed
+- Multi-tenant installs no longer fail at template time with
+  `bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is
+  not true`. The required guard now also requires `MULTI_TENANT_ENABLED`
+  to be off before triggering.
+
 ## [1.6.0-beta.1]
 
 ### Changed

--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.0-beta.1]
+
+### Changed
+- Chart now only ships **infrastructure configuration**: database / Valkey
+  / RabbitMQ / MongoDB connection info, multi-tenant toggle + endpoints,
+  outbound adapter URLs + auth toggles, OpenTelemetry plumbing, and
+  inbound auth wiring. All operational tuning (timeouts, retries, circuit
+  breakers, cache TTLs, rate limit, idempotency window, reconciliation,
+  webhook retries, JD polling cadence, usage limits, operating hours,
+  CORS, routing UUIDs) is dropped from the chart and is now managed at
+  runtime via the systemplane admin API or covered by lib-commons
+  compiled defaults.
+
+### Removed env vars (now systemplane-managed or default-covered)
+- `LOG_LEVEL`, `CORS_ALLOWED_*`, `AUTH_CACHE_TTL_SEC`, `DB_METRICS_INTERVAL_SEC`
+- `RATE_LIMIT_*`, `IDEMPOTENCY_RETRY_WINDOW_SEC`, `IDEMPOTENCY_REQUIRE_REDIS`,
+  `DUPLICATE_GUARD_TTL_SEC`
+- `MIDAZ_TIMEOUT_MS`, `MIDAZ_MAX_RETRIES`, `MIDAZ_OTEL_ENABLED`, `MIDAZ_DEBUG`,
+  `MIDAZ_BREAKER_FAILURES`, `MIDAZ_BREAKER_TIMEOUT_SECONDS`
+- `CRM_TIMEOUT_MS`, `CRM_MAX_RETRIES`, `CRM_CACHE_TTL_MS`, `CRM_*_LOOKUP_PATH_TEMPLATE`
+- `FEES_TIMEOUT_MS`, `FEES_MAX_RETRIES`, `FEES_FAIL_CLOSED_DEFAULT`,
+  `FEES_MAX_FEE_AMOUNT_CENTS`, `FEES_REFUND_ON_DEVOLUCAO`
+- `JD_TIMEOUT_MS`, `JD_MAX_RETRIES`, `JD_SIGNATURE_REQUIRED`,
+  `JD_VALIDATE_EXTERNAL_SIGNATURE`, `JD_POLLING_ENABLED`, `JD_POLL_*`
+- `RABBITMQ_MAX_RETRIES`, `RABBITMQ_PUBLISH_TIMEOUT_MS`,
+  `RABBITMQ_RETRY_BACKOFF_MS`, `RABBITMQ_ROUTING_KEY_PREFIX`
+- `RECONCILIATION_PENDING_ALERT_THRESHOLD`, `BTF_RECONCILIATION_*`
+- `WEBHOOK_QUEUE_NAME`, `WEBHOOK_DLQ_NAME`, `WEBHOOK_CONSUMER_TAG`,
+  `WEBHOOK_PREFETCH_COUNT`, `WEBHOOK_TIMEOUT_MS`, `WEBHOOK_MAX_RETRIES`,
+  `WEBHOOK_RETRY_BACKOFF_MS`, `WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS`,
+  `WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC`, `WEBHOOK_ENDPOINT_URL`
+- `USAGE_LIMITS_ENABLED`, `USAGE_LIMIT_DAILY_CENTS`, `USAGE_LIMIT_MONTHLY_CENTS`
+- `TRANSFER_OPERATING_OPEN`, `TRANSFER_OPERATING_CLOSE`, `TRANSFER_OPERATING_TIMEZONE`
+- `BTF_FEE_ENABLED`, `BTF_MIDAZ_CB_ENABLED`
+- `SYSTEMPLANE_BACKEND`, `SYSTEMPLANE_POSTGRES_SCHEMA` (chart internals,
+  app reads these via lib-commons configuration loader)
+- `ALLOW_INSECURE_OTEL` (unused by app)
+- `MULTI_TENANT_MAX_TENANT_POOLS`, `MULTI_TENANT_IDLE_TIMEOUT_SEC`,
+  `MULTI_TENANT_TIMEOUT`, `MULTI_TENANT_CACHE_TTL_SEC`,
+  `MULTI_TENANT_CIRCUIT_BREAKER_*`, `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC`,
+  `MULTI_TENANT_REDIS_PORT` (chart default 6379)
+
+### Kept
+- All Postgres / Valkey / MongoDB / RabbitMQ connection configuration
+- Multi-tenant toggle + infra endpoints
+  (`MULTI_TENANT_ENABLED`, `MULTI_TENANT_URL`, `MULTI_TENANT_REDIS_HOST`,
+   `MULTI_TENANT_REDIS_TLS`, `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE`,
+   `AWS_REGION`)
+- Server / TLS wiring (`SERVER_*`, `TLS_TERMINATED_UPSTREAM`,
+  `HTTP_BODY_LIMIT_BYTES`, `ALLOW_PRIVATE_UPSTREAMS`)
+- Outbound adapter URLs + auth toggles (Midaz / CRM / Fees / JD)
+- Inbound auth wiring (`PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_ADDRESS`)
+- OpenTelemetry plumbing
+- All secrets (in `templates/secrets.yaml`)
+
+### Migration
+Consumers whose `values.yaml` set any of the removed keys should:
+1. Remove the entries from `values.yaml` (chart now ignores them).
+2. Pre-populate the equivalent systemplane key in Postgres before this
+   chart version rolls out, OR accept the lib-commons compiled default
+   (sane production values for retries, timeouts, etc.).
+3. Use the runtime admin API to tweak any value at any time without
+   restarting the pod.
+
 ## [1.0.0] - 2024-03-24
 
 ### Changed

--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-beta.8]
+
+### Fixed
+- `templates/deployment.yaml`: the `wait-for-dependencies` init container
+  is now gated behind `MULTI_TENANT_ENABLED != "true"`. In 2.0.0-beta.7
+  we stopped rendering `POSTGRES_HOST` / `POSTGRES_PORT` / `REDIS_HOST`
+  tuning in MT mode, but the init container still referenced
+  `$POSTGRES_HOST:$POSTGRES_PORT` and `$REDIS_HOST` for its `nc -z`
+  probes. With those envs unset the probe loop ran forever printing
+  `nc: bad port ''` and pods never started.
+
+  In MT mode the bootstrap does not connect to any static Postgres /
+  Redis at boot — per-tenant connections are resolved via tenant-manager
+  at request time — so the dependency wait gate has nothing legitimate
+  to wait for. The init container is now omitted entirely in MT mode.
+- `templates/migrations.yaml`: the migrations Job is now gated by
+  `MULTI_TENANT_ENABLED != "true"` as well. Per-tenant schema migrations
+  in MT mode are owned by tenant-manager, not by a static pre-upgrade
+  hook bound to a single Postgres host.
+
 ## [2.0.0-beta.7]
 
 ### Changed

--- a/charts/plugin-br-bank-transfer/CHANGELOG.md
+++ b/charts/plugin-br-bank-transfer/CHANGELOG.md
@@ -11,26 +11,53 @@ All notable changes to this project will be documented in this file.
   in that mode (app identity, server address, multi-tenant infrastructure,
   app-level Redis connection envs, outbound adapter URLs + auth toggles,
   inbound auth, telemetry toggle/endpoint, feature flags, AWS region for
-  the secrets-manager client). Removed from the MT-mode render:
-  - All `POSTGRES_*` / `MIGRATIONS_PATH` / `INFRA_CONNECT_TIMEOUT_SEC`
-    (per-tenant Postgres resolves via tenant-manager)
+  the secrets-manager client). Gated single-tenant-only in MT-mode render:
+  - All `POSTGRES_*` / `MIGRATIONS_PATH` (per-tenant Postgres resolves via
+    tenant-manager; migrations init container only runs in single-tenant)
   - All `MONGO_*` (per-tenant Mongo resolves via tenant-manager)
   - All `RABBITMQ_*` (not used in MT mode)
   - Redis pool / timeout / `REDIS_PROTOCOL` tuning (systemplane-managed)
-  - `DEPLOYMENT_MODE`, `VERSION`, `HTTP_BODY_LIMIT_BYTES`,
-    `TLS_TERMINATED_UPSTREAM`, `SERVER_*` TLS / proxy
+  - `DEPLOYMENT_MODE`, `HTTP_BODY_LIMIT_BYTES`, `TLS_TERMINATED_UPSTREAM`,
+    `SERVER_*` TLS / proxy
   - `OTEL_LIBRARY_NAME`, `OTEL_RESOURCE_SERVICE_NAME`,
     `OTEL_RESOURCE_SERVICE_VERSION`, `OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT`
   - JD live config (`JD_BASE_URL`, `JD_ORIGIN_ISPB`, `JD_SOAP_PATH`,
     `JD_SIGNING_MODE`, `JD_LEGACY_CODE`, `JD_PRIVATE_KEY_KEYINFO`) — these
     are per-tenant via `TenantIntegrationResolver` in MT mode
-  - `LICENSE_SERVICE_ADDRESS`, `TENANT_IDS`
-  - `ORGANIZATION_ID`, `DEFAULT_ORGANIZATION_ID`, `IS_DEVELOPMENT`,
-    `DEFAULT_TENANT_ID`, `DEFAULT_TENANT_SLUG`,
-    `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE`
-- Single-tenant mode is unchanged: the previous required guards still apply
+  - `LICENSE_SERVICE_ADDRESS`
+  - `ORGANIZATION_ID`
+- Single-tenant mode is unchanged: same defaults, same required guards
   (`POSTGRES_PASSWORD`, `MONGO_PASSWORD`, `JD_BASE_URL`, `JD_ORIGIN_ISPB`
-  when sandbox mode is off) and all single-tenant defaults still render.
+  when sandbox mode is off).
+
+### Removed (dead envs not consumed by the app)
+Audited against `plugin-br-bank-transfer` source (`internal/bootstrap/config`,
+`.env.example`, and the `lib-license-go` / `lib-commons` integrations) and
+dropped from the chart entirely:
+
+- `VERSION` — populated at build time via Docker `--build-arg VERSION` +
+  Go `ldflags -X ...bootstrap.Version=...`. Not read from env at runtime.
+- `TENANT_IDS` — explicitly removed from the app in the D7 license rewrite
+  (`internal/bootstrap/config/validate_production.go`).
+- `PLUGIN_AUTH_CLIENT_ID`, `PLUGIN_AUTH_CLIENT_SECRET` — explicitly removed
+  in D7; the inbound `PLUGIN_AUTH_ENABLED` + `PLUGIN_AUTH_ADDRESS` are the
+  only inbound-auth wiring the app needs.
+- `DEFAULT_ORGANIZATION_ID`, `DEFAULT_TENANT_ID`, `DEFAULT_TENANT_SLUG` —
+  no `env:` tag anywhere in source and no reference in `.env.example`.
+- `IS_DEVELOPMENT` — no `env:` tag or `.env.example` reference. The
+  per-environment behaviour is selected via `ENV_NAME` / `DEPLOYMENT_MODE`.
+- `INFRA_CONNECT_TIMEOUT_SEC` — no source reference. Per-dependency
+  connect timeouts use the explicit `POSTGRES_CONNECT_TIMEOUT_SEC` /
+  `MONGO_*_TIMEOUT_MS` / `REDIS_DIAL_TIMEOUT_MS` envs instead.
+- `MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE` — no source reference;
+  the per-tenant integration secret name template is hard-coded in the
+  `TenantIntegrationResolver`.
+- `MULTI_TENANT_REDIS_CA_CERT` — no source reference and no `.env.example`
+  entry; MT-mode Redis uses TLS via the system trust store.
+- `SYSTEMPLANE_POSTGRES_DSN`, `SYSTEMPLANE_SECRET_MASTER_KEY` — no source
+  reference. lib-commons `systemplane` reads DSN/key bundles via its own
+  envs (`SYSTEMPLANE_*` v5 surface), not these.
+- `JD_CERTIFICATE_PEM` — orphan / typo. The app reads `JD_CERT_PEM`.
 
 ### Fixed
 - Multi-tenant installs no longer fail at template time with

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 1.6.0-beta.1
+version: 2.0.0-beta.1
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 1.5.0-beta.1
+version: 1.6.0-beta.1
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.7
+version: 2.0.0-beta.8
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.9
+version: 2.0.0-beta.10
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.3
+version: 2.0.0-beta.4
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.2
+version: 2.0.0-beta.3
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.4
+version: 2.0.0-beta.5
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.8
+version: 2.0.0-beta.9
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.10
+version: 2.0.0-beta.11
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.5
+version: 2.0.0-beta.6
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.6
+version: 2.0.0-beta.7
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.1
+version: 2.0.0-beta.2
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.11
+version: 2.0.0-beta.12
 
 appVersion: "2.4.0"
 keywords:

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   # APPLICATION IDENTITY
   # =====================================================================
   ENV_NAME: {{ .Values.bankTransfer.configmap.ENV_NAME | default "production" | quote }}
+  APPLICATION_NAME: {{ .Values.bankTransfer.configmap.APPLICATION_NAME | default "plugin-br-bank-transfer" | quote }}
   DEPLOYMENT_MODE: {{ .Values.bankTransfer.configmap.DEPLOYMENT_MODE | default "byoc" | quote }}
   VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
 
@@ -44,8 +45,29 @@ data:
   MULTI_TENANT_URL: {{ .Values.bankTransfer.configmap.MULTI_TENANT_URL | default "" | quote }}
   AWS_REGION: {{ .Values.bankTransfer.configmap.AWS_REGION | default "" | quote }}
   MULTI_TENANT_REDIS_HOST: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | default "" | quote }}
+  MULTI_TENANT_REDIS_PORT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
+  MULTI_TENANT_ENVIRONMENT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENVIRONMENT | default "" | quote }}
+  MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ALLOW_INSECURE_HTTP | default "false" | quote }}
   MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | default "tenants/{env}/{tenantId}/{applicationName}/integration/configuration" | quote }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS }}
+  MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC }}
+  MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT }}
+  MULTI_TENANT_TIMEOUT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD }}
+  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC }}
+  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC }}
+  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC | quote }}
+  {{- end }}
   {{- end }}
 
   # =====================================================================
@@ -90,6 +112,9 @@ data:
   REDIS_TLS: {{ .Values.bankTransfer.configmap.REDIS_TLS | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.REDIS_MASTER_NAME }}
   REDIS_MASTER_NAME: {{ .Values.bankTransfer.configmap.REDIS_MASTER_NAME | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.REDIS_USER }}
+  REDIS_USER: {{ .Values.bankTransfer.configmap.REDIS_USER | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.REDIS_CA_CERT }}
   REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.REDIS_CA_CERT | quote }}
@@ -152,14 +177,23 @@ data:
   {{- if .Values.bankTransfer.configmap.MIDAZ_AUTH_ADDRESS }}
   MIDAZ_AUTH_ADDRESS: {{ .Values.bankTransfer.configmap.MIDAZ_AUTH_ADDRESS | quote }}
   {{- end }}
+  {{- if .Values.bankTransfer.configmap.MIDAZ_TIMEOUT_MS }}
+  MIDAZ_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.MIDAZ_TIMEOUT_MS | quote }}
+  {{- end }}
 
   # CRM
   CRM_BASE_URL: {{ required "bankTransfer.configmap.CRM_BASE_URL is required" .Values.bankTransfer.configmap.CRM_BASE_URL | quote }}
   CRM_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.CRM_AUTH_ENABLED | default "false" | quote }}
+  {{- if .Values.bankTransfer.configmap.CRM_TIMEOUT_MS }}
+  CRM_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.CRM_TIMEOUT_MS | quote }}
+  {{- end }}
 
   # Fees
   FEES_BASE_URL: {{ required "bankTransfer.configmap.FEES_BASE_URL is required" .Values.bankTransfer.configmap.FEES_BASE_URL | quote }}
   FEES_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.FEES_AUTH_ENABLED | default "false" | quote }}
+  {{- if .Values.bankTransfer.configmap.FEES_TIMEOUT_MS }}
+  FEES_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.FEES_TIMEOUT_MS | quote }}
+  {{- end }}
 
   # JD-SPB. Sandbox mode swaps the adapter; live config required otherwise.
   JD_SANDBOX_MODE: {{ .Values.bankTransfer.configmap.JD_SANDBOX_MODE | default "false" | quote }}
@@ -168,8 +202,12 @@ data:
   JD_ORIGIN_ISPB: {{ required "bankTransfer.configmap.JD_ORIGIN_ISPB is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_ORIGIN_ISPB | quote }}
   JD_SOAP_PATH: {{ .Values.bankTransfer.configmap.JD_SOAP_PATH | default "/soap" | quote }}
   JD_SIGNING_MODE: {{ .Values.bankTransfer.configmap.JD_SIGNING_MODE | default "local_pem" | quote }}
+  JD_POLLING_ENABLED: {{ .Values.bankTransfer.configmap.JD_POLLING_ENABLED | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.JD_LEGACY_CODE }}
   JD_LEGACY_CODE: {{ .Values.bankTransfer.configmap.JD_LEGACY_CODE | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.JD_PRIVATE_KEY_KEYINFO }}
+  JD_PRIVATE_KEY_KEYINFO: {{ .Values.bankTransfer.configmap.JD_PRIVATE_KEY_KEYINFO | quote }}
   {{- end }}
   {{- end }}
 
@@ -178,6 +216,15 @@ data:
   # =====================================================================
   ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.ORGANIZATION_ID | default "" | quote }}
   DEFAULT_ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.DEFAULT_ORGANIZATION_ID | default "" | quote }}
+  ORGANIZATION_IDS: {{ .Values.bankTransfer.configmap.ORGANIZATION_IDS | default "" | quote }}
+  IS_DEVELOPMENT: {{ .Values.bankTransfer.configmap.IS_DEVELOPMENT | default "false" | quote }}
+
+  # =====================================================================
+  # FEATURE FLAGS
+  # =====================================================================
+  WEBHOOK_ENABLED: {{ .Values.bankTransfer.configmap.WEBHOOK_ENABLED | default "false" | quote }}
+  BTF_FEE_ENABLED: {{ .Values.bankTransfer.configmap.BTF_FEE_ENABLED | default "false" | quote }}
+  OTEL_SDK_DISABLED: {{ .Values.bankTransfer.configmap.OTEL_SDK_DISABLED | default "false" | quote }}
 
   # =====================================================================
   # EXTRA OVERRIDES (escape hatch for env vars not modeled above)

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -42,6 +42,28 @@ data:
   ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
 
   # =====================================================================
+  # CORS POLICY
+  # CORS_ALLOWED_ORIGINS is rendered in both modes. The plugin's
+  # production validator (internal/bootstrap/config/validate_production.go)
+  # rejects wildcard "*" and any origin containing localhost / 127.0.0.1 /
+  # [::1], so production deployments MUST set this to a concrete public
+  # hostname allowlist. When unset, the in-code dev safety net falls back
+  # to "http://localhost:3000" which trips that production validator.
+  # CORS_ALLOWED_METHODS and CORS_ALLOWED_HEADERS are optional: only
+  # rendered when explicitly set so operators can rely on the plugin's
+  # own sensible defaults until they need to override.
+  # =====================================================================
+  {{- if .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS }}
+  CORS_ALLOWED_ORIGINS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS }}
+  CORS_ALLOWED_METHODS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS | quote }}
+  {{- end }}
+  {{- if .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS }}
+  CORS_ALLOWED_HEADERS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS | quote }}
+  {{- end }}
+
+  # =====================================================================
   # MULTI-TENANCY
   # Toggle is always rendered. Infrastructure endpoints only in MT mode.
   # All operational tuning (timeouts, pool sizes, circuit breaker) ships

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -1,25 +1,32 @@
 {{- if .Values.bankTransfer.enabled }}
+{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
+{{- $namespace := include "global.namespace" . }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "bank-transfer.fullname" . }}
-  namespace: {{ include "global.namespace" . }}
+  namespace: {{ $namespace }}
 data:
   # =====================================================================
   # APPLICATION IDENTITY
+  # Rendered in both modes — required by the bootstrap.
   # =====================================================================
   ENV_NAME: {{ .Values.bankTransfer.configmap.ENV_NAME | default "production" | quote }}
   APPLICATION_NAME: {{ .Values.bankTransfer.configmap.APPLICATION_NAME | default "plugin-br-bank-transfer" | quote }}
+  {{- if not $multiTenantEnabled }}
   DEPLOYMENT_MODE: {{ .Values.bankTransfer.configmap.DEPLOYMENT_MODE | default "byoc" | quote }}
   VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
+  {{- end }}
 
   # =====================================================================
-  # HTTP SERVER + TLS
+  # HTTP SERVER
+  # Only SERVER_ADDRESS is rendered in MT mode. Tuning (body limit, TLS
+  # termination flags, proxy headers) is single-tenant or systemplane-managed.
   # =====================================================================
   SERVER_ADDRESS: {{ .Values.bankTransfer.configmap.SERVER_ADDRESS | default ":4027" | quote }}
+  {{- if not $multiTenantEnabled }}
   HTTP_BODY_LIMIT_BYTES: {{ .Values.bankTransfer.configmap.HTTP_BODY_LIMIT_BYTES | default "1048576" | quote }}
   TLS_TERMINATED_UPSTREAM: {{ .Values.bankTransfer.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
-  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE }}
   SERVER_TLS_CERT_FILE: {{ .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE | quote }}
   {{- end }}
@@ -32,32 +39,31 @@ data:
   {{- if .Values.bankTransfer.configmap.SERVER_TRUSTED_PROXIES }}
   SERVER_TRUSTED_PROXIES: {{ .Values.bankTransfer.configmap.SERVER_TRUSTED_PROXIES | quote }}
   {{- end }}
+  {{- end }}
+  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
 
   # =====================================================================
-  # MULTI-TENANCY (chart-managed: toggle + infrastructure endpoints only)
+  # MULTI-TENANCY
+  # Toggle is always rendered. Infrastructure endpoints only in MT mode.
   # All operational tuning (timeouts, pool sizes, circuit breaker) ships
   # via lib-commons defaults or is hot-reloadable via systemplane.
   # =====================================================================
   MULTI_TENANT_ENABLED: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
-  DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
-  DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
-  {{- if eq (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false") "true" }}
-  MULTI_TENANT_URL: {{ .Values.bankTransfer.configmap.MULTI_TENANT_URL | default "" | quote }}
-  AWS_REGION: {{ .Values.bankTransfer.configmap.AWS_REGION | default "" | quote }}
-  MULTI_TENANT_REDIS_HOST: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | default "" | quote }}
+  {{- if $multiTenantEnabled }}
+  MULTI_TENANT_URL: {{ required "bankTransfer.configmap.MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_URL | quote }}
+  MULTI_TENANT_ENVIRONMENT: {{ required "bankTransfer.configmap.MULTI_TENANT_ENVIRONMENT is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_ENVIRONMENT | quote }}
+  MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ALLOW_INSECURE_HTTP | default "false" | quote }}
+  MULTI_TENANT_REDIS_HOST: {{ required "bankTransfer.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | quote }}
   MULTI_TENANT_REDIS_PORT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
-  MULTI_TENANT_ENVIRONMENT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENVIRONMENT | default "" | quote }}
-  MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ALLOW_INSECURE_HTTP | default "false" | quote }}
-  MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | default "tenants/{env}/{tenantId}/{applicationName}/integration/configuration" | quote }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT }}
+  MULTI_TENANT_REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT | quote }}
+  {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS }}
   MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC }}
   MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT }}
-  MULTI_TENANT_TIMEOUT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD }}
   MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | quote }}
@@ -65,15 +71,21 @@ data:
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC }}
   MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | quote }}
   {{- end }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC }}
-  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC | quote }}
+  AWS_REGION: {{ required "bankTransfer.configmap.AWS_REGION is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.AWS_REGION | quote }}
+  {{- else }}
+  DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
+  DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
+  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE }}
+  MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | quote }}
   {{- end }}
   {{- end }}
 
+  {{- if not $multiTenantEnabled }}
+
   # =====================================================================
-  # POSTGRES (primary)
+  # POSTGRES (primary) — single-tenant only.
+  # MT mode resolves per-tenant DBs via tenant-manager.
   # =====================================================================
-  {{- $namespace := include "global.namespace" . }}
   POSTGRES_HOST: {{ .Values.bankTransfer.configmap.POSTGRES_HOST | default (printf "%s-postgresql-primary.%s.svc.cluster.local" .Release.Name $namespace) | quote }}
   POSTGRES_PORT: {{ .Values.bankTransfer.configmap.POSTGRES_PORT | default "5432" | quote }}
   POSTGRES_USER: {{ .Values.bankTransfer.configmap.POSTGRES_USER | default "bank_transfer" | quote }}
@@ -97,31 +109,39 @@ data:
   POSTGRES_REPLICA_DB: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_DB | quote }}
   POSTGRES_REPLICA_SSLMODE: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_SSLMODE | default "require" | quote }}
   {{- end }}
+  {{- end }}
 
   # =====================================================================
   # VALKEY / REDIS (app-level)
+  # MT mode: only connection envs (HOST, DB, USER, TLS, CA_CERT) are rendered.
+  # Pool/timeout tuning is single-tenant or systemplane-managed.
   # =====================================================================
   REDIS_HOST: {{ .Values.bankTransfer.configmap.REDIS_HOST | default (printf "%s-valkey-primary.%s.svc.cluster.local:6379" .Release.Name $namespace) | quote }}
   REDIS_DB: {{ .Values.bankTransfer.configmap.REDIS_DB | default "0" | quote }}
-  REDIS_PROTOCOL: {{ .Values.bankTransfer.configmap.REDIS_PROTOCOL | default "3" | quote }}
-  REDIS_POOL_SIZE: {{ .Values.bankTransfer.configmap.REDIS_POOL_SIZE | default "10" | quote }}
-  REDIS_MIN_IDLE_CONNS: {{ .Values.bankTransfer.configmap.REDIS_MIN_IDLE_CONNS | default "2" | quote }}
-  REDIS_READ_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_READ_TIMEOUT_MS | default "3000" | quote }}
-  REDIS_WRITE_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_WRITE_TIMEOUT_MS | default "3000" | quote }}
-  REDIS_DIAL_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_DIAL_TIMEOUT_MS | default "5000" | quote }}
   REDIS_TLS: {{ .Values.bankTransfer.configmap.REDIS_TLS | default "false" | quote }}
-  {{- if .Values.bankTransfer.configmap.REDIS_MASTER_NAME }}
-  REDIS_MASTER_NAME: {{ .Values.bankTransfer.configmap.REDIS_MASTER_NAME | quote }}
-  {{- end }}
   {{- if .Values.bankTransfer.configmap.REDIS_USER }}
   REDIS_USER: {{ .Values.bankTransfer.configmap.REDIS_USER | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.REDIS_CA_CERT }}
   REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.REDIS_CA_CERT | quote }}
   {{- end }}
+  {{- if not $multiTenantEnabled }}
+  REDIS_PROTOCOL: {{ .Values.bankTransfer.configmap.REDIS_PROTOCOL | default "3" | quote }}
+  REDIS_POOL_SIZE: {{ .Values.bankTransfer.configmap.REDIS_POOL_SIZE | default "10" | quote }}
+  REDIS_MIN_IDLE_CONNS: {{ .Values.bankTransfer.configmap.REDIS_MIN_IDLE_CONNS | default "2" | quote }}
+  REDIS_READ_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_READ_TIMEOUT_MS | default "3000" | quote }}
+  REDIS_WRITE_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_WRITE_TIMEOUT_MS | default "3000" | quote }}
+  REDIS_DIAL_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.REDIS_DIAL_TIMEOUT_MS | default "5000" | quote }}
+  {{- if .Values.bankTransfer.configmap.REDIS_MASTER_NAME }}
+  REDIS_MASTER_NAME: {{ .Values.bankTransfer.configmap.REDIS_MASTER_NAME | quote }}
+  {{- end }}
+  {{- end }}
+
+  {{- if not $multiTenantEnabled }}
 
   # =====================================================================
-  # MONGODB (audit/event persistence)
+  # MONGODB (audit/event persistence) — single-tenant only.
+  # MT mode resolves per-tenant Mongo via tenant-manager.
   # =====================================================================
   MONGO_ENABLED: {{ .Values.bankTransfer.configmap.MONGO_ENABLED | default "true" | quote }}
   MONGO_DATABASE: {{ .Values.bankTransfer.configmap.MONGO_DATABASE | default "plugin_br_bank_transfer" | quote }}
@@ -130,44 +150,59 @@ data:
   MONGO_HEARTBEAT_INTERVAL_MS: {{ .Values.bankTransfer.configmap.MONGO_HEARTBEAT_INTERVAL_MS | default "10000" | quote }}
 
   # =====================================================================
-  # RABBITMQ (connection + toggle only — retries/timeouts via systemplane)
+  # RABBITMQ — single-tenant only.
   # =====================================================================
   RABBITMQ_ENABLED: {{ .Values.bankTransfer.configmap.RABBITMQ_ENABLED | default "false" | quote }}
   {{- if eq (toString .Values.bankTransfer.configmap.RABBITMQ_ENABLED) "true" }}
   RABBITMQ_URL: {{ .Values.bankTransfer.configmap.RABBITMQ_URL | default (printf "amqp://bank_transfer:$(RABBITMQ_PASSWORD)@%s-rabbitmq.%s.svc.cluster.local:5672/" .Release.Name $namespace) | quote }}
   RABBITMQ_EXCHANGE: {{ .Values.bankTransfer.configmap.RABBITMQ_EXCHANGE | default "bank_transfer.lifecycle" | quote }}
   {{- end }}
+  {{- end }}
 
   # =====================================================================
-  # AUTHENTICATION (inbound)
+  # AUTHENTICATION (inbound) — required in both modes.
   # =====================================================================
   PLUGIN_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ENABLED | default "true" | quote }}
   PLUGIN_AUTH_ADDRESS: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ADDRESS | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000" | quote }}
 
   # =====================================================================
-  # LICENSE GATEWAY (optional override of lib-license-go default)
+  # LICENSE GATEWAY
+  # ORGANIZATION_IDS is rendered in both modes (license tenancy hint).
+  # LICENSE_SERVICE_ADDRESS + TENANT_IDS are single-tenant only.
   # =====================================================================
+  {{- if .Values.bankTransfer.configmap.ORGANIZATION_IDS }}
+  ORGANIZATION_IDS: {{ .Values.bankTransfer.configmap.ORGANIZATION_IDS | quote }}
+  {{- end }}
+  {{- if not $multiTenantEnabled }}
   {{- if .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS }}
   LICENSE_SERVICE_ADDRESS: {{ .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.TENANT_IDS }}
   TENANT_IDS: {{ .Values.bankTransfer.configmap.TENANT_IDS | quote }}
   {{- end }}
+  {{- end }}
 
   # =====================================================================
   # OPENTELEMETRY
+  # MT mode: only the toggle + endpoint + SDK-disabled flag are rendered.
+  # Library/service-name/version/deployment-env are systemplane-managed.
   # =====================================================================
   ENABLE_TELEMETRY: {{ .Values.bankTransfer.configmap.ENABLE_TELEMETRY | default "false" | quote }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.bankTransfer.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
+  OTEL_SDK_DISABLED: {{ .Values.bankTransfer.configmap.OTEL_SDK_DISABLED | default "false" | quote }}
+  {{- if not $multiTenantEnabled }}
   OTEL_LIBRARY_NAME: {{ .Values.bankTransfer.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-bank-transfer" | quote }}
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-bank-transfer" | quote }}
   OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.bankTransfer.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "production" | quote }}
+  {{- end }}
 
   # =====================================================================
   # OUTBOUND ADAPTERS — URLs + auth toggles only.
-  # Timeouts, retries, circuit breakers, cache TTLs, and lookup path
-  # templates are managed by systemplane at runtime.
+  # In MT mode, per-tenant credentials + per-tenant JD config come from
+  # AWS Secrets Manager via TenantIntegrationResolver. Tuning (timeouts,
+  # retries, circuit breakers, cache TTLs, lookup path templates) is
+  # systemplane-managed at runtime.
   # =====================================================================
 
   # Midaz
@@ -195,14 +230,16 @@ data:
   FEES_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.FEES_TIMEOUT_MS | quote }}
   {{- end }}
 
-  # JD-SPB. Sandbox mode swaps the adapter; live config required otherwise.
+  # JD-SPB. In MT mode only mode + polling are exposed; the JD base URL,
+  # credentials, SOAP path, signing keys etc. are resolved per-tenant.
+  # Sandbox mode swaps the adapter; live config required in single-tenant mode.
   JD_SANDBOX_MODE: {{ .Values.bankTransfer.configmap.JD_SANDBOX_MODE | default "false" | quote }}
-  {{- if ne (toString .Values.bankTransfer.configmap.JD_SANDBOX_MODE) "true" }}
-  JD_BASE_URL: {{ required "bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_BASE_URL | quote }}
-  JD_ORIGIN_ISPB: {{ required "bankTransfer.configmap.JD_ORIGIN_ISPB is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_ORIGIN_ISPB | quote }}
+  JD_POLLING_ENABLED: {{ .Values.bankTransfer.configmap.JD_POLLING_ENABLED | default "false" | quote }}
+  {{- if and (not $multiTenantEnabled) (ne (toString .Values.bankTransfer.configmap.JD_SANDBOX_MODE) "true") }}
+  JD_BASE_URL: {{ required "bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is not true and MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.configmap.JD_BASE_URL | quote }}
+  JD_ORIGIN_ISPB: {{ required "bankTransfer.configmap.JD_ORIGIN_ISPB is required when JD_SANDBOX_MODE is not true and MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.configmap.JD_ORIGIN_ISPB | quote }}
   JD_SOAP_PATH: {{ .Values.bankTransfer.configmap.JD_SOAP_PATH | default "/soap" | quote }}
   JD_SIGNING_MODE: {{ .Values.bankTransfer.configmap.JD_SIGNING_MODE | default "local_pem" | quote }}
-  JD_POLLING_ENABLED: {{ .Values.bankTransfer.configmap.JD_POLLING_ENABLED | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.JD_LEGACY_CODE }}
   JD_LEGACY_CODE: {{ .Values.bankTransfer.configmap.JD_LEGACY_CODE | quote }}
   {{- end }}
@@ -211,20 +248,21 @@ data:
   {{- end }}
   {{- end }}
 
+  {{- if not $multiTenantEnabled }}
+
   # =====================================================================
-  # SINGLE-TENANT DEFAULTS (ignored when MULTI_TENANT_ENABLED=true)
+  # SINGLE-TENANT DEFAULTS (ignored / not rendered when MULTI_TENANT_ENABLED=true)
   # =====================================================================
   ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.ORGANIZATION_ID | default "" | quote }}
   DEFAULT_ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.DEFAULT_ORGANIZATION_ID | default "" | quote }}
-  ORGANIZATION_IDS: {{ .Values.bankTransfer.configmap.ORGANIZATION_IDS | default "" | quote }}
   IS_DEVELOPMENT: {{ .Values.bankTransfer.configmap.IS_DEVELOPMENT | default "false" | quote }}
+  {{- end }}
 
   # =====================================================================
-  # FEATURE FLAGS
+  # FEATURE FLAGS — required in both modes.
   # =====================================================================
   WEBHOOK_ENABLED: {{ .Values.bankTransfer.configmap.WEBHOOK_ENABLED | default "false" | quote }}
   BTF_FEE_ENABLED: {{ .Values.bankTransfer.configmap.BTF_FEE_ENABLED | default "false" | quote }}
-  OTEL_SDK_DISABLED: {{ .Values.bankTransfer.configmap.OTEL_SDK_DISABLED | default "false" | quote }}
 
   # =====================================================================
   # EXTRA OVERRIDES (escape hatch for env vars not modeled above)

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -15,7 +15,6 @@ data:
   APPLICATION_NAME: {{ .Values.bankTransfer.configmap.APPLICATION_NAME | default "plugin-br-bank-transfer" | quote }}
   {{- if not $multiTenantEnabled }}
   DEPLOYMENT_MODE: {{ .Values.bankTransfer.configmap.DEPLOYMENT_MODE | default "byoc" | quote }}
-  VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
   {{- end }}
 
   # =====================================================================
@@ -56,9 +55,6 @@ data:
   MULTI_TENANT_REDIS_HOST: {{ required "bankTransfer.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | quote }}
   MULTI_TENANT_REDIS_PORT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT }}
-  MULTI_TENANT_REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_CA_CERT | quote }}
-  {{- end }}
   {{- if .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS }}
   MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | quote }}
   {{- end }}
@@ -72,12 +68,6 @@ data:
   MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | quote }}
   {{- end }}
   AWS_REGION: {{ required "bankTransfer.configmap.AWS_REGION is required when MULTI_TENANT_ENABLED=true" .Values.bankTransfer.configmap.AWS_REGION | quote }}
-  {{- else }}
-  DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
-  DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
-  {{- if .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE }}
-  MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | quote }}
-  {{- end }}
   {{- end }}
 
   {{- if not $multiTenantEnabled }}
@@ -97,7 +87,6 @@ data:
   POSTGRES_CONN_MAX_IDLE_TIME_MINS: {{ .Values.bankTransfer.configmap.POSTGRES_CONN_MAX_IDLE_TIME_MINS | default "5" | quote }}
   POSTGRES_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.POSTGRES_CONNECT_TIMEOUT_SEC | default "10" | quote }}
   MIGRATIONS_PATH: {{ .Values.bankTransfer.configmap.MIGRATIONS_PATH | default "migrations" | quote }}
-  INFRA_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.INFRA_CONNECT_TIMEOUT_SEC | default "30" | quote }}
 
   # =====================================================================
   # POSTGRES (replica — optional, for CQRS read scaling)
@@ -168,7 +157,7 @@ data:
   # =====================================================================
   # LICENSE GATEWAY
   # ORGANIZATION_IDS is rendered in both modes (license tenancy hint).
-  # LICENSE_SERVICE_ADDRESS + TENANT_IDS are single-tenant only.
+  # LICENSE_SERVICE_ADDRESS is single-tenant only.
   # =====================================================================
   {{- if .Values.bankTransfer.configmap.ORGANIZATION_IDS }}
   ORGANIZATION_IDS: {{ .Values.bankTransfer.configmap.ORGANIZATION_IDS | quote }}
@@ -176,9 +165,6 @@ data:
   {{- if not $multiTenantEnabled }}
   {{- if .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS }}
   LICENSE_SERVICE_ADDRESS: {{ .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.TENANT_IDS }}
-  TENANT_IDS: {{ .Values.bankTransfer.configmap.TENANT_IDS | quote }}
   {{- end }}
   {{- end }}
 
@@ -254,8 +240,6 @@ data:
   # SINGLE-TENANT DEFAULTS (ignored / not rendered when MULTI_TENANT_ENABLED=true)
   # =====================================================================
   ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.ORGANIZATION_ID | default "" | quote }}
-  DEFAULT_ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.DEFAULT_ORGANIZATION_ID | default "" | quote }}
-  IS_DEVELOPMENT: {{ .Values.bankTransfer.configmap.IS_DEVELOPMENT | default "false" | quote }}
   {{- end }}
 
   # =====================================================================

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -269,6 +269,8 @@ data:
   # =====================================================================
   WEBHOOK_ENABLED: {{ .Values.bankTransfer.configmap.WEBHOOK_ENABLED | default "false" | quote }}
   BTF_FEE_ENABLED: {{ .Values.bankTransfer.configmap.BTF_FEE_ENABLED | default "false" | quote }}
+  RATE_LIMIT_ENABLED: {{ .Values.bankTransfer.configmap.RATE_LIMIT_ENABLED | default "false" | quote }}
+  ALLOW_INSECURE_TLS: {{ .Values.bankTransfer.configmap.ALLOW_INSECURE_TLS | default "true" | quote }}
 
   # =====================================================================
   # EXTRA OVERRIDES (escape hatch for env vars not modeled above)

--- a/charts/plugin-br-bank-transfer/templates/configmap.yaml
+++ b/charts/plugin-br-bank-transfer/templates/configmap.yaml
@@ -5,26 +5,26 @@ metadata:
   name: {{ include "bank-transfer.fullname" . }}
   namespace: {{ include "global.namespace" . }}
 data:
-  # Application Settings
+  # =====================================================================
+  # APPLICATION IDENTITY
+  # =====================================================================
   ENV_NAME: {{ .Values.bankTransfer.configmap.ENV_NAME | default "production" | quote }}
   DEPLOYMENT_MODE: {{ .Values.bankTransfer.configmap.DEPLOYMENT_MODE | default "byoc" | quote }}
-  LOG_LEVEL: {{ .Values.bankTransfer.configmap.LOG_LEVEL | default "info" | quote }}
+  VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
+
+  # =====================================================================
+  # HTTP SERVER + TLS
+  # =====================================================================
   SERVER_ADDRESS: {{ .Values.bankTransfer.configmap.SERVER_ADDRESS | default ":4027" | quote }}
   HTTP_BODY_LIMIT_BYTES: {{ .Values.bankTransfer.configmap.HTTP_BODY_LIMIT_BYTES | default "1048576" | quote }}
-
-  # CORS Configuration
-  CORS_ALLOWED_ORIGINS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_ORIGINS | default "*" | quote }}
-  CORS_ALLOWED_METHODS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_METHODS | default "GET,POST,PUT,PATCH,DELETE,OPTIONS" | quote }}
-  CORS_ALLOWED_HEADERS: {{ .Values.bankTransfer.configmap.CORS_ALLOWED_HEADERS | default "Origin,Content-Type,Accept,Authorization,X-Request-ID" | quote }}
-
-  # TLS Configuration
+  TLS_TERMINATED_UPSTREAM: {{ .Values.bankTransfer.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
+  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE }}
   SERVER_TLS_CERT_FILE: {{ .Values.bankTransfer.configmap.SERVER_TLS_CERT_FILE | quote }}
   {{- end }}
   {{- if .Values.bankTransfer.configmap.SERVER_TLS_KEY_FILE }}
   SERVER_TLS_KEY_FILE: {{ .Values.bankTransfer.configmap.SERVER_TLS_KEY_FILE | quote }}
   {{- end }}
-  TLS_TERMINATED_UPSTREAM: {{ .Values.bankTransfer.configmap.TLS_TERMINATED_UPSTREAM | default "true" | quote }}
   {{- if .Values.bankTransfer.configmap.SERVER_PROXY_HEADER }}
   SERVER_PROXY_HEADER: {{ .Values.bankTransfer.configmap.SERVER_PROXY_HEADER | quote }}
   {{- end }}
@@ -32,27 +32,25 @@ data:
   SERVER_TRUSTED_PROXIES: {{ .Values.bankTransfer.configmap.SERVER_TRUSTED_PROXIES | quote }}
   {{- end }}
 
-  # Multi-Tenancy
+  # =====================================================================
+  # MULTI-TENANCY (chart-managed: toggle + infrastructure endpoints only)
+  # All operational tuning (timeouts, pool sizes, circuit breaker) ships
+  # via lib-commons defaults or is hot-reloadable via systemplane.
+  # =====================================================================
+  MULTI_TENANT_ENABLED: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
   DEFAULT_TENANT_ID: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_ID | default "" | quote }}
   DEFAULT_TENANT_SLUG: {{ .Values.bankTransfer.configmap.DEFAULT_TENANT_SLUG | default "default" | quote }}
-  MULTI_TENANT_ENABLED: {{ .Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
   {{- if eq (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false") "true" }}
   MULTI_TENANT_URL: {{ .Values.bankTransfer.configmap.MULTI_TENANT_URL | default "" | quote }}
   AWS_REGION: {{ .Values.bankTransfer.configmap.AWS_REGION | default "" | quote }}
   MULTI_TENANT_REDIS_HOST: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_HOST | default "" | quote }}
-  MULTI_TENANT_REDIS_PORT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
   MULTI_TENANT_REDIS_TLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
-  MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.bankTransfer.configmap.MULTI_TENANT_MAX_TENANT_POOLS | default "100" | quote }}
-  MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
-  MULTI_TENANT_TIMEOUT: {{ .Values.bankTransfer.configmap.MULTI_TENANT_TIMEOUT | default "30" | quote }}
-  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | default "5" | quote }}
-  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
   MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: {{ .Values.bankTransfer.configmap.MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE | default "tenants/{env}/{tenantId}/{applicationName}/integration/configuration" | quote }}
-  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
-  MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ .Values.bankTransfer.configmap.MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC | default "30" | quote }}
   {{- end }}
 
-  # PostgreSQL Primary
+  # =====================================================================
+  # POSTGRES (primary)
+  # =====================================================================
   {{- $namespace := include "global.namespace" . }}
   POSTGRES_HOST: {{ .Values.bankTransfer.configmap.POSTGRES_HOST | default (printf "%s-postgresql-primary.%s.svc.cluster.local" .Release.Name $namespace) | quote }}
   POSTGRES_PORT: {{ .Values.bankTransfer.configmap.POSTGRES_PORT | default "5432" | quote }}
@@ -65,8 +63,11 @@ data:
   POSTGRES_CONN_MAX_IDLE_TIME_MINS: {{ .Values.bankTransfer.configmap.POSTGRES_CONN_MAX_IDLE_TIME_MINS | default "5" | quote }}
   POSTGRES_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.POSTGRES_CONNECT_TIMEOUT_SEC | default "10" | quote }}
   MIGRATIONS_PATH: {{ .Values.bankTransfer.configmap.MIGRATIONS_PATH | default "migrations" | quote }}
+  INFRA_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.INFRA_CONNECT_TIMEOUT_SEC | default "30" | quote }}
 
-  # PostgreSQL Replica (optional - for CQRS read scaling)
+  # =====================================================================
+  # POSTGRES (replica — optional, for CQRS read scaling)
+  # =====================================================================
   {{- if .Values.bankTransfer.configmap.POSTGRES_REPLICA_HOST }}
   POSTGRES_REPLICA_HOST: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_HOST | quote }}
   POSTGRES_REPLICA_PORT: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_PORT | default "5432" | quote }}
@@ -75,10 +76,9 @@ data:
   POSTGRES_REPLICA_SSLMODE: {{ .Values.bankTransfer.configmap.POSTGRES_REPLICA_SSLMODE | default "require" | quote }}
   {{- end }}
 
-  # Infrastructure Boot Timeout
-  INFRA_CONNECT_TIMEOUT_SEC: {{ .Values.bankTransfer.configmap.INFRA_CONNECT_TIMEOUT_SEC | default "30" | quote }}
-
-  # Redis/Valkey Configuration
+  # =====================================================================
+  # VALKEY / REDIS (app-level)
+  # =====================================================================
   REDIS_HOST: {{ .Values.bankTransfer.configmap.REDIS_HOST | default (printf "%s-valkey-primary.%s.svc.cluster.local:6379" .Release.Name $namespace) | quote }}
   REDIS_DB: {{ .Values.bankTransfer.configmap.REDIS_DB | default "0" | quote }}
   REDIS_PROTOCOL: {{ .Values.bankTransfer.configmap.REDIS_PROTOCOL | default "3" | quote }}
@@ -95,21 +95,33 @@ data:
   REDIS_CA_CERT: {{ .Values.bankTransfer.configmap.REDIS_CA_CERT | quote }}
   {{- end }}
 
-  # MongoDB Configuration (mandatory for audit/event persistence)
-  # Note: MONGO_URI is in secrets.yaml to include the password securely
+  # =====================================================================
+  # MONGODB (audit/event persistence)
+  # =====================================================================
   MONGO_ENABLED: {{ .Values.bankTransfer.configmap.MONGO_ENABLED | default "true" | quote }}
   MONGO_DATABASE: {{ .Values.bankTransfer.configmap.MONGO_DATABASE | default "plugin_br_bank_transfer" | quote }}
   MONGO_MAX_POOL_SIZE: {{ .Values.bankTransfer.configmap.MONGO_MAX_POOL_SIZE | default "25" | quote }}
   MONGO_SERVER_SELECTION_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.MONGO_SERVER_SELECTION_TIMEOUT_MS | default "3000" | quote }}
   MONGO_HEARTBEAT_INTERVAL_MS: {{ .Values.bankTransfer.configmap.MONGO_HEARTBEAT_INTERVAL_MS | default "10000" | quote }}
 
-  # Authentication (plugin-auth)
-  # Note: PLUGIN_AUTH_CLIENT_ID is in secrets.yaml for secure Vault integration
+  # =====================================================================
+  # RABBITMQ (connection + toggle only — retries/timeouts via systemplane)
+  # =====================================================================
+  RABBITMQ_ENABLED: {{ .Values.bankTransfer.configmap.RABBITMQ_ENABLED | default "false" | quote }}
+  {{- if eq (toString .Values.bankTransfer.configmap.RABBITMQ_ENABLED) "true" }}
+  RABBITMQ_URL: {{ .Values.bankTransfer.configmap.RABBITMQ_URL | default (printf "amqp://bank_transfer:$(RABBITMQ_PASSWORD)@%s-rabbitmq.%s.svc.cluster.local:5672/" .Release.Name $namespace) | quote }}
+  RABBITMQ_EXCHANGE: {{ .Values.bankTransfer.configmap.RABBITMQ_EXCHANGE | default "bank_transfer.lifecycle" | quote }}
+  {{- end }}
+
+  # =====================================================================
+  # AUTHENTICATION (inbound)
+  # =====================================================================
   PLUGIN_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ENABLED | default "true" | quote }}
   PLUGIN_AUTH_ADDRESS: {{ .Values.bankTransfer.configmap.PLUGIN_AUTH_ADDRESS | default "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000" | quote }}
-  AUTH_CACHE_TTL_SEC: {{ .Values.bankTransfer.configmap.AUTH_CACHE_TTL_SEC | default "300" | quote }}
 
-  # License Validation
+  # =====================================================================
+  # LICENSE GATEWAY (optional override of lib-license-go default)
+  # =====================================================================
   {{- if .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS }}
   LICENSE_SERVICE_ADDRESS: {{ .Values.bankTransfer.configmap.LICENSE_SERVICE_ADDRESS | quote }}
   {{- end }}
@@ -117,7 +129,9 @@ data:
   TENANT_IDS: {{ .Values.bankTransfer.configmap.TENANT_IDS | quote }}
   {{- end }}
 
-  # OpenTelemetry
+  # =====================================================================
+  # OPENTELEMETRY
+  # =====================================================================
   ENABLE_TELEMETRY: {{ .Values.bankTransfer.configmap.ENABLE_TELEMETRY | default "false" | quote }}
   OTEL_LIBRARY_NAME: {{ .Values.bankTransfer.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/plugin-br-bank-transfer" | quote }}
   OTEL_RESOURCE_SERVICE_NAME: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-br-bank-transfer" | quote }}
@@ -125,149 +139,49 @@ data:
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.bankTransfer.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
   OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.bankTransfer.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "production" | quote }}
 
-  # Systemplane Runtime Configuration (optional)
-  {{- if .Values.bankTransfer.configmap.SYSTEMPLANE_BACKEND }}
-  SYSTEMPLANE_BACKEND: {{ .Values.bankTransfer.configmap.SYSTEMPLANE_BACKEND | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.SYSTEMPLANE_POSTGRES_SCHEMA }}
-  SYSTEMPLANE_POSTGRES_SCHEMA: {{ .Values.bankTransfer.configmap.SYSTEMPLANE_POSTGRES_SCHEMA | quote }}
-  {{- end }}
+  # =====================================================================
+  # OUTBOUND ADAPTERS — URLs + auth toggles only.
+  # Timeouts, retries, circuit breakers, cache TTLs, and lookup path
+  # templates are managed by systemplane at runtime.
+  # =====================================================================
 
-  # Rate Limiting
-  RATE_LIMIT_ENABLED: {{ .Values.bankTransfer.configmap.RATE_LIMIT_ENABLED | default "true" | quote }}
-  RATE_LIMIT_MAX: {{ .Values.bankTransfer.configmap.RATE_LIMIT_MAX | default "100" | quote }}
-  RATE_LIMIT_EXPIRY_SEC: {{ .Values.bankTransfer.configmap.RATE_LIMIT_EXPIRY_SEC | default "60" | quote }}
-
-  # Database Metrics & Observability
-  DB_METRICS_INTERVAL_SEC: {{ .Values.bankTransfer.configmap.DB_METRICS_INTERVAL_SEC | default "15" | quote }}
-  RECONCILIATION_PENDING_ALERT_THRESHOLD: {{ .Values.bankTransfer.configmap.RECONCILIATION_PENDING_ALERT_THRESHOLD | default "20" | quote }}
-
-  # Idempotency
-  IDEMPOTENCY_RETRY_WINDOW_SEC: {{ .Values.bankTransfer.configmap.IDEMPOTENCY_RETRY_WINDOW_SEC | default "300" | quote }}
-  IDEMPOTENCY_REQUIRE_REDIS: {{ .Values.bankTransfer.configmap.IDEMPOTENCY_REQUIRE_REDIS | default "true" | quote }}
-  DUPLICATE_GUARD_TTL_SEC: {{ .Values.bankTransfer.configmap.DUPLICATE_GUARD_TTL_SEC | default "300" | quote }}
-
-  # Midaz Adapter
+  # Midaz
   MIDAZ_BASE_URL: {{ required "bankTransfer.configmap.MIDAZ_BASE_URL is required" .Values.bankTransfer.configmap.MIDAZ_BASE_URL | quote }}
   MIDAZ_TRANSACTION_URL: {{ .Values.bankTransfer.configmap.MIDAZ_TRANSACTION_URL | default .Values.bankTransfer.configmap.MIDAZ_BASE_URL | quote }}
-  MIDAZ_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.MIDAZ_TIMEOUT_MS | default "3000" | quote }}
-  MIDAZ_MAX_RETRIES: {{ .Values.bankTransfer.configmap.MIDAZ_MAX_RETRIES | default "3" | quote }}
-  MIDAZ_OTEL_ENABLED: {{ .Values.bankTransfer.configmap.MIDAZ_OTEL_ENABLED | default "true" | quote }}
-  MIDAZ_DEBUG: {{ .Values.bankTransfer.configmap.MIDAZ_DEBUG | default "false" | quote }}
   MIDAZ_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.MIDAZ_AUTH_ENABLED | default "false" | quote }}
   {{- if .Values.bankTransfer.configmap.MIDAZ_AUTH_ADDRESS }}
   MIDAZ_AUTH_ADDRESS: {{ .Values.bankTransfer.configmap.MIDAZ_AUTH_ADDRESS | quote }}
   {{- end }}
-  MIDAZ_BREAKER_FAILURES: {{ .Values.bankTransfer.configmap.MIDAZ_BREAKER_FAILURES | default "3" | quote }}
-  MIDAZ_BREAKER_TIMEOUT_SECONDS: {{ .Values.bankTransfer.configmap.MIDAZ_BREAKER_TIMEOUT_SECONDS | default "30" | quote }}
 
-  # CRM Adapter
-  # Note: CRM_CLIENT_ID is in secrets.yaml for secure Vault integration
+  # CRM
   CRM_BASE_URL: {{ required "bankTransfer.configmap.CRM_BASE_URL is required" .Values.bankTransfer.configmap.CRM_BASE_URL | quote }}
-  CRM_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.CRM_TIMEOUT_MS | default "2000" | quote }}
-  CRM_MAX_RETRIES: {{ .Values.bankTransfer.configmap.CRM_MAX_RETRIES | default "2" | quote }}
-  CRM_CACHE_TTL_MS: {{ .Values.bankTransfer.configmap.CRM_CACHE_TTL_MS | default "300000" | quote }}
   CRM_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.CRM_AUTH_ENABLED | default "false" | quote }}
-  {{- if .Values.bankTransfer.configmap.CRM_SENDER_LOOKUP_PATH_TEMPLATE }}
-  CRM_SENDER_LOOKUP_PATH_TEMPLATE: {{ .Values.bankTransfer.configmap.CRM_SENDER_LOOKUP_PATH_TEMPLATE | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.CRM_RECIPIENT_LOOKUP_PATH_TEMPLATE }}
-  CRM_RECIPIENT_LOOKUP_PATH_TEMPLATE: {{ .Values.bankTransfer.configmap.CRM_RECIPIENT_LOOKUP_PATH_TEMPLATE | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.configmap.CRM_HOLDER_LOOKUP_PATH_TEMPLATE }}
-  CRM_HOLDER_LOOKUP_PATH_TEMPLATE: {{ .Values.bankTransfer.configmap.CRM_HOLDER_LOOKUP_PATH_TEMPLATE | quote }}
-  {{- end }}
 
-  # Fees Adapter
-  # Note: FEES_CLIENT_ID is in secrets.yaml for secure Vault integration
+  # Fees
   FEES_BASE_URL: {{ required "bankTransfer.configmap.FEES_BASE_URL is required" .Values.bankTransfer.configmap.FEES_BASE_URL | quote }}
-  FEES_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.FEES_TIMEOUT_MS | default "2000" | quote }}
-  FEES_MAX_RETRIES: {{ .Values.bankTransfer.configmap.FEES_MAX_RETRIES | default "2" | quote }}
-  FEES_FAIL_CLOSED_DEFAULT: {{ .Values.bankTransfer.configmap.FEES_FAIL_CLOSED_DEFAULT | default "false" | quote }}
-  FEES_MAX_FEE_AMOUNT_CENTS: {{ .Values.bankTransfer.configmap.FEES_MAX_FEE_AMOUNT_CENTS | default "99999999" | quote }}
-  FEES_REFUND_ON_DEVOLUCAO: {{ .Values.bankTransfer.configmap.FEES_REFUND_ON_DEVOLUCAO | default "false" | quote }}
   FEES_AUTH_ENABLED: {{ .Values.bankTransfer.configmap.FEES_AUTH_ENABLED | default "false" | quote }}
 
-  # JD Sandbox Mode (uses in-process fake adapter, cannot combine with live JD config)
+  # JD-SPB. Sandbox mode swaps the adapter; live config required otherwise.
   JD_SANDBOX_MODE: {{ .Values.bankTransfer.configmap.JD_SANDBOX_MODE | default "false" | quote }}
-
-  # JD SPB Adapter (only when NOT in sandbox mode)
   {{- if ne (toString .Values.bankTransfer.configmap.JD_SANDBOX_MODE) "true" }}
   JD_BASE_URL: {{ required "bankTransfer.configmap.JD_BASE_URL is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_BASE_URL | quote }}
-  JD_SOAP_PATH: {{ .Values.bankTransfer.configmap.JD_SOAP_PATH | default "/soap" | quote }}
   JD_ORIGIN_ISPB: {{ required "bankTransfer.configmap.JD_ORIGIN_ISPB is required when JD_SANDBOX_MODE is not true" .Values.bankTransfer.configmap.JD_ORIGIN_ISPB | quote }}
+  JD_SOAP_PATH: {{ .Values.bankTransfer.configmap.JD_SOAP_PATH | default "/soap" | quote }}
+  JD_SIGNING_MODE: {{ .Values.bankTransfer.configmap.JD_SIGNING_MODE | default "local_pem" | quote }}
   {{- if .Values.bankTransfer.configmap.JD_LEGACY_CODE }}
   JD_LEGACY_CODE: {{ .Values.bankTransfer.configmap.JD_LEGACY_CODE | quote }}
   {{- end }}
-  JD_SIGNING_MODE: {{ .Values.bankTransfer.configmap.JD_SIGNING_MODE | default "local_pem" | quote }}
-  JD_SIGNATURE_REQUIRED: {{ .Values.bankTransfer.configmap.JD_SIGNATURE_REQUIRED | default "true" | quote }}
-  JD_VALIDATE_EXTERNAL_SIGNATURE: {{ .Values.bankTransfer.configmap.JD_VALIDATE_EXTERNAL_SIGNATURE | default "true" | quote }}
-  JD_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.JD_TIMEOUT_MS | default "8000" | quote }}
-  JD_MAX_RETRIES: {{ .Values.bankTransfer.configmap.JD_MAX_RETRIES | default "3" | quote }}
   {{- end }}
 
-  # JD Polling (TED IN ingestion)
-  JD_POLLING_ENABLED: {{ .Values.bankTransfer.configmap.JD_POLLING_ENABLED | default "false" | quote }}
-  JD_POLL_INTERVAL_SECONDS: {{ .Values.bankTransfer.configmap.JD_POLL_INTERVAL_SECONDS | default "30" | quote }}
-  JD_POLL_MAX_MESSAGES_PER_CYCLE: {{ .Values.bankTransfer.configmap.JD_POLL_MAX_MESSAGES_PER_CYCLE | default "50" | quote }}
-  JD_POLL_MAX_RETRIES: {{ .Values.bankTransfer.configmap.JD_POLL_MAX_RETRIES | default "3" | quote }}
-  JD_POLL_RECOVERY_BATCH_SIZE: {{ .Values.bankTransfer.configmap.JD_POLL_RECOVERY_BATCH_SIZE | default "200" | quote }}
-  JD_POLL_DISABLE_OPERATING_HOURS_WINDOW: {{ .Values.bankTransfer.configmap.JD_POLL_DISABLE_OPERATING_HOURS_WINDOW | default "true" | quote }}
-
-  # RabbitMQ Event Bus (optional)
-  RABBITMQ_ENABLED: {{ .Values.bankTransfer.configmap.RABBITMQ_ENABLED | default "false" | quote }}
-  {{- if eq (toString .Values.bankTransfer.configmap.RABBITMQ_ENABLED) "true" }}
-  RABBITMQ_URL: {{ .Values.bankTransfer.configmap.RABBITMQ_URL | default (printf "amqp://bank_transfer:$(RABBITMQ_PASSWORD)@%s-rabbitmq.%s.svc.cluster.local:5672/" .Release.Name $namespace) | quote }}
-  RABBITMQ_EXCHANGE: {{ .Values.bankTransfer.configmap.RABBITMQ_EXCHANGE | default "bank_transfer.lifecycle" | quote }}
-  RABBITMQ_ROUTING_KEY_PREFIX: {{ .Values.bankTransfer.configmap.RABBITMQ_ROUTING_KEY_PREFIX | default "transfer" | quote }}
-  RABBITMQ_PUBLISH_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.RABBITMQ_PUBLISH_TIMEOUT_MS | default "5000" | quote }}
-  RABBITMQ_MAX_RETRIES: {{ .Values.bankTransfer.configmap.RABBITMQ_MAX_RETRIES | default "3" | quote }}
-  RABBITMQ_RETRY_BACKOFF_MS: {{ .Values.bankTransfer.configmap.RABBITMQ_RETRY_BACKOFF_MS | default "200" | quote }}
-  {{- end }}
-
-  # Webhook Delivery Worker (optional)
-  WEBHOOK_ENABLED: {{ .Values.bankTransfer.configmap.WEBHOOK_ENABLED | default "false" | quote }}
-  {{- if eq (toString .Values.bankTransfer.configmap.WEBHOOK_ENABLED) "true" }}
-  WEBHOOK_ENDPOINT_URL: {{ required "bankTransfer.configmap.WEBHOOK_ENDPOINT_URL is required when WEBHOOK_ENABLED=true" .Values.bankTransfer.configmap.WEBHOOK_ENDPOINT_URL | quote }}
-  WEBHOOK_QUEUE_NAME: {{ .Values.bankTransfer.configmap.WEBHOOK_QUEUE_NAME | default "transfer.webhook.delivery" | quote }}
-  WEBHOOK_DLQ_NAME: {{ .Values.bankTransfer.configmap.WEBHOOK_DLQ_NAME | default "transfer.webhook.dlq" | quote }}
-  WEBHOOK_CONSUMER_TAG: {{ .Values.bankTransfer.configmap.WEBHOOK_CONSUMER_TAG | default "plugin-br-bank-transfer-webhook" | quote }}
-  WEBHOOK_PREFETCH_COUNT: {{ .Values.bankTransfer.configmap.WEBHOOK_PREFETCH_COUNT | default "20" | quote }}
-  WEBHOOK_TIMEOUT_MS: {{ .Values.bankTransfer.configmap.WEBHOOK_TIMEOUT_MS | default "5000" | quote }}
-  WEBHOOK_MAX_RETRIES: {{ .Values.bankTransfer.configmap.WEBHOOK_MAX_RETRIES | default "3" | quote }}
-  WEBHOOK_RETRY_BACKOFF_MS: {{ .Values.bankTransfer.configmap.WEBHOOK_RETRY_BACKOFF_MS | default "500" | quote }}
-  WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS: {{ .Values.bankTransfer.configmap.WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS | default "false" | quote }}
-  WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC: {{ .Values.bankTransfer.configmap.WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC | default "0" | quote }}
-  {{- end }}
-
-  # Usage Limits
-  USAGE_LIMITS_ENABLED: {{ .Values.bankTransfer.configmap.USAGE_LIMITS_ENABLED | default "false" | quote }}
-  {{- if eq (toString .Values.bankTransfer.configmap.USAGE_LIMITS_ENABLED) "true" }}
-  USAGE_LIMIT_DAILY_CENTS: {{ .Values.bankTransfer.configmap.USAGE_LIMIT_DAILY_CENTS | default "0" | quote }}
-  USAGE_LIMIT_MONTHLY_CENTS: {{ .Values.bankTransfer.configmap.USAGE_LIMIT_MONTHLY_CENTS | default "0" | quote }}
-  {{- end }}
-
-  # Operating Hours
-  TRANSFER_OPERATING_OPEN: {{ .Values.bankTransfer.configmap.TRANSFER_OPERATING_OPEN | default "06:30" | quote }}
-  TRANSFER_OPERATING_CLOSE: {{ .Values.bankTransfer.configmap.TRANSFER_OPERATING_CLOSE | default "17:00" | quote }}
-  TRANSFER_OPERATING_TIMEZONE: {{ .Values.bankTransfer.configmap.TRANSFER_OPERATING_TIMEZONE | default "America/Sao_Paulo" | quote }}
-
-  # Application Version (for logs/telemetry)
-  VERSION: {{ .Values.bankTransfer.image.tag | default .Chart.AppVersion | quote }}
-
-  BTF_RECONCILIATION_ENABLED: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_ENABLED | default "true" | quote }}
-  BTF_RECONCILIATION_INTERVAL_SEC: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_INTERVAL_SEC | default "30" | quote }}
-  BTF_RECONCILIATION_BATCH_SIZE: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_BATCH_SIZE | default "20" | quote }}
-  BTF_RECONCILIATION_MAX_ATTEMPTS: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_MAX_ATTEMPTS | default "5" | quote }}
-  BTF_RECONCILIATION_STALE_AFTER_SEC: {{ .Values.bankTransfer.configmap.BTF_RECONCILIATION_STALE_AFTER_SEC | default "60" | quote }}
-
-  BTF_FEE_ENABLED: {{ .Values.bankTransfer.configmap.BTF_FEE_ENABLED | default "false" | quote }}
-  BTF_MIDAZ_CB_ENABLED: {{ .Values.bankTransfer.configmap.BTF_MIDAZ_CB_ENABLED | default "false" | quote }}
+  # =====================================================================
+  # SINGLE-TENANT DEFAULTS (ignored when MULTI_TENANT_ENABLED=true)
+  # =====================================================================
+  ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.ORGANIZATION_ID | default "" | quote }}
   DEFAULT_ORGANIZATION_ID: {{ .Values.bankTransfer.configmap.DEFAULT_ORGANIZATION_ID | default "" | quote }}
-  ALLOW_PRIVATE_UPSTREAMS: {{ .Values.bankTransfer.configmap.ALLOW_PRIVATE_UPSTREAMS | default "false" | quote }}
 
-  
-  # Extra Env Vars (must be a map of key: value pairs)
+  # =====================================================================
+  # EXTRA OVERRIDES (escape hatch for env vars not modeled above)
+  # =====================================================================
   {{- range $key, $value := .Values.bankTransfer.extraEnvVars }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/plugin-br-bank-transfer/templates/deployment.yaml
+++ b/charts/plugin-br-bank-transfer/templates/deployment.yaml
@@ -94,8 +94,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - name: "POD_IP"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
             value: "$(HOST_IP):4317"
+          - name: "OTEL_RESOURCE_ATTRIBUTES"
+            value: "k8s.pod.ip=$(POD_IP)"
           {{- end }}
           ports:
             - name: http

--- a/charts/plugin-br-bank-transfer/templates/deployment.yaml
+++ b/charts/plugin-br-bank-transfer/templates/deployment.yaml
@@ -37,6 +37,11 @@ spec:
       serviceAccountName: {{ include "bank-transfer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.bankTransfer.podSecurityContext | nindent 8 }}
+      {{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
+      {{- if not $multiTenantEnabled }}
+      # In multi-tenant mode the bootstrap does not connect to any static
+      # Postgres / Redis at boot — per-tenant connections are resolved via
+      # tenant-manager at request time. Skip the dependency wait gate.
       initContainers:
         - name: wait-for-dependencies
           image: busybox:1.37
@@ -77,6 +82,7 @@ spec:
               wait_for_service "$REDIS_SVC" "$REDIS_PORT_NUM"
 
               echo "All dependencies are ready!"
+      {{- end }}
       containers:
         - name: {{ include "bank-transfer.fullname" . }}
           securityContext:

--- a/charts/plugin-br-bank-transfer/templates/migrations.yaml
+++ b/charts/plugin-br-bank-transfer/templates/migrations.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.bankTransfer.migrations.enabled }}
+{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
+{{- if and .Values.bankTransfer.migrations.enabled (not $multiTenantEnabled) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/plugin-br-bank-transfer/templates/migrations.yaml
+++ b/charts/plugin-br-bank-transfer/templates/migrations.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.bankTransfer.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "bank-transfer.fullname" . }}-migrations
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "bank-transfer.labels" (dict "context" . "component" "migrations" "name" "migrations") | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade,post-install
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  backoffLimit: {{ .Values.bankTransfer.migrations.backoffLimit | default 3 }}
+  template:
+    metadata:
+      labels:
+        {{- include "bank-transfer.selectorLabels" (dict "context" . "component" "migrations" "name" "migrations") | nindent 8 }}
+    spec:
+      {{- with .Values.bankTransfer.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          envFrom:
+            - configMapRef:
+                name: {{ include "bank-transfer.fullname" . }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              MAX_ATTEMPTS=60
+              SLEEP_SECONDS=5
+              ATTEMPTS=0
+              echo "Waiting for PostgreSQL at $POSTGRES_HOST:$POSTGRES_PORT..."
+              while ! nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
+                ATTEMPTS=$((ATTEMPTS + 1))
+                if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
+                  echo "Timeout waiting for PostgreSQL after $((MAX_ATTEMPTS * SLEEP_SECONDS))s"
+                  exit 1
+                fi
+                echo "PostgreSQL not ready, retrying in ${SLEEP_SECONDS}s... (attempt $ATTEMPTS/$MAX_ATTEMPTS)"
+                sleep $SLEEP_SECONDS
+              done
+              echo "PostgreSQL is ready."
+      containers:
+        - name: migrations
+          image: "{{ .Values.bankTransfer.migrations.image.repository }}:{{ .Values.bankTransfer.migrations.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.bankTransfer.migrations.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "bank-transfer.fullname" . }}
+                  key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "bank-transfer.fullname" . }}
+                  key: POSTGRES_PORT
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "bank-transfer.fullname" . }}
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "bank-transfer.fullname" . }}
+                  key: POSTGRES_DB
+            - name: POSTGRES_SSLMODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "bank-transfer.fullname" . }}
+                  key: POSTGRES_SSLMODE
+            - name: POSTGRES_CONNECT_TIMEOUT_SEC
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "bank-transfer.fullname" . }}
+                  key: POSTGRES_CONNECT_TIMEOUT_SEC
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.bankTransfer.useExistingSecret }}{{ required "bankTransfer.existingSecretName is required when bankTransfer.useExistingSecret is true" .Values.bankTransfer.existingSecretName }}{{ else }}{{ include "bank-transfer.fullname" . }}{{ end }}
+                  key: POSTGRES_PASSWORD
+          resources:
+            {{- toYaml .Values.bankTransfer.migrations.resources | nindent 12 }}
+{{- end }}

--- a/charts/plugin-br-bank-transfer/templates/migrations.yaml
+++ b/charts/plugin-br-bank-transfer/templates/migrations.yaml
@@ -47,7 +47,7 @@ spec:
               echo "PostgreSQL is ready."
       containers:
         - name: migrations
-          image: "{{ .Values.bankTransfer.migrations.image.repository }}:{{ .Values.bankTransfer.migrations.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.bankTransfer.migrations.image.repository }}:{{ .Values.bankTransfer.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.bankTransfer.migrations.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: POSTGRES_HOST

--- a/charts/plugin-br-bank-transfer/templates/migrations.yaml
+++ b/charts/plugin-br-bank-transfer/templates/migrations.yaml
@@ -1,91 +1,135 @@
-{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
-{{- if and .Values.bankTransfer.migrations.enabled (not $multiTenantEnabled) }}
+{{- $bankTransfer := .Values.bankTransfer | default dict }}
+{{- $migrations := get $bankTransfer "migrations" | default dict }}
+{{- $configmap := get $bankTransfer "configmap" | default dict }}
+{{- $postgresql := .Values.postgresql | default dict }}
+{{- $migrationImage := get $migrations "image" | default dict }}
+{{- $defaultMigrationResources := dict "requests" (dict "cpu" "50m" "memory" "64Mi") "limits" (dict "cpu" "250m" "memory" "256Mi") }}
+{{- $migrationsEnabled := and (eq (lower (toString (get $bankTransfer "enabled" | default false))) "true") (eq (lower (toString (get $migrations "enabled" | default false))) "true") }}
+{{- if $migrationsEnabled }}
+{{- if eq (lower (toString (get $configmap "MULTI_TENANT_ENABLED" | default "false"))) "true" }}
+{{- fail "bankTransfer.migrations.enabled cannot be true when bankTransfer.configmap.MULTI_TENANT_ENABLED=true; tenant-manager owns tenant database migrations" }}
+{{- end }}
+{{- if and (eq (lower (toString (get $postgresql "enabled" | default false))) "true") (not (eq (lower (toString (get $postgresql "external" | default false))) "true")) }}
+{{- fail "bankTransfer.migrations.enabled cannot be true when chart-managed postgresql.enabled=true; use an external PostgreSQL migration path instead" }}
+{{- end }}
+{{- if not (eq (lower (toString (get $migrations "useExistingSecret" | default false))) "true") }}
+{{- fail "bankTransfer.migrations.useExistingSecret must be true because migration hooks run before chart-managed Secrets exist" }}
+{{- end }}
+{{- $existingSecretName := required "bankTransfer.migrations.existingSecretName is required when bankTransfer.migrations.enabled=true" (get $migrations "existingSecretName") }}
+{{- $namespace := include "global.namespace" . }}
+{{- $migrationTag := "" }}
+{{- $migrationDigest := "" }}
+{{- if kindIs "string" $migrationImage }}
+{{- if not (regexMatch "(@sha256:[A-Fa-f0-9]{64}|:[^/:@]+)$" $migrationImage) }}
+{{- fail "bankTransfer.migrations.image string must include an explicit tag or sha256 digest when bankTransfer.migrations.enabled=true" }}
+{{- end }}
+{{- else }}
+{{- $migrationTag = get $migrationImage "tag" | default "" }}
+{{- $migrationDigest = get $migrationImage "digest" | default "" }}
+{{- if and (empty $migrationTag) (empty $migrationDigest) }}
+{{- fail "bankTransfer.migrations.image.tag or bankTransfer.migrations.image.digest is required when bankTransfer.migrations.enabled=true; migration images must not silently reuse the app tag" }}
+{{- end }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "bank-transfer.fullname" . }}-migrations
-  namespace: {{ include "global.namespace" . }}
+  name: {{ printf "%s-migrations" (include "bank-transfer.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $namespace }}
   labels:
-    {{- include "bank-transfer.labels" (dict "context" . "component" "migrations" "name" "migrations") | nindent 4 }}
+    {{- include "bank-transfer.labels" (dict "context" . "component" "migrations" "name" (get $bankTransfer "name") ) | nindent 4 }}
   annotations:
-    helm.sh/hook: pre-upgrade,post-install
-    helm.sh/hook-delete-policy: before-hook-creation
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "argocd.argoproj.io/hook": PreSync
+    "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
+    {{- with (get $migrations "annotations") }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  backoffLimit: {{ .Values.bankTransfer.migrations.backoffLimit | default 3 }}
+  backoffLimit: {{ get $migrations "backoffLimit" | default 3 }}
+  activeDeadlineSeconds: {{ get $migrations "activeDeadlineSeconds" | default 600 }}
+  ttlSecondsAfterFinished: {{ get $migrations "ttlSecondsAfterFinished" | default 600 }}
   template:
     metadata:
       labels:
-        {{- include "bank-transfer.selectorLabels" (dict "context" . "component" "migrations" "name" "migrations") | nindent 8 }}
+        {{- include "bank-transfer.labels" (dict "context" . "component" "migrations" "name" (get $bankTransfer "name") ) | nindent 8 }}
+      {{- with (get $migrations "podAnnotations") }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
-      {{- with .Values.bankTransfer.imagePullSecrets }}
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with (get $bankTransfer "imagePullSecrets") }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: OnFailure
-      initContainers:
-        - name: wait-for-postgres
-          image: busybox:1.37
-          envFrom:
-            - configMapRef:
-                name: {{ include "bank-transfer.fullname" . }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              MAX_ATTEMPTS=60
-              SLEEP_SECONDS=5
-              ATTEMPTS=0
-              echo "Waiting for PostgreSQL at $POSTGRES_HOST:$POSTGRES_PORT..."
-              while ! nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
-                ATTEMPTS=$((ATTEMPTS + 1))
-                if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
-                  echo "Timeout waiting for PostgreSQL after $((MAX_ATTEMPTS * SLEEP_SECONDS))s"
-                  exit 1
-                fi
-                echo "PostgreSQL not ready, retrying in ${SLEEP_SECONDS}s... (attempt $ATTEMPTS/$MAX_ATTEMPTS)"
-                sleep $SLEEP_SECONDS
-              done
-              echo "PostgreSQL is ready."
+      {{- with (get $migrations "serviceAccountName") }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
       containers:
         - name: migrations
-          image: "{{ .Values.bankTransfer.migrations.image.repository }}:{{ .Values.bankTransfer.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.bankTransfer.migrations.image.pullPolicy | default "IfNotPresent" }}
+          {{- if kindIs "string" $migrationImage }}
+          image: {{ $migrationImage | quote }}
+          imagePullPolicy: Always
+          {{- else }}
+          {{- $migrationRepository := get $migrationImage "repository" | default "ghcr.io/lerianstudio/plugin-br-bank-transfer-migrations" }}
+          {{- if $migrationDigest }}
+          image: "{{ $migrationRepository }}@{{ $migrationDigest }}"
+          {{- else }}
+          image: "{{ $migrationRepository }}:{{ $migrationTag }}"
+          {{- end }}
+          imagePullPolicy: {{ get $migrationImage "pullPolicy" | default "IfNotPresent" }}
+          {{- end }}
           env:
+            - name: MIGRATIONS_PATH
+              value: {{ get $migrations "path" | default "/migrations" | quote }}
+            # The migrations runner refuses sslmode=disable unless this is set;
+            # mirror the app-level toggle so non-TLS Postgres targets work.
+            - name: ALLOW_INSECURE_TLS
+              value: {{ get $configmap "ALLOW_INSECURE_TLS" | default "false" | quote }}
             - name: POSTGRES_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_HOST
+              value: {{ get $configmap "POSTGRES_HOST" | default (printf "%s-postgresql-primary.%s.svc.cluster.local" .Release.Name $namespace) | quote }}
             - name: POSTGRES_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_PORT
+              value: {{ get $configmap "POSTGRES_PORT" | default "5432" | quote }}
             - name: POSTGRES_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_USER
+              value: {{ get $configmap "POSTGRES_USER" | default "plugin-br-bank-transfer" | quote }}
             - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_DB
+              value: {{ get $configmap "POSTGRES_DB" | default "plugin-br-bank-transfer" | quote }}
             - name: POSTGRES_SSLMODE
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_SSLMODE
+              value: {{ get $configmap "POSTGRES_SSLMODE" | default "require" | quote }}
             - name: POSTGRES_CONNECT_TIMEOUT_SEC
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "bank-transfer.fullname" . }}
-                  key: POSTGRES_CONNECT_TIMEOUT_SEC
+              value: {{ get $configmap "POSTGRES_CONNECT_TIMEOUT_SEC" | default "10" | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.bankTransfer.useExistingSecret }}{{ required "bankTransfer.existingSecretName is required when bankTransfer.useExistingSecret is true" .Values.bankTransfer.existingSecretName }}{{ else }}{{ include "bank-transfer.fullname" . }}{{ end }}
+                  name: {{ $existingSecretName }}
                   key: POSTGRES_PASSWORD
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           resources:
-            {{- toYaml .Values.bankTransfer.migrations.resources | nindent 12 }}
+            {{- toYaml (get $migrations "resources" | default $defaultMigrationResources) | nindent 12 }}
+      {{- with (get $bankTransfer "nodeSelector") }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (get $bankTransfer "affinity") }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (get $bankTransfer "tolerations") }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/plugin-br-bank-transfer/templates/pdb.yaml
+++ b/charts/plugin-br-bank-transfer/templates/pdb.yaml
@@ -20,5 +20,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "bank-transfer.selectorLabels" (dict "context" . "name" .Values.bankTransfer.name ) | nindent 6 }}
+      {{- include "bank-transfer.selectorLabels" (dict "context" . "component" .Values.bankTransfer.name "name" .Values.bankTransfer.name ) | nindent 6 }}
 {{- end }}

--- a/charts/plugin-br-bank-transfer/templates/secrets.yaml
+++ b/charts/plugin-br-bank-transfer/templates/secrets.yaml
@@ -43,14 +43,6 @@ stringData:
   {{- end }}
   {{- end }}
 
-  # Authentication (plugin-auth)
-  {{- if .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_ID }}
-  PLUGIN_AUTH_CLIENT_ID: {{ .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_ID | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_SECRET }}
-  PLUGIN_AUTH_CLIENT_SECRET: {{ .Values.bankTransfer.secrets.PLUGIN_AUTH_CLIENT_SECRET | quote }}
-  {{- end }}
-
   # License Key
   {{- if .Values.bankTransfer.secrets.LICENSE_KEY }}
   LICENSE_KEY: {{ .Values.bankTransfer.secrets.LICENSE_KEY | quote }}
@@ -70,14 +62,6 @@ stringData:
   {{- end }}
   {{- if .Values.bankTransfer.secrets.FEES_CLIENT_SECRET }}
   FEES_CLIENT_SECRET: {{ .Values.bankTransfer.secrets.FEES_CLIENT_SECRET | quote }}
-  {{- end }}
-
-  # Systemplane Secret (optional - for runtime config encryption)
-  {{- if .Values.bankTransfer.secrets.SYSTEMPLANE_SECRET_MASTER_KEY }}
-  SYSTEMPLANE_SECRET_MASTER_KEY: {{ .Values.bankTransfer.secrets.SYSTEMPLANE_SECRET_MASTER_KEY | quote }}
-  {{- end }}
-  {{- if .Values.bankTransfer.secrets.SYSTEMPLANE_POSTGRES_DSN }}
-  SYSTEMPLANE_POSTGRES_DSN: {{ .Values.bankTransfer.secrets.SYSTEMPLANE_POSTGRES_DSN | quote }}
   {{- end }}
 
   # JD SPB Credentials
@@ -124,9 +108,5 @@ stringData:
   WEBHOOK_BROKER_EVENT_SIGNING_SECRET: {{ .Values.bankTransfer.secrets.WEBHOOK_BROKER_EVENT_SIGNING_SECRET | quote }}
   {{- end }}
 
-  # JD Certificate PEM
-  {{- if .Values.bankTransfer.secrets.JD_CERTIFICATE_PEM }}
-  JD_CERTIFICATE_PEM: {{ .Values.bankTransfer.secrets.JD_CERTIFICATE_PEM | quote }}
-  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/plugin-br-bank-transfer/templates/secrets.yaml
+++ b/charts/plugin-br-bank-transfer/templates/secrets.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.bankTransfer.enabled }}
 {{- if not .Values.bankTransfer.useExistingSecret }}
+{{- $multiTenantEnabled := eq (toString (.Values.bankTransfer.configmap.MULTI_TENANT_ENABLED | default "false")) "true" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,10 +8,13 @@ metadata:
   namespace: {{ include "global.namespace" . }}
 type: Opaque
 stringData:
-  # PostgreSQL Credentials
-  POSTGRES_PASSWORD: {{ required "bankTransfer.secrets.POSTGRES_PASSWORD is required" .Values.bankTransfer.secrets.POSTGRES_PASSWORD | quote }}
+  {{- if not $multiTenantEnabled }}
+  # PostgreSQL Credentials — single-tenant only.
+  # MT mode resolves per-tenant Postgres via tenant-manager; no static credential needed.
+  POSTGRES_PASSWORD: {{ required "bankTransfer.secrets.POSTGRES_PASSWORD is required when MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.secrets.POSTGRES_PASSWORD | quote }}
   {{- if .Values.bankTransfer.secrets.POSTGRES_REPLICA_PASSWORD }}
   POSTGRES_REPLICA_PASSWORD: {{ .Values.bankTransfer.secrets.POSTGRES_REPLICA_PASSWORD | quote }}
+  {{- end }}
   {{- end }}
 
   # Redis/Valkey Password
@@ -24,9 +28,11 @@ stringData:
   MULTI_TENANT_SERVICE_API_KEY: {{ .Values.bankTransfer.secrets.MULTI_TENANT_SERVICE_API_KEY | quote }}
   {{- end }}
 
-  # MongoDB Password and URI
   {{- $namespace := include "global.namespace" . }}
-  MONGO_PASSWORD: {{ required "bankTransfer.secrets.MONGO_PASSWORD is required" .Values.bankTransfer.secrets.MONGO_PASSWORD | quote }}
+  {{- if not $multiTenantEnabled }}
+  # MongoDB Password and URI — single-tenant only.
+  # MT mode resolves per-tenant Mongo via tenant-manager.
+  MONGO_PASSWORD: {{ required "bankTransfer.secrets.MONGO_PASSWORD is required when MULTI_TENANT_ENABLED is not true" .Values.bankTransfer.secrets.MONGO_PASSWORD | quote }}
   {{- if .Values.bankTransfer.secrets.MONGO_URI }}
   MONGO_URI: {{ .Values.bankTransfer.secrets.MONGO_URI | quote }}
   {{- else }}
@@ -34,6 +40,7 @@ stringData:
   {{- end }}
   {{- if .Values.bankTransfer.secrets.MONGO_TLS_CA_CERT }}
   MONGO_TLS_CA_CERT: {{ .Values.bankTransfer.secrets.MONGO_TLS_CA_CERT | quote }}
+  {{- end }}
   {{- end }}
 
   # Authentication (plugin-auth)

--- a/charts/plugin-br-bank-transfer/values-template.yaml
+++ b/charts/plugin-br-bank-transfer/values-template.yaml
@@ -19,26 +19,38 @@ bankTransfer:
     tls: []
 
   configmap:
-    # Application Settings
+    # Chart scope (as of 1.6.0): infrastructure connection + multi-tenant
+    # toggle + outbound URLs / auth toggles only. Operational tuning
+    # (timeouts, retries, circuit breakers, polling cadence, rate limit,
+    # idempotency, reconciliation, webhook config, usage limits,
+    # operating hours, CORS, routing UUIDs) is managed via the
+    # systemplane admin API at runtime or covered by lib-commons
+    # compiled defaults.
+
+    # =================================================================
+    # Application identity
+    # =================================================================
     ENV_NAME: ""  # REQUIRED - Environment name (e.g., production, staging)
-    LOG_LEVEL: "info"
     SERVER_ADDRESS: ":4027"
     HTTP_BODY_LIMIT_BYTES: "1048576"
-
-    # CORS Configuration
-    CORS_ALLOWED_ORIGINS: "*"
-    CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
-
-    # TLS Configuration
     TLS_TERMINATED_UPSTREAM: "true"
 
-    # Multi-Tenancy
+    # =================================================================
+    # Multi-tenancy
+    # =================================================================
     DEFAULT_TENANT_ID: ""  # REQUIRED - Default tenant UUID
     DEFAULT_TENANT_SLUG: ""  # REQUIRED - Default tenant slug
     MULTI_TENANT_ENABLED: "false"
+    # When MULTI_TENANT_ENABLED=true, also set:
+    # MULTI_TENANT_URL: ""
+    # AWS_REGION: ""
+    # MULTI_TENANT_REDIS_HOST: ""
+    # MULTI_TENANT_REDIS_TLS: "false"
+    # MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE: "tenants/{env}/{tenantId}/{applicationName}/integration/configuration"
 
-    # PostgreSQL Primary - REQUIRED
+    # =================================================================
+    # PostgreSQL primary - REQUIRED
+    # =================================================================
     POSTGRES_HOST: ""  # REQUIRED - PostgreSQL primary host
     POSTGRES_PORT: "5432"
     POSTGRES_USER: "bank_transfer"
@@ -50,16 +62,19 @@ bankTransfer:
     POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
     POSTGRES_CONNECT_TIMEOUT_SEC: "10"
     MIGRATIONS_PATH: "migrations"
-
-    # PostgreSQL Replica (optional - for CQRS read scaling)
-    # POSTGRES_REPLICA_HOST: ""
-    # POSTGRES_REPLICA_PORT: "5432"
-
-    # Infrastructure Boot Timeout
     INFRA_CONNECT_TIMEOUT_SEC: "30"
 
-    # Redis/Valkey - REQUIRED
-    REDIS_HOST: ""  # REQUIRED - Redis/Valkey host:port (e.g., bank-transfer-valkey:6379)
+    # PostgreSQL replica (optional - CQRS read scaling)
+    # POSTGRES_REPLICA_HOST: ""
+    # POSTGRES_REPLICA_PORT: "5432"
+    # POSTGRES_REPLICA_USER: ""
+    # POSTGRES_REPLICA_DB: ""
+    # POSTGRES_REPLICA_SSLMODE: "require"
+
+    # =================================================================
+    # Redis/Valkey (app-level) - REQUIRED
+    # =================================================================
+    REDIS_HOST: ""  # REQUIRED - Redis/Valkey host:port
     REDIS_DB: "0"
     REDIS_PROTOCOL: "3"
     REDIS_POOL_SIZE: "10"
@@ -69,108 +84,71 @@ bankTransfer:
     REDIS_DIAL_TIMEOUT_MS: "5000"
     REDIS_TLS: "false"
 
-    # MongoDB - REQUIRED for audit/event persistence
+    # =================================================================
+    # MongoDB (audit/event persistence) - REQUIRED
+    # MONGO_URI is in secrets.
+    # =================================================================
     MONGO_ENABLED: "true"
-    MONGO_URI: ""  # REQUIRED - MongoDB connection URI
-    MONGO_DATABASE: "plugin_br_bank_transfer_jd"
+    MONGO_DATABASE: "plugin_br_bank_transfer"
     MONGO_MAX_POOL_SIZE: "25"
     MONGO_SERVER_SELECTION_TIMEOUT_MS: "3000"
     MONGO_HEARTBEAT_INTERVAL_MS: "10000"
 
-    # Authentication - REQUIRED for production
-    AUTH_ENABLED: "true"
-    AUTH_SERVICE_ADDRESS: ""  # REQUIRED when AUTH_ENABLED=true
-    AUTH_CACHE_TTL_SEC: "300"
+    # =================================================================
+    # RabbitMQ (event bus, optional)
+    # =================================================================
+    RABBITMQ_ENABLED: "false"
+    # RABBITMQ_URL: ""  # Required if RABBITMQ_ENABLED=true
+    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
 
-    # License Validation (required for production)
+    # =================================================================
+    # Authentication (inbound)
+    # =================================================================
+    PLUGIN_AUTH_ENABLED: "true"
+    PLUGIN_AUTH_ADDRESS: ""  # REQUIRED when PLUGIN_AUTH_ENABLED=true
+
+    # =================================================================
+    # License gateway override (optional)
+    # =================================================================
     # LICENSE_SERVICE_ADDRESS: ""
-    # ORGANIZATION_IDS: ""
+    # TENANT_IDS: ""
 
+    # =================================================================
     # OpenTelemetry
+    # =================================================================
     ENABLE_TELEMETRY: "false"
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-bank-transfer"
     OTEL_RESOURCE_SERVICE_NAME: "plugin-br-bank-transfer"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""  # Set if ENABLE_TELEMETRY=true
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
 
-    # Rate Limiting
-    RATE_LIMIT_ENABLED: "true"
-    RATE_LIMIT_MAX: "100"
-    RATE_LIMIT_EXPIRY_SEC: "60"
+    # =================================================================
+    # Outbound adapters - URLs + auth toggles only
+    # Timeouts, retries, circuit breakers, cache TTLs are
+    # systemplane-managed at runtime.
+    # =================================================================
 
-    # Observability & Metrics
-    DB_METRICS_INTERVAL_SEC: "15"
-    RECONCILIATION_PENDING_ALERT_THRESHOLD: "20"
-
-    # Idempotency
-    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
-    IDEMPOTENCY_REQUIRE_REDIS: "true"
-
-    # Midaz Adapter - REQUIRED
+    # Midaz - REQUIRED
     MIDAZ_BASE_URL: ""  # REQUIRED - Midaz API endpoint
     MIDAZ_TRANSACTION_URL: ""  # REQUIRED - Midaz transaction endpoint
-    MIDAZ_TIMEOUT_MS: "3000"
-    MIDAZ_MAX_RETRIES: "3"
-    MIDAZ_OTEL_ENABLED: "true"
-    MIDAZ_DEBUG: "false"
     MIDAZ_AUTH_ENABLED: "false"
     # MIDAZ_AUTH_ADDRESS: ""  # Required if MIDAZ_AUTH_ENABLED=true
-    MIDAZ_BREAKER_FAILURES: "3"
-    MIDAZ_BREAKER_TIMEOUT_SECONDS: "30"
 
-    # CRM Adapter - REQUIRED
+    # CRM - REQUIRED
     CRM_BASE_URL: ""  # REQUIRED - CRM API endpoint
-    CRM_TIMEOUT_MS: "2000"
-    CRM_MAX_RETRIES: "2"
-    CRM_CACHE_TTL_MS: "300000"
+    CRM_AUTH_ENABLED: "false"
 
-    # Fees Adapter - REQUIRED
+    # Fees - REQUIRED
     FEES_BASE_URL: ""  # REQUIRED - Fees API endpoint
-    FEES_TIMEOUT_MS: "2000"
-    FEES_MAX_RETRIES: "2"
-    FEES_FAIL_CLOSED_DEFAULT: "false"
-    FEES_MAX_FEE_AMOUNT_CENTS: "99999999"
+    FEES_AUTH_ENABLED: "false"
 
-    # JD SPB Adapter - REQUIRED
-    JD_BASE_URL: ""  # REQUIRED - JD SOAP endpoint
+    # JD-SPB
+    JD_SANDBOX_MODE: "false"
+    JD_BASE_URL: ""  # REQUIRED when JD_SANDBOX_MODE=false
     JD_SOAP_PATH: "/soap"
-    JD_ORIGIN_ISPB: ""  # REQUIRED - Origin ISPB code
+    JD_ORIGIN_ISPB: ""  # REQUIRED when JD_SANDBOX_MODE=false
     # JD_LEGACY_CODE: ""
     JD_SIGNING_MODE: "local_pem"  # local_pem | external_provided | disabled
-    JD_SIGNATURE_REQUIRED: "true"
-    JD_VALIDATE_EXTERNAL_SIGNATURE: "true"
-    JD_TIMEOUT_MS: "8000"
-    JD_MAX_RETRIES: "3"
-
-    # JD Sandbox Mode (must be false in production)
-    JD_SANDBOX_MODE: "false"
-
-    # JD Polling (TED IN ingestion)
-    JD_POLLING_ENABLED: "false"
-    JD_POLL_INTERVAL_SECONDS: "30"
-    JD_POLL_MAX_MESSAGES_PER_CYCLE: "50"
-    JD_POLL_MAX_RETRIES: "3"
-    JD_POLL_RECOVERY_BATCH_SIZE: "200"
-
-    # RabbitMQ Event Bus (optional)
-    RABBITMQ_ENABLED: "false"
-    # RABBITMQ_URL: ""  # Required if RABBITMQ_ENABLED=true
-    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
-    RABBITMQ_ROUTING_KEY_PREFIX: "transfer"
-
-    # Webhook Delivery Worker (optional)
-    WEBHOOK_ENABLED: "false"
-    # WEBHOOK_ENDPOINT_URL: ""  # Required if WEBHOOK_ENABLED=true
-    WEBHOOK_QUEUE_NAME: "transfer.webhook.delivery"
-    WEBHOOK_DLQ_NAME: "transfer.webhook.dlq"
-
-    # Usage Limits
-    USAGE_LIMITS_ENABLED: "false"
-
-    # Operating Hours
-    TRANSFER_OPERATING_OPEN: "06:30"
-    TRANSFER_OPERATING_CLOSE: "17:00"
-    TRANSFER_OPERATING_TIMEZONE: "America/Sao_Paulo"
 
   secrets:
     # PostgreSQL - REQUIRED

--- a/charts/plugin-br-bank-transfer/values-template.yaml
+++ b/charts/plugin-br-bank-transfer/values-template.yaml
@@ -149,6 +149,7 @@ bankTransfer:
     JD_ORIGIN_ISPB: ""  # REQUIRED when JD_SANDBOX_MODE=false
     # JD_LEGACY_CODE: ""
     JD_SIGNING_MODE: "local_pem"  # local_pem | external_provided | disabled
+    JD_POLLING_ENABLED: "false"
 
   secrets:
     # PostgreSQL - REQUIRED

--- a/charts/plugin-br-bank-transfer/values-template.yaml
+++ b/charts/plugin-br-bank-transfer/values-template.yaml
@@ -17,7 +17,9 @@ bankTransfer:
           - path: /
             pathType: Prefix
     tls: []
-
+  migrations:
+    # -- Enable or disable the migrations job
+    enabled: true
   configmap:
     # Chart scope (as of 1.6.0): infrastructure connection + multi-tenant
     # toggle + outbound URLs / auth toggles only. Operational tuning

--- a/charts/plugin-br-bank-transfer/values-template.yaml
+++ b/charts/plugin-br-bank-transfer/values-template.yaml
@@ -153,6 +153,9 @@ bankTransfer:
     JD_SIGNING_MODE: "local_pem"  # local_pem | external_provided | disabled
     JD_POLLING_ENABLED: "false"
 
+    RATE_LIMIT_ENABLED: "false"
+    ALLOW_INSECURE_TLS: "true"
+
   secrets:
     # PostgreSQL - REQUIRED
     POSTGRES_PASSWORD: ""  # REQUIRED - PostgreSQL primary password

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -215,6 +215,20 @@ bankTransfer:
     TLS_TERMINATED_UPSTREAM: "true"
 
     # =================================================================
+    # CORS policy
+    # In production the plugin's validator rejects wildcard "*" and any
+    # localhost / 127.0.0.1 / [::1] origin. Leave empty in single-tenant
+    # dev defaults; production deployments MUST override CORS_ALLOWED_ORIGINS
+    # with the API's public ingress hostname (e.g.
+    # "https://bank-transfer.sa-east-1.lerian.io"). When unset, the app's
+    # in-code safety net defaults to http://localhost:3000 — fine for dev,
+    # fatal in production.
+    # =================================================================
+    CORS_ALLOWED_ORIGINS: ""
+    CORS_ALLOWED_METHODS: ""
+    CORS_ALLOWED_HEADERS: ""
+
+    # =================================================================
     # Multi-tenancy
     # Only the toggle, the DEFAULT_TENANT_* identifiers, and the
     # infrastructure endpoints live in the chart. Operational tuning

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -83,6 +83,26 @@ bankTransfer:
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
     tag: "2.4.0"
+  # -- PostgreSQL migrations job (pre-upgrade / post-install hook)
+  migrations:
+    # -- Enable or disable the migrations job
+    enabled: true
+    image:
+      # -- Repository for the migrations init container image
+      repository: ghcr.io/lerianstudio/plugin-br-bank-transfer-postgres-migrations
+      # -- Image pull policy
+      pullPolicy: IfNotPresent
+      # -- Image tag — defaults to Chart.AppVersion when empty
+      tag: "3.2.0-beta.13"
+    # -- Maximum number of retries before the Job is considered failed
+    backoffLimit: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 64Mi
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
   # -- Overrides the default generated name by Helm
@@ -187,6 +207,7 @@ bankTransfer:
     # Application identity
     # =================================================================
     ENV_NAME: "production"
+    APPLICATION_NAME: "plugin-br-bank-transfer"
     SERVER_ADDRESS: ":4027"
     HTTP_BODY_LIMIT_BYTES: "1048576"
 
@@ -207,7 +228,13 @@ bankTransfer:
     MULTI_TENANT_ENABLED: "false"
     # When MULTI_TENANT_ENABLED=true the chart also emits:
     #   MULTI_TENANT_URL, AWS_REGION, MULTI_TENANT_REDIS_HOST,
-    #   MULTI_TENANT_REDIS_TLS, MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE
+    #   MULTI_TENANT_REDIS_PORT, MULTI_TENANT_REDIS_TLS,
+    #   MULTI_TENANT_ENVIRONMENT, MULTI_TENANT_ALLOW_INSECURE_HTTP,
+    #   MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE
+    # Optional tuning (lib-commons defaults apply when unset):
+    #   MULTI_TENANT_MAX_TENANT_POOLS, MULTI_TENANT_IDLE_TIMEOUT_SEC,
+    #   MULTI_TENANT_TIMEOUT, MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD,
+    #   MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC, MULTI_TENANT_CACHE_TTL_SEC
     # Set those under .configmap as needed.
 
     # =================================================================
@@ -296,14 +323,17 @@ bankTransfer:
     MIDAZ_TRANSACTION_URL: "http://midaz.midaz.svc.cluster.local.:3001"
     MIDAZ_AUTH_ENABLED: "false"
     # MIDAZ_AUTH_ADDRESS: ""
+    # MIDAZ_TIMEOUT_MS: ""
 
     # CRM (REQUIRED)
     CRM_BASE_URL: "http://plugin-crm.midaz-plugins.svc.cluster.local:4003"
     CRM_AUTH_ENABLED: "false"
+    # CRM_TIMEOUT_MS: ""
 
     # Fees (REQUIRED)
     FEES_BASE_URL: "http://plugin-fees.midaz-plugins.svc.cluster.local:4004"
     FEES_AUTH_ENABLED: "false"
+    # FEES_TIMEOUT_MS: ""
 
     # JD-SPB
     # JD sandbox mode swaps the adapter; when false, JD_BASE_URL and
@@ -314,6 +344,23 @@ bankTransfer:
     JD_ORIGIN_ISPB: "" # MUST BE SET — Origin ISPB code
     # JD_LEGACY_CODE: ""
     JD_SIGNING_MODE: "local_pem" # local_pem | external_provided | disabled
+    JD_POLLING_ENABLED: "false"
+    # JD_PRIVATE_KEY_KEYINFO: ""  # key metadata for external signing providers
+
+    # =================================================================
+    # Single-tenant defaults
+    # =================================================================
+    ORGANIZATION_ID: ""
+    ORGANIZATION_IDS: ""
+    IS_DEVELOPMENT: "false"
+
+    # =================================================================
+    # Feature flags
+    # =================================================================
+    WEBHOOK_ENABLED: "false"
+    BTF_FEE_ENABLED: "false"
+    OTEL_SDK_DISABLED: "false"
+
   # -- Secrets for storing sensitive data
   # @default -- templates/secrets.yaml
   secrets:
@@ -533,6 +580,3 @@ rabbitmq:
       mountPath: /etc/rabbitmq/definitions
   customConfig: |
     management.load_definitions = /etc/rabbitmq/definitions/load_definition.json
-br-bank-transfer:
-  image:
-    tag: 1.0.0

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -92,8 +92,6 @@ bankTransfer:
       repository: ghcr.io/lerianstudio/plugin-br-bank-transfer-migrations
       # -- Image pull policy
       pullPolicy: IfNotPresent
-      # -- Image tag — defaults to Chart.AppVersion when empty
-      tag: "3.2.0-beta.13"
     # -- Maximum number of retries before the Job is considered failed
     backoffLimit: 3
     resources:

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -89,7 +89,7 @@ bankTransfer:
     enabled: true
     image:
       # -- Repository for the migrations init container image
-      repository: ghcr.io/lerianstudio/plugin-br-bank-transfer-postgres-migrations
+      repository: ghcr.io/lerianstudio/plugin-br-bank-transfer-migrations
       # -- Image pull policy
       pullPolicy: IfNotPresent
       # -- Image tag — defaults to Chart.AppVersion when empty

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -183,23 +183,37 @@ bankTransfer:
   # -- ConfigMap for environment variables and configurations
   # @default -- templates/configmap.yaml
   configmap:
-    # Application Settings
+    # =================================================================
+    # Application identity
+    # =================================================================
     ENV_NAME: "production"
-    LOG_LEVEL: "info"
     SERVER_ADDRESS: ":4027"
     HTTP_BODY_LIMIT_BYTES: "1048576"
-    # CORS Configuration
-    CORS_ALLOWED_ORIGINS: "*"
-    CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-    CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
-    # TLS Configuration
+
+    # =================================================================
+    # TLS / proxy
+    # =================================================================
     TLS_TERMINATED_UPSTREAM: "true"
-    # Multi-Tenancy
+
+    # =================================================================
+    # Multi-tenancy
+    # Only the toggle, the DEFAULT_TENANT_* identifiers, and the
+    # infrastructure endpoints live in the chart. Operational tuning
+    # (pool sizes, timeouts, circuit breaker) is hot-reloadable via
+    # systemplane or covered by lib-commons compiled defaults.
+    # =================================================================
     DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"
     DEFAULT_TENANT_SLUG: "default"
     MULTI_TENANT_ENABLED: "false"
-    # PostgreSQL Primary (host defaults to {{ .Release.Name }}-postgresql-primary.{{ .Release.Namespace }}.svc.cluster.local)
-    # POSTGRES_HOST: ""  # Leave empty to use dynamic default based on release name
+    # When MULTI_TENANT_ENABLED=true the chart also emits:
+    #   MULTI_TENANT_URL, AWS_REGION, MULTI_TENANT_REDIS_HOST,
+    #   MULTI_TENANT_REDIS_TLS, MULTI_TENANT_INTEGRATION_SECRET_NAME_TEMPLATE
+    # Set those under .configmap as needed.
+
+    # =================================================================
+    # PostgreSQL (primary)
+    # POSTGRES_HOST defaults to "<release>-postgresql-primary.<ns>.svc.cluster.local"
+    # =================================================================
     POSTGRES_PORT: "5432"
     POSTGRES_USER: "bank_transfer"
     POSTGRES_DB: "bank_transfer"
@@ -210,17 +224,18 @@ bankTransfer:
     POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
     POSTGRES_CONNECT_TIMEOUT_SEC: "10"
     MIGRATIONS_PATH: "migrations"
-    # PostgreSQL Replica (optional - for CQRS read scaling)
+    INFRA_CONNECT_TIMEOUT_SEC: "30"
+    # PostgreSQL replica (optional — CQRS read scaling)
     # POSTGRES_REPLICA_HOST: ""
     # POSTGRES_REPLICA_PORT: "5432"
     # POSTGRES_REPLICA_USER: ""
     # POSTGRES_REPLICA_DB: ""
     # POSTGRES_REPLICA_SSLMODE: "require"
 
-    # Infrastructure Boot Timeout
-    INFRA_CONNECT_TIMEOUT_SEC: "30"
-    # Redis/Valkey Configuration (host defaults to {{ .Release.Name }}-valkey-primary.{{ .Release.Namespace }}.svc.cluster.local:6379)
-    # REDIS_HOST: ""  # Leave empty to use dynamic default based on release name
+    # =================================================================
+    # Valkey / Redis (app-level)
+    # REDIS_HOST defaults to "<release>-valkey-primary.<ns>.svc.cluster.local:6379"
+    # =================================================================
     REDIS_DB: "0"
     REDIS_PROTOCOL: "3"
     REDIS_POOL_SIZE: "10"
@@ -229,113 +244,76 @@ bankTransfer:
     REDIS_WRITE_TIMEOUT_MS: "3000"
     REDIS_DIAL_TIMEOUT_MS: "5000"
     REDIS_TLS: "false"
-    # MongoDB Configuration (mandatory for audit/event persistence)
+
+    # =================================================================
+    # MongoDB (audit/event persistence)
+    # MONGO_URI is in templates/secrets.yaml.
+    # =================================================================
     MONGO_ENABLED: "true"
-    # MONGO_URI is constructed from secrets if not explicitly set
     MONGO_DATABASE: "plugin_br_bank_transfer"
     MONGO_MAX_POOL_SIZE: "25"
     MONGO_SERVER_SELECTION_TIMEOUT_MS: "3000"
     MONGO_HEARTBEAT_INTERVAL_MS: "10000"
-    # Authentication (plugin-auth)
+
+    # =================================================================
+    # RabbitMQ (event bus, optional)
+    # RABBITMQ_URL is rendered from chart defaults when empty.
+    # Retries / timeouts / routing-key prefix are systemplane-managed.
+    # =================================================================
+    RABBITMQ_ENABLED: "false"
+    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
+
+    # =================================================================
+    # Authentication (inbound — plugin-access-manager)
+    # =================================================================
     PLUGIN_AUTH_ENABLED: "true"
     PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
-    PLUGIN_AUTH_CLIENT_ID: "plugin-br-bank-transfer"
-    AUTH_CACHE_TTL_SEC: "300"
-    # License Validation
+
+    # =================================================================
+    # License gateway override (optional — defaults to lib-license-go's
+    # hard-coded endpoint when LICENSE_SERVICE_ADDRESS is unset)
+    # =================================================================
     # LICENSE_SERVICE_ADDRESS: ""
     # TENANT_IDS: ""
 
+    # =================================================================
     # OpenTelemetry
+    # =================================================================
     ENABLE_TELEMETRY: "false"
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-bank-transfer"
     OTEL_RESOURCE_SERVICE_NAME: "plugin-br-bank-transfer"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
-    # Systemplane Runtime Configuration (optional)
-    # SYSTEMPLANE_BACKEND: "postgres"
-    # SYSTEMPLANE_POSTGRES_SCHEMA: "system"
-    # Rate Limiting
-    RATE_LIMIT_ENABLED: "true"
-    RATE_LIMIT_MAX: "100"
-    RATE_LIMIT_EXPIRY_SEC: "60"
-    # Database Metrics & Observability
-    DB_METRICS_INTERVAL_SEC: "15"
-    RECONCILIATION_PENDING_ALERT_THRESHOLD: "20"
-    # Idempotency
-    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
-    IDEMPOTENCY_REQUIRE_REDIS: "true"
-    # Midaz Adapter (REQUIRED)
+
+    # =================================================================
+    # Outbound adapters — endpoints + auth toggles only.
+    # Timeouts, retries, circuit breakers, cache TTLs, and lookup
+    # path templates are systemplane-managed at runtime.
+    # =================================================================
+
+    # Midaz (REQUIRED)
     MIDAZ_BASE_URL: "http://midaz.midaz.svc.cluster.local.:3001"
     MIDAZ_TRANSACTION_URL: "http://midaz.midaz.svc.cluster.local.:3001"
-    MIDAZ_TIMEOUT_MS: "3000"
-    MIDAZ_MAX_RETRIES: "3"
-    MIDAZ_OTEL_ENABLED: "true"
-    MIDAZ_DEBUG: "false"
     MIDAZ_AUTH_ENABLED: "false"
     # MIDAZ_AUTH_ADDRESS: ""
-    MIDAZ_BREAKER_FAILURES: "3"
-    MIDAZ_BREAKER_TIMEOUT_SECONDS: "30"
-    # CRM Adapter (REQUIRED)
+
+    # CRM (REQUIRED)
     CRM_BASE_URL: "http://plugin-crm.midaz-plugins.svc.cluster.local:4003"
-    CRM_TIMEOUT_MS: "2000"
-    CRM_MAX_RETRIES: "2"
-    CRM_CACHE_TTL_MS: "300000"
     CRM_AUTH_ENABLED: "false"
-    # CRM_CLIENT_ID: ""
-    # Fees Adapter (REQUIRED)
+
+    # Fees (REQUIRED)
     FEES_BASE_URL: "http://plugin-fees.midaz-plugins.svc.cluster.local:4004"
-    FEES_TIMEOUT_MS: "2000"
-    FEES_MAX_RETRIES: "2"
-    FEES_FAIL_CLOSED_DEFAULT: "false"
-    FEES_MAX_FEE_AMOUNT_CENTS: "99999999"
     FEES_AUTH_ENABLED: "false"
-    # FEES_CLIENT_ID: ""
-    # JD SPB Adapter (REQUIRED)
-    JD_BASE_URL: "" # MUST BE SET - JD SOAP endpoint
-    JD_SOAP_PATH: "/soap"
-    JD_ORIGIN_ISPB: "" # MUST BE SET - Origin ISPB code
-    # JD_LEGACY_CODE: ""
-    JD_SIGNING_MODE: "local_pem"  # local_pem | external_provided | disabled
-    JD_SIGNATURE_REQUIRED: "true"
-    JD_VALIDATE_EXTERNAL_SIGNATURE: "true"
-    JD_TIMEOUT_MS: "8000"
-    JD_MAX_RETRIES: "3"
-    # JD Sandbox Mode (must be false in production)
+
+    # JD-SPB
+    # JD sandbox mode swaps the adapter; when false, JD_BASE_URL and
+    # JD_ORIGIN_ISPB are required by the chart.
     JD_SANDBOX_MODE: "false"
-    # JD Polling (TED IN ingestion)
-    JD_POLLING_ENABLED: "false"
-    JD_POLL_INTERVAL_SECONDS: "30"
-    JD_POLL_MAX_MESSAGES_PER_CYCLE: "50"
-    JD_POLL_MAX_RETRIES: "3"
-    JD_POLL_RECOVERY_BATCH_SIZE: "200"
-    # RabbitMQ Event Bus (optional)
-    RABBITMQ_ENABLED: "false"
-    # RABBITMQ_URL: "amqp://bank_transfer:password@plugin-br-bank-transfer-jd-rabbitmq:5672/"
-    RABBITMQ_EXCHANGE: "bank_transfer.lifecycle"
-    RABBITMQ_ROUTING_KEY_PREFIX: "transfer"
-    RABBITMQ_PUBLISH_TIMEOUT_MS: "5000"
-    RABBITMQ_MAX_RETRIES: "3"
-    RABBITMQ_RETRY_BACKOFF_MS: "200"
-    # Webhook Delivery Worker (optional)
-    WEBHOOK_ENABLED: "false"
-    # WEBHOOK_ENDPOINT_URL: "https://example.com/webhooks/transfers"
-    WEBHOOK_QUEUE_NAME: "transfer.webhook.delivery"
-    WEBHOOK_DLQ_NAME: "transfer.webhook.dlq"
-    WEBHOOK_CONSUMER_TAG: "plugin-br-bank-transfer-webhook"
-    WEBHOOK_PREFETCH_COUNT: "20"
-    WEBHOOK_TIMEOUT_MS: "5000"
-    WEBHOOK_MAX_RETRIES: "3"
-    WEBHOOK_RETRY_BACKOFF_MS: "500"
-    WEBHOOK_ALLOW_UNSIGNED_BROKER_EVENTS: "false"
-    WEBHOOK_UNSIGNED_BROKER_EVENTS_GRACE_SEC: "0"
-    # Usage Limits
-    USAGE_LIMITS_ENABLED: "false"
-    USAGE_LIMIT_DAILY_CENTS: "0"
-    USAGE_LIMIT_MONTHLY_CENTS: "0"
-    # Operating Hours
-    TRANSFER_OPERATING_OPEN: "06:30"
-    TRANSFER_OPERATING_CLOSE: "17:00"
-    TRANSFER_OPERATING_TIMEZONE: "America/Sao_Paulo"
+    JD_BASE_URL: "" # MUST BE SET — JD SOAP endpoint
+    JD_SOAP_PATH: "/soap"
+    JD_ORIGIN_ISPB: "" # MUST BE SET — Origin ISPB code
+    # JD_LEGACY_CODE: ""
+    JD_SIGNING_MODE: "local_pem" # local_pem | external_provided | disabled
   # -- Secrets for storing sensitive data
   # @default -- templates/secrets.yaml
   secrets:

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -371,6 +371,8 @@ bankTransfer:
     # =================================================================
     WEBHOOK_ENABLED: "false"
     BTF_FEE_ENABLED: "false"
+    RATE_LIMIT_ENABLED: "false"
+    ALLOW_INSECURE_TLS: "true"
     OTEL_SDK_DISABLED: "false"
 
   # -- Secrets for storing sensitive data

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -83,13 +83,26 @@ bankTransfer:
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
     tag: "2.4.0"
-  # -- PostgreSQL migrations job (pre-upgrade / post-install hook)
+  # -- PostgreSQL migrations job (Helm hook pre-install,pre-upgrade; ArgoCD PreSync).
+  # The Job references NO chart-managed ConfigMap/Secret (all env inline), so the
+  # PreSync hook works on first install. Requires an operator-provisioned Secret
+  # carrying POSTGRES_PASSWORD (useExistingSecret/existingSecretName below) and an
+  # explicit image tag or digest. Must stay disabled when MULTI_TENANT_ENABLED=true
+  # (tenant-manager owns tenant database migrations — template enforces this).
   migrations:
-    # -- Enable or disable the migrations job
-    enabled: true
+    # -- Enable or disable the migrations job. When enabling, you MUST set
+    # useExistingSecret=true, existingSecretName, and image.tag (or digest).
+    enabled: false
+    # -- Migration hooks run before chart-managed Secrets exist; the password
+    # must come from a pre-existing Secret with key POSTGRES_PASSWORD.
+    useExistingSecret: false
+    # -- Name of the pre-existing Secret containing POSTGRES_PASSWORD
+    existingSecretName: ""
     image:
       # -- Repository for the migrations init container image
       repository: ghcr.io/lerianstudio/plugin-br-bank-transfer-migrations
+      # -- Image tag (required when enabled; never silently reuses the app tag)
+      tag: ""
       # -- Image pull policy
       pullPolicy: IfNotPresent
     # -- Maximum number of retries before the Job is considered failed

--- a/charts/tracer/Chart.yaml
+++ b/charts/tracer/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.0.0-beta.6
+version: 2.0.0-beta.7
 
 appVersion: "1.0.0"
 

--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "tracer.labels" (dict "context" . "component" .Values.tracer.name "name" .Values.tracer.name) | nindent 4 }}
 data:
   # Application Configuration
+  ENV_NAME: {{ .Values.tracer.configmap.ENV_NAME | default "production" | quote }}
   SERVER_PORT: {{ .Values.tracer.configmap.SERVER_PORT | default "4020" | quote }}
   SERVER_ADDRESS: {{ .Values.tracer.configmap.SERVER_ADDRESS | default ":4020" | quote }}
 

--- a/charts/tracer/values-template.yaml
+++ b/charts/tracer/values-template.yaml
@@ -57,6 +57,7 @@ tracer:
     targetMemoryUtilizationPercentage: 80
 
   configmap:
+    ENV_NAME: "production"
     SERVER_ADDRESS: ":4020"
     LOG_LEVEL: "info"
     DB_HOST: ""

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -170,6 +170,11 @@ tracer:
   # @default -- templates/configmap.yaml
   configmap:
     # Application Settings
+    # ENV_NAME selects the deployment environment. lib-commons v4.6.3+
+    # TenantEventListener fails fast at boot if this (or ENVIRONMENT_NAME) is
+    # unset — must be "staging" or "production". GitOps overrides this to
+    # "staging" per non-prod environment.
+    ENV_NAME: "production"
     # SERVER_PORT/SERVER_ADDRESS default to 4020 to match the tracer source
     # convention (Dockerfile EXPOSE 4020 + .env.example + Dockerfile.dev). The
     # app reads SERVER_ADDRESS first; if empty, falls back to SERVER_PORT.


### PR DESCRIPTION
## Summary

- Add `values.\"bc-correios\".probes.{liveness,readiness,startup}Path` to override probe HTTP paths per environment
- Defaults preserved: `/health/live`, `/health/ready`, `/health/live` (backwards-compatible)

## Why

App v2.0.0-beta.1 removed `/health/live` and `/health/ready`, leaving only `/health`. Pods on Firmino dev started crashing because startup probe was hitting `/health/live` → 404. This makes the probe paths configurable so dev can point to `/health` while prod (when app fixes it) stays on the granular endpoints.

## Test plan

- [x] `helm lint` passes
- [ ] Gitops PR (#TBD) overrides paths to `/health` in Firmino dev
- [ ] Pod becomes Ready and rolling update completes