### PR TITLE
fix(templates): address CodeRabbit blocking findings on infra secret gating (#1514)

### DIFF
--- a/charts/flowker/templates/_helpers.tpl
+++ b/charts/flowker/templates/_helpers.tpl
@@ -136,6 +136,8 @@ Input (dict): context (root .), secretName (app Secret name for the external-inl
     secretKeyRef:
       name: {{ .secretName }}
       key: MONGO_PASSWORD
+{{- else }}
+{{- fail "flowker.secrets.MONGO_PASSWORD is required when mongodb is external and mongodb.auth.existingSecret is not set" }}
 {{- end }}
 - name: MONGO_URI
   value: {{ printf "mongodb://%s:$(MONGO_PASSWORD)@%s:27017/?authSource=admin" $mongo.auth.rootUser (include "flowker.mongoHost" $ctx) | quote }}

--- a/charts/matcher/templates/secrets.yaml
+++ b/charts/matcher/templates/secrets.yaml
@@ -30,7 +30,14 @@ data:
   {{- end }}
 
   # RabbitMQ Secrets
-  RABBITMQ_PASSWORD: {{ required "matcher.secrets.RABBITMQ_PASSWORD is required" .Values.matcher.secrets.RABBITMQ_PASSWORD | b64enc | quote }}
+  # Single-sourced from the rabbitmq subchart Secret (via authentication.existingSecret) when
+  # rabbitmq is internal or an existingSecret is set. Only emitted here for external RabbitMQ
+  # without an existingSecret (operator-provided password), mirroring the PostgreSQL/Valkey gating.
+  {{- $rmq := .Values.rabbitmq | default dict }}
+  {{- $rmqAuth := $rmq.authentication | default dict }}
+  {{- if and (not (and (ne (toString $rmq.enabled) "false") (not $rmq.external))) (not $rmqAuth.existingSecret) }}
+  RABBITMQ_PASSWORD: {{ required "matcher.secrets.RABBITMQ_PASSWORD is required for external RabbitMQ without an existingSecret" .Values.matcher.secrets.RABBITMQ_PASSWORD | b64enc | quote }}
+  {{- end }}
 
   # Object Storage Secrets
   OBJECT_STORAGE_ACCESS_KEY_ID: {{ .Values.matcher.secrets.OBJECT_STORAGE_ACCESS_KEY_ID | default "" | b64enc | quote }}

--- a/charts/plugin-bc-correios/templates/_helpers.tpl
+++ b/charts/plugin-bc-correios/templates/_helpers.tpl
@@ -126,7 +126,8 @@ existingSecret values are the operator's responsibility and pass untouched.
 {{- $rmq := default dict .Values.rabbitmq -}}
 {{- $rmqEnabled := ne (toString $rmq.enabled) "false" -}}
 {{- $auth := default dict $rmq.authentication -}}
-{{- $secretName := include "bc-correios.fullname" . -}}
+{{- $component := index .Values "bc-correios" -}}
+{{- $secretName := ternary $component.existingSecretName (include "bc-correios.fullname" .) $component.useExistingSecret -}}
 {{- if and $rmqEnabled (eq (default "" $auth.existingSecret) "bc-correios") (ne $secretName "bc-correios") -}}
 {{- fail (printf "\n\nERROR: rabbitmq.authentication.existingSecret is still the shipped default \"bc-correios\" but the app Secret renders as %q.\n   The broker would reference a Secret that does not exist.\n   Update rabbitmq.authentication.existingSecret to %q (or set it to your own existing Secret).\n" $secretName $secretName) -}}
 {{- end -}}

--- a/charts/plugin-br-pix-switch/templates/_helpers.tpl
+++ b/charts/plugin-br-pix-switch/templates/_helpers.tpl
@@ -214,8 +214,13 @@ Usage:
       # RabbitMQ (RABBITMQ_URI) — TLS-only: default to the amqps port (5671).
       # All documented URIs carry an explicit :5671; this fallback only applies
       # to a portless amqps:// URI, so it must not assume the plaintext 5672.
+      RABBIT_DEFAULT_PORT=5671
+      case "${RABBITMQ_URI:-}" in
+        amqp://*) RABBIT_DEFAULT_PORT=5672 ;;
+        amqps://*) RABBIT_DEFAULT_PORT=5671 ;;
+      esac
       set -- $(parse_url "${RABBITMQ_URI:-}")
-      wait_for_service "rabbitmq" "${1:-}" "${2:-5671}"
+      wait_for_service "rabbitmq" "${1:-}" "${2:-$RABBIT_DEFAULT_PORT}"
 
       echo "all dependencies ready"
 {{- end }}


### PR DESCRIPTION
Resolve the 4 blocking CodeRabbit findings on PR #1514. Direct push to `develop` is blocked by the repository ruleset (changes must go through a PR), so these fixes are delivered as a PR into `develop`.

### Fixes
1. **charts/flowker/templates/_helpers.tpl** — fail-loud gate when `MONGO_PASSWORD` has no source (external mongo, no `existingSecret`, no inline `flowker.secrets.MONGO_PASSWORD`), avoiding an unusable `MONGO_URI` at runtime.
2. **charts/matcher/templates/secrets.yaml** — gate `RABBITMQ_PASSWORD` emission by infra mode (only external RabbitMQ without an existingSecret), mirroring the PostgreSQL/Valkey gating.
3. **charts/plugin-bc-correios/templates/_helpers.tpl** — `rabbitmqExistingSecretConsistent` now honors `useExistingSecret`/`existingSecretName` instead of always using fullname.
4. **charts/plugin-br-pix-switch/templates/_helpers.tpl** — RabbitMQ fallback port respects the URI scheme (`amqp`→5672, `amqps`→5671).

`helm lint` passes for all four charts.

Requested-by: Guilherme Rodrigues