### PR TITLE
chore(charts): rename README version-matrix section to notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ For implementation and configuration details, see the [README](https://charts.le
 | `2.2.0-beta.1` | 1.0.0 |
 -----------------
 
-### Lerian Notification
+### Notifications
 
-For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/lerian-notification).
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/notifications).
 
 #### Application Version Mapping
 


### PR DESCRIPTION
Follow-up to #1505. The chart rename moved `charts/lerian-notification` → `charts/notifications`, but the central README version matrix still had `### Lerian Notification`. The release pipeline's `update-chart-version-readme` matches the chart name to a section heading (must contain `notifications`) and failed on the previous release run, so the chart was never published.

Renames the section heading `### Lerian Notification` → `### Notifications` and the link to `charts/notifications`. Unblocks publishing `notifications-helm` (semantic-release will compute the version for the new chart name).