### PR TITLE
feat(plugin-br-pix-switch): use amqps for dict-hub-vsync rabbitmq connection

### DIFF
--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.0.0-beta.1
+version: 2.0.0-beta.2
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.101"

--- a/charts/plugin-br-pix-switch/templates/_helpers.tpl
+++ b/charts/plugin-br-pix-switch/templates/_helpers.tpl
@@ -211,9 +211,11 @@ Usage:
       set -- $(parse_url "${MONGO_URL:-}")
       wait_for_service "mongo" "${1:-}" "${2:-27017}"
 
-      # RabbitMQ (RABBITMQ_URI)
+      # RabbitMQ (RABBITMQ_URI) — TLS-only: default to the amqps port (5671).
+      # All documented URIs carry an explicit :5671; this fallback only applies
+      # to a portless amqps:// URI, so it must not assume the plaintext 5672.
       set -- $(parse_url "${RABBITMQ_URI:-}")
-      wait_for_service "rabbitmq" "${1:-}" "${2:-5672}"
+      wait_for_service "rabbitmq" "${1:-}" "${2:-5671}"
 
       echo "all dependencies ready"
 {{- end }}

--- a/charts/plugin-br-pix-switch/values-template.yaml
+++ b/charts/plugin-br-pix-switch/values-template.yaml
@@ -99,7 +99,9 @@ dictHubVsync:
   secrets:
     DATABASE_URL: "postgres://pixswitch:<password>@postgres-host:5432/pix-dict?sslmode=require"
     VALKEY_URL: "redis://default:<password>@valkey-host:6379/0"
-    RABBITMQ_URI: "amqp://pixswitch:<password>@rabbitmq-host:5672/"
+    # TLS-only: amqps:// on 5671. lib-commons v5.7.0 validates the broker cert
+    # against the system trust store (a private CA needs an app-code change).
+    RABBITMQ_URI: "amqps://pixswitch:<password>@rabbitmq-host:5671/"
     LICENSE_KEY: ""
 
 # ------------------------------------------------------------

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -715,6 +715,9 @@ dictHubVsync:
     DATABASE_URL: ""
     SYSTEMPLANE_POSTGRES_DSN: ""
     VALKEY_URL: ""
+    # RabbitMQ — required (vsync is a queue consumer). Must be amqps:// (TLS) on
+    # 5671; lib-commons v5.7.0 validates the broker cert against the system trust
+    # store. Supplied per environment via secret/Vault. Never set ALLOW_INSECURE_TLS.
     RABBITMQ_URI: ""
     LICENSE_KEY: ""
     CRM_CLIENT_SECRET: ""
@@ -1459,6 +1462,10 @@ mongodb:
 
 # RabbitMQ (groundhog2k chart — same as plugin-br-bank-transfer / matcher)
 # Used only by dict-hub-vsync for RABBITMQ_URI.
+# Chosen path: EXTERNAL broker with a CA-signed TLS cert (trusted by the system
+# trust store) on amqps://:5671. The in-cluster subchart would present a
+# self-signed cert that lib-commons rejects, so it stays disabled — the anacleto
+# chaos/fuzzing overlays also migrate off the embedded broker to external.
 rabbitmq:
   enabled: false
   image:


### PR DESCRIPTION
## What

Make `plugin-br-pix-switch` TLS-first for RabbitMQ. **dict-hub-vsync** is the only RabbitMQ consumer in the chart.

- `values-template.yaml` → operator `RABBITMQ_URI` example: `amqp://...:5672/` → **`amqps://pixswitch:<password>@rabbitmq-host:5671/`**
- `values.yaml` → `dictHubVsync.secrets.RABBITMQ_URI` default stays empty (supplied per env via secret/Vault); added a comment documenting it **must be `amqps://` on 5671**; documented the external-broker decision next to `rabbitmq.enabled: false`
- `templates/_helpers.tpl` → `wait-for-dependencies` RabbitMQ port fallback `5672` → **`5671`** (removes the last plaintext assumption)
- `Chart.yaml` → `2.0.0-beta.1` → `2.0.0-beta.2`

