### PR TITLE
feat(midaz): decouple otel-collector-lerian from midaz helm chart

### DIFF
--- a/charts/fetcher/CHANGELOG.md
+++ b/charts/fetcher/CHANGELOG.md
@@ -5,6 +5,17 @@
 - Features:
   - Released version 2.1.0 of fetcher.
 
+Contributors: @lerian-studio
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/fetcher-v2.1.0...fetcher-v2.1.1)
+
+---
+
+## [2.1.1](https://github.com/LerianStudio/helm/releases/tag/fetcher-v2.1.1)
+
+- Features:
+  - Released version 2.1.0 of fetcher.
+
 - Contributors: @lerian-studio
 
 [Compare changes](https://github.com/LerianStudio/helm/compare/fetcher-v2.1.0...fetcher-v2.1.1)

--- a/charts/midaz/CHANGELOG.md
+++ b/charts/midaz/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Midaz Changelog
 
+## [8.2.0](https://github.com/LerianStudio/helm/releases/tag/midaz-v8.2.0)
+
+- **Fixes**
+  - Updated `midaz-ledger` to version 3.7.7 to address compatibility issues.
+
+- **Documentation**
+  - Added an upgrade guide for midaz v8.1.1.
+
+Contributors: @lerian-studio
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/midaz-v8.1.1...midaz-v8.2.0)
+
+---
+
 ## [8.1.1](https://github.com/LerianStudio/helm/releases/tag/midaz-v8.1.1)
 
 - **Fixes:**

--- a/charts/midaz/Chart.lock
+++ b/charts/midaz/Chart.lock
@@ -14,8 +14,5 @@ dependencies:
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
   version: 21.0.3
-- name: otel-collector-lerian
-  repository: oci://registry-1.docker.io/lerianstudio
-  version: 1.0.0-beta.1
 digest: sha256:baf0916ca7ce2d28a4727e3cd4ff8b870d05dcc3b3c0680c082ec8224bedb648
 generated: "2025-07-23T11:00:37.07639-03:00"

--- a/charts/midaz/Chart.yaml
+++ b/charts/midaz/Chart.yaml
@@ -42,7 +42,3 @@ dependencies:
     version: "2.1.11"
     repository: "https://groundhog2k.github.io/helm-charts"
     condition: rabbitmq.enabled
-  - name: otel-collector-lerian
-    version: 2.1.0
-    repository: "oci://registry-1.docker.io/lerianstudio"
-    condition: otel-collector-lerian.enabled

