### PR TITLE
chore(charts): re-trigger notifications-helm release (beta.3)

### DIFF
--- a/charts/notifications/Chart.yaml
+++ b/charts/notifications/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 # This is the version number of the application being deployed.
 appVersion: "0.1.0"
 keywords:


### PR DESCRIPTION
The Docker Hub repo `lerianstudio/notifications-helm` now exists (created by admin), so the release push that failed with 401 (creating a new repo) will now succeed. Publishes `notifications-helm:1.0.0-beta.3` to Docker Hub + GHCR.