> Note: on `develop` the connection strings live under each component's `secrets:` (empty by default) and are injected per environment — there is no hardcoded `amqp://` default to flip, so the chart change is the operator-facing example + guidance + hardening.

## Why

`lib-commons v5.7.0` rejects plaintext AMQP unless `ALLOW_INSECURE_TLS=true`. Since prod does not exist yet, we start clean. The library passes through as soon as `RABBITMQ_URI` begins with `amqps://`, validating the broker certificate against the **system trust store** — so:

- ✅ No `ALLOW_INSECURE_TLS` anywhere (verified absent in the whole chart).
- ✅ No TLS cert secret mounted (not needed for system-trust-store validation).
- ✅ The `wait-for-dependencies` init container parses the port from the URI (scheme-agnostic), so it targets `:5671`; when `RABBITMQ_URI` is empty it skips the check, and the no-port fallback is now `5671` (was `5672`) so it never assumes plaintext.

## ⚠️ Out of chart scope — private CA caveat

If a broker presents a certificate signed by a **private CA** (not in the container trust store), this Helm change is **not** sufficient: it would require an **application-code change** to inject a custom TLS config into the AMQP dialer. `lib-commons v5.7.0` exposes no env var to load a custom CA/cert. Do not work around this with `ALLOW_INSECURE_TLS`.

## Per-environment broker decision (RESOLVED)

The actual per-env `RABBITMQ_URI` is supplied via secret/Vault in gitops repo `midaz-firmino-gitops`, not in this chart. **All environments will use an external RabbitMQ broker** that terminates TLS with a CA-signed certificate trusted by the system trust store:

| Env | Broker | Action |
|-----|--------|--------|
| dev (firmino), dev-st (benedita) | external (`rabbitmq.enabled: false`) | flip Vault `RABBITMQ_URI` → `amqps://…:5671/` once broker exposes 5671/TLS |
| chaos + fuzzing (anacleto, 4 overlays) | **switching from embedded subchart → external** | set `rabbitmq.enabled: false`, drop the embedded `rabbitmq:` block, flip Vault → external `amqps://…:5671/` |

This **resolves the embedded-broker blocker**: the in-cluster RabbitMQ subchart (groundhog2k) would have presented a self-signed cert that the system trust store rejects — a dead end without `ALLOW_INSECURE_TLS`. Using an external broker with a CA-signed cert avoids that entirely and makes all four anacleto envs consistent with dev/dev-st.

## Companion gitops change (required, coordinated) — NOT yet staged

This chart PR is **inert on its own**. The migration takes effect only when the gitops companion change lands in `midaz-firmino-gitops`:
1. anacleto chaos/fuzzing overlays: `rabbitmq.enabled: false` + remove embedded `rabbitmq:` block.
2. Vault keys updated to `amqps://…:5671/`:
   - `secret/data/firmino/plugin-br-pix-switch/dev#RABBITMQ_URI`
   - `secret/data/benedita/plugin-br-pix-switch/dev-st#RABBITMQ_URI`
   - `secret/data/anacleto/plugin-br-pix-switch/dev#RABBITMQ_URI` (shared by all 4 anacleto overlays)

**Sequencing: do not flip a Vault key until that environment's external broker exposes port 5671 with a CA-signed TLS cert.** Merging this chart PR before the gitops companion + Vault are ready is safe (the chart is inert), but no env is actually migrated until those land.

## Scope note

No existing chart in this repo uses `amqps://`. `plugin-br-bank-transfer` is **not** an AMQPS reference — its app connection is `amqp://` + `ALLOW_INSECURE_TLS: "true"`; its only TLS handling is for the RabbitMQ management HTTP API bootstrap.

Requested-by: @rodrigo.vasconcelos