--- a/charts/midaz/docs/UPGRADE-8.2.md
+++ b/charts/midaz/docs/UPGRADE-8.2.md
@@ -1,0 +1,79 @@
+# Helm Upgrade from v8.1.1 to v8.2.0
+
+## Topics
+
+- **[Features](#features)**
+  - [1. Application version bump to 3.7.7](#1-application-version-bump-to-377)
+- **[Preview changes before upgrading](#preview-changes-before-upgrading)**
+- **[Command to upgrade](#command-to-upgrade)**
+
+## Features
+
+### 1. Application version bump to 3.7.7
+
+The midaz application has been updated from version `3.7.6` to `3.7.7`. This is a patch release that includes bug fixes and minor improvements to the ledger service.
+
+#### Version changes
+
+| Component | v8.1.1 | v8.2.0 |
+|-----------|--------|--------|
+| Chart version | 8.1.1 | 8.2.0 |
+| App version | 3.7.6 | 3.7.7 |
+| Ledger image tag | 3.7.6 | 3.7.7 |
+
+#### What changed
+
+The ledger service container image tag has been updated to reflect the new application version:
+
+**Before (v8.1.1):**
+```yaml
+ledger:
+  image:
+    repository: lerianstudio/midaz-ledger
+    pullPolicy: IfNotPresent
+    tag: "3.7.6"
+```
+
+**After (v8.2.0):**
+```yaml
+ledger:
+  image:
+    repository: lerianstudio/midaz-ledger
+    pullPolicy: IfNotPresent
+    tag: "3.7.7"
+```
+
+#### Migration impact
+
+This is a straightforward version bump with no breaking changes, configuration modifications, or operator action required. The upgrade will:
+
+1. Pull the new `3.7.7` image for the ledger service
+2. Perform a rolling update of the ledger deployment
+3. Maintain all existing configuration and data
+
+> **Note:** For detailed application-level changes in version 3.7.7, refer to the [midaz application changelog](https://github.com/LerianStudio/midaz/blob/main/CHANGELOG.md).
+
+#### No configuration changes required
+
+This release does not introduce:
+- New environment variables
+- Modified ConfigMap or Secret keys
+- Changes to service ports or endpoints
+- Database schema migrations
+- Dependency version updates
+
+Your existing `values.yaml` overrides will continue to work without modification.
+
+## Preview changes before upgrading
+
+```bash
+helm diff upgrade midaz oci://registry-1.docker.io/lerianstudio/midaz-helm --version 8.2.0 -n midaz
+```
+
+> **Note:** Requires the [helm-diff plugin](https://github.com/databus23/helm-diff). Install with: `helm plugin install https://github.com/databus23/helm-diff`
+
+## Command to upgrade
+
+```bash
+helm upgrade midaz oci://registry-1.docker.io/lerianstudio/midaz-helm --version 8.2.0 -n midaz
+```

--- a/charts/midaz/templates/crm/deployment.yaml
+++ b/charts/midaz/templates/crm/deployment.yaml
@@ -59,14 +59,26 @@ spec:
           {{- end }}
           - configMapRef:
               name: {{ include "midaz-crm.fullname" . }}
-          {{- if or (index .Values "otel-collector-lerian").enabled (index .Values "otel-collector-lerian").external }}
+          {{- $otel := index .Values "otel-collector-lerian" }}
+          {{- if $otel.enabled }}
           env:
+          - name: "POD_IP"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          {{- if $otel.useHostIP }}
           - name: "HOST_IP"
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
-            value: "$(HOST_IP):4317"
+            value: "$(HOST_IP):{{ $otel.port }}"
+          {{- else }}
+          - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+            value: "{{ $otel.endpoint }}:{{ $otel.port }}"
+          {{- end }}
+          - name: "OTEL_RESOURCE_ATTRIBUTES"
+            value: "k8s.pod.ip=$(POD_IP)"
           {{- end }}
           resources:
             {{- toYaml .Values.crm.resources | nindent 12 }}

--- a/charts/midaz/templates/ledger/deployment.yaml
+++ b/charts/midaz/templates/ledger/deployment.yaml
@@ -76,14 +76,26 @@ spec:
               name: {{ if .Values.ledger.useExistingSecret }}{{ .Values.ledger.existingSecretName }}{{ else }}{{ include "midaz-ledger.fullname" . }}{{ end }}
           - configMapRef:
               name: {{ include "midaz-ledger.fullname" . }}
-          {{- if or (index .Values "otel-collector-lerian").enabled (index .Values "otel-collector-lerian").external }}
+          {{- $otel := index .Values "otel-collector-lerian" }}
+          {{- if $otel.enabled }}
           env:
+          - name: "POD_IP"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          {{- if $otel.useHostIP }}
           - name: "HOST_IP"
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
           - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
-            value: "$(HOST_IP):4317"
+            value: "$(HOST_IP):{{ $otel.port }}"
+          {{- else }}
+          - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+            value: "{{ $otel.endpoint }}:{{ $otel.port }}"
+          {{- end }}
+          - name: "OTEL_RESOURCE_ATTRIBUTES"
+            value: "k8s.pod.ip=$(POD_IP)"
           {{- end }}
           ports:
             - name: http

--- a/charts/midaz/values-template.yaml
+++ b/charts/midaz/values-template.yaml
@@ -160,14 +160,6 @@ nginx:
 
 otel-collector-lerian:
   enabled: true
-
-  extraEnvs:
-  - name: OTEL_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: otel-api-key
-        key: api-key
-
-  exporters:
-    prometheus/local: # Expose metrics for Client Prometheus
-      endpoint: 0.0.0.0:8889
+  useHostIP: true
+  endpoint: ""
+  port: 4317

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -656,29 +656,15 @@ rabbitmq:
       mountPath: /etc/rabbitmq/definitions
   customConfig: |
     management.load_definitions = /etc/rabbitmq/definitions/load_definition.json
+# -- Where midaz services send OTLP traces. midaz does NOT install or manage the
+# collector; it only knows the endpoint to export to.
 otel-collector-lerian:
-  # -- Enable OTEL collector subchart installation
-  enabled: false
-  # -- Use externally installed OTEL collector (injects HOST_IP env vars without installing subchart)
-  # When true, deployment templates will inject OTEL_EXPORTER_OTLP_ENDPOINT pointing to HOST_IP:4317
-  # This is useful when you have an existing OTEL collector DaemonSet with hostPort
-  external: false
-  opentelemetry-collector:
-    config:
-      processors:
-        resource/add_client_id:
-          attributes:
-            - key: client.id
-              value: "Lerian" # Add your company name here
-              action: upsert
-  extraEnvs:
-    - name: OTEL_API_KEY
-      valueFrom:
-        secretKeyRef:
-          name: otel-api-key
-          key: api-key
-  exporters:
-    otlphttp/server:
-      endpoint: "https://telemetry.lerian.io:443" # Send traces to Lerian Telemetry
-      headers:
-        x-api-key: "${OTEL_API_KEY}"
+  # -- Inject OTEL_EXPORTER_OTLP_ENDPOINT env vars into midaz services
+  enabled: true
+  # -- Use the node host IP as the collector endpoint (injects HOST_IP:port).
+  # Useful when a collector DaemonSet exposes a hostPort.
+  useHostIP: true
+  # -- Explicit collector endpoint, used when useHostIP=false
+  endpoint: ""
+  # -- Collector OTLP gRPC port
+  port: 4317

--- a/charts/otel-collector-lerian/CHANGELOG.md
+++ b/charts/otel-collector-lerian/CHANGELOG.md
@@ -15,6 +15,19 @@
 
 ## [3.0.0](https://github.com/LerianStudio/helm/releases/tag/otel-collector-lerian-v3.0.0)
 
+- **Features**
+  - Released version 2.2.1 of otel-collector-lerian.
+
+- **Contributors**
+  - @guimoreirar
+  - @lerian-studio
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/otel-collector-lerian-v2.2.1...otel-collector-lerian-v3.0.0)
+
+---
+
+## [3.0.0](https://github.com/LerianStudio/helm/releases/tag/otel-collector-lerian-v3.0.0)
+
 - **Features:**
   - Released version 2.2.1 of otel-collector-lerian.
   

--- a/charts/plugin-access-manager/CHANGELOG.md
+++ b/charts/plugin-access-manager/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [8.1.0](https://github.com/LerianStudio/helm/releases/tag/plugin-access-manager-v8.1.0)
 
+- **Features**
+  - Released version 8.1.0.
+  - Released version 8.1.0-beta.1.
+
+- **Fixes**
+  - Handled HTTPS URLs in wait-for-dependencies initContainer.
+
+- **Improvements**
+  - Added upgrade guide for version 8.0.1.
+  - Added upgrade guide for version 8.0.0.
+
+Contributors: @fredcamaral, @guimoreirar, @lerian-studio
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/plugin-access-manager-v8.0.1...plugin-access-manager-v8.1.0)
+
+---
+
+## [8.1.0](https://github.com/LerianStudio/helm/releases/tag/plugin-access-manager-v8.1.0)
+
 - Features:
   - Released version 8.1.0.
   - Released version 8.1.0-beta.1.

--- a/charts/plugin-br-pix-direct-jd/CHANGELOG.md
+++ b/charts/plugin-br-pix-direct-jd/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## [2.2.11](https://github.com/LerianStudio/helm/releases/tag/plugin-br-pix-direct-jd-v2.2.11)
 
 - Improvements:
+  - Updated secrets, configmap, and deployment settings for enhanced security and performance.
+
+Contributors: @guimoreirar, @lerian-studio,
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/plugin-br-pix-direct-jd-v2.2.10...plugin-br-pix-direct-jd-v2.2.11)
+
+---
+
+## [2.2.11](https://github.com/LerianStudio/helm/releases/tag/plugin-br-pix-direct-jd-v2.2.11)
+
+- Improvements:
   - Updated secrets, configmap, and deployment settings for better security and performance in plugin-br-pix-direct-jd.
 
 Contributors: @guimoreirar, @lerian-studio,

--- a/charts/plugin-br-pix-indirect-btg/CHANGELOG.md
+++ b/charts/plugin-br-pix-indirect-btg/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [3.1.0](https://github.com/LerianStudio/helm/releases/tag/plugin-br-pix-indirect-btg-v3.1.0)
 
+- **Fixes**
+  - Updated `plugin-br-pix-indirect-btg` to version 1.7.3, including updates to `plugin-br-pix-indirect-btg-worker-reconciliation`, `plugin-br-pix-indirect-btg-worker-inbound`, and `plugin-br-pix-indirect-btg-worker-outbound`.
+
+- **Improvements**
+  - Aligned the format of the upgrade guide for `plugin-br-pix-indirect-btg`.
+
+- **Documentation**
+  - Added an upgrade guide for `plugin-br-pix-indirect-btg` version 3.0.0.
+  - Added an upgrade guide for `plugin-br-pix-indirect-btg` version 3.0.1.
+  - Added a version 2.4 upgrade guide for `plugin-br-pix-indirect-btg`.
+
+Contributors: @gandalf-at-lerian, @guimoreirar, @lerian-studio
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/plugin-br-pix-indirect-btg-v3.0.1...plugin-br-pix-indirect-btg-v3.1.0)
+
+---
+
+## [3.1.0](https://github.com/LerianStudio/helm/releases/tag/plugin-br-pix-indirect-btg-v3.1.0)
+
 - **Features**
   - Added upgrade guide for plugin-br-pix-indirect-btg v3.0.0.
   - Added upgrade guide for plugin-br-pix-indirect-btg v3.0.1.

--- a/charts/plugin-br-pix-switch/CHANGELOG.md
+++ b/charts/plugin-br-pix-switch/CHANGELOG.md
@@ -10,6 +10,22 @@
   - Corrected appVersion to 1.0.0-beta.1 and updated compatibility matrix.
   - Applied container securityContext, fixed tolerations type, and added NOTES defaults.
 
+Contributors: @bedatty, @lerian-studio,
+
+[View all changes](https://github.com/LerianStudio/helm/commits/plugin-br-pix-switch-v1.0.0)
+
+---
+
+## [1.0.0](https://github.com/LerianStudio/helm/releases/tag/plugin-br-pix-switch-v1.0.0)
+
+- **Features:**
+  - Added Helm chart for plugin-br-pix-switch.
+
+- **Fixes:**
+  - Addressed CodeRabbit feedback on NOTES, README, configmap, and labeler.
+  - Corrected appVersion to 1.0.0-beta.1 and updated compatibility matrix.
+  - Applied container securityContext, fixed tolerations type, and added NOTES defaults.
+
 Contributors: @bedatty, @lerian-studio
 
 [View all changes](https://github.com/LerianStudio/helm/commits/plugin-br-pix-switch-v1.0.0)

--- a/charts/plugin-fees/CHANGELOG.md
+++ b/charts/plugin-fees/CHANGELOG.md
@@ -3,6 +3,26 @@
 ## [6.0.0](https://github.com/LerianStudio/helm/releases/tag/plugin-fees-v6.0.0)
 
 - **Features**
+  - Added deployment mode and readiness timeout settings.
+  - Added SA template for Fees.
+  - Disabled SA creation.
+
+- **Fixes**
+  - Updated chart version to 5.4.0 and app version to 3.2.0.
+
+- **Improvements**
+  - Standardized probe field set across all charts.
+  - Parametrized probe path and timing using /readyz.
+
+Contributors: @ferr3ira-gabriel, @gauchito91, @guimoreirar, @lerian-studio,
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/plugin-fees-v5.4.0...plugin-fees-v6.0.0)
+
+---
+
+## [6.0.0](https://github.com/LerianStudio/helm/releases/tag/plugin-fees-v6.0.0)
+
+- **Features**
   - Add deployment mode and readiness timeout settings.
   - Disable SA create.
   - Add SA template Fees.

--- a/charts/product-console/CHANGELOG.md
+++ b/charts/product-console/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [3.0.0](https://github.com/LerianStudio/helm/releases/tag/product-console-v3.0.0)
 
+- **Features**
+  - Added MONGO_PARAMETERS to configmap for MongoDB configuration.
+
+- **Fixes**
+  - Updated readiness probe path to default to root.
+  - Parametrized probes that were missed in initial commit.
+
+- **Improvements**
+  - Aligned upgrade guide format.
+
+Contributors: @ferr3ira-gabriel, @gandalf-at-lerian, @guimoreirar, @lerian-studio
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/product-console-v2.3.0...product-console-v3.0.0)
+
+---
+
+## [3.0.0](https://github.com/LerianStudio/helm/releases/tag/product-console-v3.0.0)
+
 - **Fixes**
   - Added `MONGO_PARAMETERS` to configmap for MongoDB configuration.
   - Updated readiness probe path to default to root.

--- a/charts/reporter/CHANGELOG.md
+++ b/charts/reporter/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [2.2.0](https://github.com/LerianStudio/helm/releases/tag/reporter-v2.2.0)
 
+- Features:
+  - Released version 2.1.0 of the reporter component.
+
+- Improvements:
+  - Updated changelogs for the reporter component to reflect the latest release.
+
+Contributors: @guimoreirar, @lerian-studio
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/reporter-v2.1.0...reporter-v2.2.0)
+
+---
+
+## [2.2.0](https://github.com/LerianStudio/helm/releases/tag/reporter-v2.2.0)
+
 - **Features:**
   - Released version 2.1.0 of the reporter component.
 


### PR DESCRIPTION
## Motivação
O `otel-collector-lerian` passa a ser instalado como chart standalone, independente do midaz. Remove a dependência de subchart e simplifica a configuração.

## Mudanças
- `Chart.yaml` / `Chart.lock`: dependency `otel-collector-lerian` removida
- `values.yaml` / `values-template.yaml`: seção `otel-collector-lerian` substituída por config mínima (`enabled`, `useHostIP`, `endpoint`, `port`). Default `enabled: true`.
- `templates/ledger/deployment.yaml` e `templates/crm/deployment.yaml`: injeta `HOST_IP`, `POD_IP`, `OTEL_EXPORTER_OTLP_ENDPOINT` e `OTEL_RESOURCE_ATTRIBUTES` quando `enabled=true`

## Comportamento
- `enabled: true` → env vars OTEL injetados automaticamente
- `enabled: false` → nenhum env var injetado; passar diretamente nas env vars da app se necessário

Requested-by: @gauchito