### PR TITLE
fix(go-boilerplate-ddd): OTEL endpoint scheme + ALLOW_INSECURE_TLS support (chart 2.0.2)

### DIFF
--- a/charts/go-boilerplate-ddd/Chart.yaml
+++ b/charts/go-boilerplate-ddd/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 2.0.1
+version: 2.0.2
 appVersion: "1.0.0"
 keywords:
   - boilerplate

--- a/charts/go-boilerplate-ddd/templates/configmap.yaml
+++ b/charts/go-boilerplate-ddd/templates/configmap.yaml
@@ -30,6 +30,9 @@ data:
   POSTGRES_USER: {{ .Values.boilerplate.configmap.POSTGRES_USER | default "go-boilerplate-ddd" | quote }}
   POSTGRES_NAME: {{ .Values.boilerplate.configmap.POSTGRES_NAME | default "go-boilerplate-ddd" | quote }}
   POSTGRES_SSLMODE: {{ .Values.boilerplate.configmap.POSTGRES_SSLMODE | default "disable" | quote }}
+  {{- if .Values.boilerplate.configmap.ALLOW_INSECURE_TLS }}
+  ALLOW_INSECURE_TLS: {{ .Values.boilerplate.configmap.ALLOW_INSECURE_TLS | quote }}
+  {{- end }}
   MIGRATIONS_PATH: {{ .Values.boilerplate.configmap.MIGRATIONS_PATH | default "migrations" | quote }}
 
   # PostgreSQL Connection Pool

--- a/charts/go-boilerplate-ddd/templates/deployment.yaml
+++ b/charts/go-boilerplate-ddd/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               fieldRef:
                 fieldPath: status.hostIP
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
-            value: "$(HOST_IP):4317"
+            value: "http://$(HOST_IP):4317"
           {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
## Problema

O app `go-boilerplate-ddd` versão **1.2.2** introduziu validação mais estrita que quebrou dois comportamentos que funcionavam no 1.1.1:

### 1 — OTEL endpoint sem scheme `http://`

O template do Deployment injeta `$(HOST_IP):4317` (sem `http://`). A v1.2.2 passou a exigir URL válida com scheme:

```
parse "21.26.7.82:4317": first path segment in URL cannot contain colon
invalid OTEL_EXPORTER_OTLP_ENDPOINT value 21.26.7.82:4317
```

**Fix:** `deployment.yaml` — adicionar `http://` no valor injetado.

### 2 — Postgres insecure TLS não declarado

A v1.2.2 rejeita conexões com `POSTGRES_SSLMODE=disable` a menos que `ALLOW_INSECURE_TLS=true` seja explicitamente declarado:

```
init infrastructure: postgres: TLS required (set ALLOW_INSECURE_TLS=true to bypass)
```

**Fix:** `configmap.yaml` — adicionar suporte à key `ALLOW_INSECURE_TLS` via `{{- if }}` condicional. Ambientes de produção (sslmode=require) não são afetados.

## Mudanças

| arquivo | alteração |
|---|---|
| `templates/deployment.yaml` | `$(HOST_IP):4317` → `http://$(HOST_IP):4317` |
| `templates/configmap.yaml` | bloco condicional `ALLOW_INSECURE_TLS` após `POSTGRES_SSLMODE` |
| `Chart.yaml` | versão `2.0.1` → `2.0.2` |

## Uso (gitops values.yaml — ambientes DEV)

```yaml
configmap:
  POSTGRES_SSLMODE: "disable"
  ALLOW_INSECURE_TLS: "true"   # novo: necessário com sslmode=disable no v1.2.2+
```