### PR TITLE
feat(plugins): parameterize bc-correios probes following plugin-fees pattern

### DIFF
--- a/charts/plugin-bc-correios/templates/deployment.yaml
+++ b/charts/plugin-bc-correios/templates/deployment.yaml
@@ -114,26 +114,31 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: {{ $component.livenessProbe.path | default "/health/live" }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ $component.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ $component.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ $component.livenessProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ $component.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $component.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
-              path: /health/ready
+              path: {{ $component.readinessProbe.path | default "/health/ready" }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ $component.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ $component.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ $component.readinessProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ $component.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $component.readinessProbe.failureThreshold | default 3 }}
           startupProbe:
             httpGet:
-              path: /health/live
+              path: {{ $component.startupProbe.path | default "/health/live" }}
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ $component.startupProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ $component.startupProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ $component.startupProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ $component.startupProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $component.startupProbe.failureThreshold | default 30 }}
           resources:
             {{- toYaml $component.resources | nindent 12 }}
       {{- with $component.nodeSelector }}

--- a/charts/plugin-bc-correios/values-template.yaml
+++ b/charts/plugin-bc-correios/values-template.yaml
@@ -28,6 +28,51 @@ bc-correios:
             pathType: Prefix
     tls: []
 
+  # -- Liveness probe configuration
+  livenessProbe:
+    # -- HTTP path to probe for liveness
+    path: "/health/live"
+    # -- Seconds to wait before the first liveness probe
+    initialDelaySeconds: 15
+    # -- Seconds between liveness probes
+    periodSeconds: 20
+    # -- Seconds before the probe times out
+    timeoutSeconds: 5
+    # -- Number of consecutive successes required to mark the container healthy
+    successThreshold: 1
+    # -- Number of consecutive failures required to mark the container unhealthy
+    failureThreshold: 3
+
+  # -- Readiness probe configuration
+  readinessProbe:
+    # -- HTTP path to probe for readiness
+    path: "/health/ready"
+    # -- Seconds to wait before the first readiness probe
+    initialDelaySeconds: 5
+    # -- Seconds between readiness probes
+    periodSeconds: 10
+    # -- Seconds before the probe times out
+    timeoutSeconds: 5
+    # -- Number of consecutive successes required to mark the container ready
+    successThreshold: 1
+    # -- Number of consecutive failures required to mark the container not ready
+    failureThreshold: 3
+
+  # -- Startup probe configuration
+  startupProbe:
+    # -- HTTP path to probe during startup
+    path: "/health/live"
+    # -- Seconds to wait before the first startup probe
+    initialDelaySeconds: 0
+    # -- Seconds between startup probes
+    periodSeconds: 10
+    # -- Seconds before the probe times out
+    timeoutSeconds: 1
+    # -- Number of consecutive successes required to mark startup complete
+    successThreshold: 1
+    # -- Number of consecutive failures required before the container is restarted
+    failureThreshold: 30
+
   configmap:
     # Application Settings
     APP_ENV: ""       # REQUIRED - e.g., production, staging

--- a/charts/plugin-bc-correios/values.yaml
+++ b/charts/plugin-bc-correios/values.yaml
@@ -172,6 +172,30 @@ bc-correios:
   #     hostnames:
   #       - "correios.com.br"
   hostAliases: []
+  # -- Liveness probe configuration
+  livenessProbe:
+    path: "/health/live"
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  # -- Readiness probe configuration
+  readinessProbe:
+    path: "/health/ready"
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  # -- Startup probe configuration
+  startupProbe:
+    path: "/health/live"
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 30
   # -- ConfigMap for environment variables and configurations
   # @default -- templates/configmap.yaml
   configmap:


### PR DESCRIPTION
## Summary

- Parameterize `livenessProbe`, `readinessProbe`, and `startupProbe` in `plugin-bc-correios` chart
- Follow the **exact pattern** used by `plugin-fees` (full probe spec configurable, not just path)
- All defaults preserve the previous hardcoded behavior — `helm template` output is identical when no override is applied

## Why

App `v2.0.0-beta.1` collapsed `/health/live` and `/health/ready` into a single `/health` endpoint. Pods on Firmino dev started crashing because startup probe was hitting `/health/live` → 404. This makes the probe spec configurable so dev can point to `/health` while prod (when app fixes it) stays on the granular endpoints.

## Test plan

- [x] `helm lint` — 0 failures
- [x] `helm template` — probe blocks render identical to previous hardcoded values
- [ ] Gitops PR overrides paths to `/health` in Firmino dev
- [ ] Pod becomes Ready and rolling update completes