### PR TITLE
chore(charts): deprecate go-boilerplate-ddd, migrated to helm-internal

### DIFF
--- a/charts/go-boilerplate-ddd/Chart.yaml
+++ b/charts/go-boilerplate-ddd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: go-boilerplate-ddd-helm
-description: A Helm chart for Go Boilerplate DDD - Lerian reference service template
+description: '[DEPRECATED] Moved to helm-internal. Use oci://ghcr.io/lerianstudio/helm-internal/go-boilerplate-ddd-helm instead.'
 type: application
 home: https://github.com/LerianStudio/go-boilerplate-ddd
 sources:
@@ -9,7 +9,8 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 2.0.1
+version: 2.0.3
+deprecated: true
 appVersion: "1.0.0"
 keywords:
   - boilerplate

--- a/charts/go-boilerplate-ddd/DEPRECATED.md
+++ b/charts/go-boilerplate-ddd/DEPRECATED.md
@@ -1,0 +1,33 @@
+# ⚠️ DEPRECATED — go-boilerplate-ddd-helm
+
+This chart has been **moved to [helm-internal](https://github.com/LerianStudio/helm-internal)**.
+
+## New location
+
+```
+oci://ghcr.io/lerianstudio/helm-internal/go-boilerplate-ddd-helm
+```
+
+## Migration
+
+Update your `helmfile.yaml`:
+
+```yaml
+chart: oci://ghcr.io/lerianstudio/helm-internal/go-boilerplate-ddd-helm
+version: "1.0.0"
+```
+
+## Breaking changes (v1.2.2+)
+
+If upgrading the application to v1.2.2+, the following values are required:
+
+```yaml
+configmap:
+  # OTEL endpoint is now injected with http:// prefix by the chart template
+  # No changes needed for OTEL.
+  
+  # Required when POSTGRES_SSLMODE=disable or Redis is plain (no TLS):
+  ALLOW_INSECURE_TLS: "true"
+```
+
+See the [helm-internal chart](https://github.com/LerianStudio/helm-internal/tree/main/charts/go-boilerplate-ddd) for the latest version.


### PR DESCRIPTION
## O que

Marca o chart `go-boilerplate-ddd` como **DEPRECATED** no repositório helm público.

O chart foi migrado para [`LerianStudio/helm-internal`](https://github.com/LerianStudio/helm-internal/tree/main/charts/go-boilerplate-ddd) por ser um template interno da Lerian.

## Mudanças

- `Chart.yaml`: adiciona `deprecated: true` + descrição com aviso + bump para `2.0.3`
- `DEPRECATED.md`: guia de migração com novo OCI path e breaking changes do v1.2.2+

## Novo path

```
oci://ghcr.io/lerianstudio/helm-internal/go-boilerplate-ddd-helm:1.0.0
```

## Próximos passos após merge

- Remover o diretório `charts/go-boilerplate-ddd/` num PR subsequente após período de rollback (1-2 semanas)
- Deletar pacote OCI `ghcr.io/lerianstudio/go-boilerplate-ddd-helm` via GitHub UI (requer write:packages)