### PR TITLE
feat(lerian-notification): expose all MULTI_TENANT_* vars via ConfigMap

### DIFF
--- a/charts/lerian-notification/values.yaml
+++ b/charts/lerian-notification/values.yaml
@@ -108,8 +108,11 @@ config:
 
   # ---- Multi-tenant (tenant-manager) ----
   MULTI_TENANT_ENABLED: "false"
+  MULTI_TENANT_URL: ""
+  MULTI_TENANT_REDIS_HOST: ""
   MULTI_TENANT_REDIS_PORT: "6379"
   MULTI_TENANT_REDIS_TLS: "false"
+  MULTI_TENANT_ALLOW_INSECURE_HTTP: "false"
   MULTI_TENANT_MAX_TENANT_POOLS: "100"
   MULTI_TENANT_IDLE_TIMEOUT_SEC: "300"
   MULTI_TENANT_TIMEOUT: "30"
@@ -273,10 +276,10 @@ secrets:
   RABBITMQ_DEFAULT_USER: ""
   RABBITMQ_DEFAULT_PASS: ""
   RABBITMQ_HEALTH_CHECK_URL: ""
-  # -- Multi-tenant
-  MULTI_TENANT_URL: ""
+  # -- Multi-tenant (MULTI_TENANT_URL and MULTI_TENANT_REDIS_HOST are
+  #    non-sensitive and live in `config`/ConfigMap; only the API key and
+  #    Redis password are sensitive)
   MULTI_TENANT_SERVICE_API_KEY: ""
-  MULTI_TENANT_REDIS_HOST: ""
   MULTI_TENANT_REDIS_PASSWORD: ""
   # -- Plugin Auth
   PLUGIN_AUTH_HOST: ""


### PR DESCRIPTION
## What

Ensures the full `MULTI_TENANT_*` env contract is rendered through the `lerian-notification` ConfigMap.

The chart's ConfigMap renders every key under `.Values.config`. Of the 13 requested vars, **10 were already present**. This PR addresses the 3 that were not in the ConfigMap:

| Var | Before | After |
|-----|--------|-------|
| `MULTI_TENANT_ALLOW_INSECURE_HTTP` | absent | added to `config` (default `"false"`) |
| `MULTI_TENANT_URL` | in `secrets` (non-sensitive placeholder) | moved to `config` |
| `MULTI_TENANT_REDIS_HOST` | in `secrets` (non-sensitive placeholder) | moved to `config` |

`MULTI_TENANT_SERVICE_API_KEY` and `MULTI_TENANT_REDIS_PASSWORD` remain in the Secret (intentionally not in the ConfigMap).

## Why move URL / REDIS_HOST

They carry no credentials, so they belong in the ConfigMap. Just as importantly, deployments use `envFrom: [configMapRef, secretRef]` — keeping empty placeholders in the Secret would shadow the ConfigMap values via the configMap→secret ordering. Moving them avoids that conflict.

## Values

Defaults are kept environment-neutral (`ALLOW_INSECURE_HTTP: "false"`, empty `URL`/`REDIS_HOST`). Concrete per-env values (e.g. the dev valkey host and tenant-manager URL) belong in env-specific overrides, not the shared chart defaults.

Requested-by: @Jefferson Rodrigues