### PR TITLE
fix(otel-collector-lerian): add pod_association, hostNetwork and fix processor order

### DIFF
--- a/charts/otel-collector-lerian/values.yaml
+++ b/charts/otel-collector-lerian/values.yaml
@@ -7,6 +7,24 @@
 opentelemetry-collector:
   mode: daemonset # Changed from deployment to daemonset for kubeletstats
 
+  # hostNetwork is required so the k8sattributes processor can resolve pod
+  # identity from the connection source IP (pod_association: from connection).
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  ports:
+    otlp:
+      enabled: true
+      containerPort: 4317
+      servicePort: 4317
+      hostPort: 0
+      protocol: TCP
+    otlp-http:
+      enabled: true
+      containerPort: 4318
+      servicePort: 4318
+      hostPort: 0
+      protocol: TCP
+
   # Contrib image is needed for k8scluster, k8sattributes, transform, and loki exporter.
   image:
     repository: otel/opentelemetry-collector-contrib
@@ -264,6 +282,9 @@ opentelemetry-collector:
       k8sattributes:
         auth_type: "serviceAccount"
         passthrough: false
+        pod_association:
+          - sources:
+            - from: connection
         extract:
           metadata:
             - k8s.pod.name
@@ -327,10 +348,10 @@ opentelemetry-collector:
           receivers: [otlp]
           processors:
               - memory_limiter
-              - batch
               - k8sattributes
               - resource/add_client_id
               - transform/remove_sensitive_attributes
+              - batch
           exporters: [spanmetrics, otlphttp/server]
 
         # Pipeline for span-derived metrics, sent to central backend.
@@ -348,11 +369,11 @@ opentelemetry-collector:
           receivers: [otlp, k8s_cluster, kubeletstats]
           processors:
             - memory_limiter
-            - batch
             - resource/add_client_id
             - k8sattributes
             - filter/include_midaz_namespaces
             - filter/drop_node_metrics
+            - batch
           exporters: [otlphttp/server]
         logs:
           receivers: [otlp, k8sobjects]


### PR DESCRIPTION
## Problema

`k8s.pod.name` está vindo vazio nas dimensions do `spanmetrics`, o que faz o Mimir mesclar séries de pods diferentes (cardinalidade/identidade incorreta de pod).

A causa é a combinação de **três** problemas no `charts/otel-collector-lerian/values.yaml`:

### 1. Falta `hostNetwork` + `pod_association: from connection`
Sem `hostNetwork: true` (e `dnsPolicy: ClusterFirstWithHostNet`) e sem `pod_association` configurando `from: connection`, o processor `k8sattributes` não consegue resolver a identidade do pod a partir do IP de origem da conexão.

### 2. Ordem dos processors na pipeline `traces`
`k8sattributes` estava **depois** de `batch`. Com isso o contexto de conexão é perdido antes do enriquecimento. Movido para **antes** de `batch`.

### 3. Ordem dos processors na pipeline `metrics/cluster`
Mesmo problema: `k8sattributes` movido para **antes** de `batch`.

## Mudanças

- Adicionado `hostNetwork: true`, `dnsPolicy: ClusterFirstWithHostNet` e bloco `ports` (otlp 4317 / otlp-http 4318, `hostPort: 0`) no topo do bloco `opentelemetry-collector`.
- Adicionado `pod_association` (`from: connection`) ao processor `k8sattributes`.
- Reordenado processors na pipeline `traces` (`k8sattributes` antes de `batch`).
- Reordenado processors na pipeline `metrics/cluster` (`k8sattributes` antes de `batch`).

Resultado esperado: `k8s.pod.name` corretamente preenchido nas dimensions do `spanmetrics`, eliminando a mesclagem de séries no Mimir.

> Nota: o branch `develop` foi descontinuado no repo (migração para `main`, PR #1478). Por isso este PR tem como base `main`. `values.yaml` era idêntico em ambas as refs.

Requested-by: @gauchito