### PR TITLE
chore(charts): align notifications chart version to beta.1

### DIFF
--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0-beta.5
+version: 1.0.0-beta.1
 # This is the version number of the application being deployed.
 appVersion: "0.1.0"
 keywords:


### PR DESCRIPTION
Publishes `notifications-helm:1.0.0-beta.1` (follow-up to #1505/#1509). semantic-release versions from `notifications-v*` tags (none) → first release is beta.1; aligns Chart.yaml accordingly and triggers the release pipeline now that the README matrix section exists.