### PR TITLE
chore(charts): clean up leftover old-name header in notifications _helpers

### DIFF
--- a/charts/notifications/templates/_helpers.tpl
+++ b/charts/notifications/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{/*
 ================================================================================
-LERIAN NOTIFICATION - HELM TEMPLATE HELPERS
+NOTIFICATIONS - HELM TEMPLATE HELPERS
 ================================================================================
 Topology:
   - api             (HTTP service + ingress)


### PR DESCRIPTION
Aligns the `_helpers.tpl` header to the new name and re-triggers the release pipeline to publish `notifications-helm` (the previous run created the beta.1 tag but failed mid-publish on a transient docker.io error, leaving no artifact). semantic-release will cut the next version (beta.2).