### PR TITLE
feat(otel-collector): apply midaz namespace filter across all signals + deprecation rename

### DIFF
--- a/charts/otel-collector-lerian/README.md
+++ b/charts/otel-collector-lerian/README.md
@@ -59,7 +59,7 @@ This chart provides a pre-configured OpenTelemetry Collector with the following 
 - **transform/remove_sensitive_attributes**: Removes sensitive payload data from spans
 - **transform/mask_body_sensitive_data**: Masks PII data in logs (documents, names, emails, addresses, phone numbers, PIX keys)
 - **filter/drop_node_metrics**: Excludes node-level metrics
-- **filter/include_midaz_namespaces**: Filters metrics to include only `midaz` and `midaz-plugins` namespaces
+- **filter/include_midaz_namespaces**: BYOC privacy filter — restricts metrics, logs, and traces to the `midaz` and `midaz-plugins` namespaces only. Telemetry from any other namespace is dropped at the collector before being exported.
 
 ### Connectors
 - **spanmetrics**: Generates RED metrics (Rate, Errors, Duration) from trace spans

--- a/charts/otel-collector-lerian/values.yaml
+++ b/charts/otel-collector-lerian/values.yaml
@@ -296,14 +296,33 @@ opentelemetry-collector:
             metric_names:
               - ^k8s\.node\..*$
 
-      # Filters metrics to include the 'midaz' and 'midaz-plugins' namespaces.
+      # BYOC privacy filter — restricts telemetry to the 'midaz' and
+      # 'midaz-plugins' namespaces. The same filter is applied across metrics,
+      # logs, and traces so Lerian never receives data from the client's other
+      # workloads (kube-system, app-of-the-client, etc.).
+      #
+      # `metrics` and `logs` sections use the filterprocessor's declarative
+      # `include` form. `traces` uses OTTL syntax — the `span:` list specifies
+      # what to DROP, so the condition is INVERTED (drop spans whose namespace
+      # is NOT in the allowed set, or whose `k8s.namespace.name` is missing
+      # entirely).
       filter/include_midaz_namespaces:
+        error_mode: ignore
         metrics:
           include:
             match_type: regexp
             resource_attributes:
               - key: k8s.namespace.name
                 value: '^(midaz|midaz-plugins)$'
+        logs:
+          include:
+            match_type: regexp
+            resource_attributes:
+              - key: k8s.namespace.name
+                value: '^(midaz|midaz-plugins)$'
+        traces:
+          span:
+            - 'resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], "^(midaz|midaz-plugins)$")'
 
       # Enriches all telemetry with Kubernetes metadata (pod name, namespace, etc.).
       k8sattributes:
@@ -365,7 +384,7 @@ opentelemetry-collector:
           - name: http.route
           - name: http.status_code
           - name: http.response.status_code
-        dimensions_cache_size: 50000
+        aggregation_cardinality_limit: 50000
 
     exporters:
       # Disable the default debug exporter
@@ -396,6 +415,7 @@ opentelemetry-collector:
             - memory_limiter
             - k8sattributes
             - resource/add_client_id
+            - filter/include_midaz_namespaces
             - batch
           exporters: [otlphttp/server]
         traces:
@@ -404,15 +424,17 @@ opentelemetry-collector:
           # 2. k8sattributes BEFORE batch — batch drops the connection context that
           #    `pod_association: from connection` relies on.
           # 3. Add the client ID for multi-tenancy.
-          # 4. Sanitize by removing sensitive payloads.
-          # 5. Normalize HTTP semconv (legacy <-> OTel-stable) so the spanmetrics
+          # 4. Drop spans from namespaces outside the allowed set (BYOC privacy).
+          # 5. Sanitize by removing sensitive payloads.
+          # 6. Normalize HTTP semconv (legacy <-> OTel-stable) so the spanmetrics
           #    connector sees both `http.status_code` and `http.response.status_code`.
-          # 6. batch LAST so all enrichment/normalization runs on individual spans.
+          # 7. batch LAST so all enrichment/normalization runs on individual spans.
           receivers: [otlp]
           processors:
               - memory_limiter
               - k8sattributes
               - resource/add_client_id
+              - filter/include_midaz_namespaces
               - transform/remove_sensitive_attributes
               - transform/normalize_http_semconv
               - batch
@@ -448,6 +470,7 @@ opentelemetry-collector:
             - memory_limiter
             - k8sattributes
             - resource/add_client_id
+            - filter/include_midaz_namespaces
             - transform/mask_body_sensitive_data_replace_1
             - transform/mask_body_sensitive_data_replace_2
             - transform/mask_body_sensitive_data_replace_3


### PR DESCRIPTION
## Summary

Two chart polish items uncovered during the benedita dev-st validation of \`4.1.0-beta.1\`:

1. **Extend `filter/include_midaz_namespaces` to logs, traces and OTLP-pushed metrics** — today it only filters `metrics/cluster` (the k8s_cluster + kubeletstats receivers). Logs from `k8sobjects` events and spans from any app namespace were flowing through without filtering. For a BYOC chart that prioritizes data minimization, this is a privacy/scope gap.

2. **Rename `dimensions_cache_size` → `aggregation_cardinality_limit`** to fix the upstream deprecation warning printed on collector startup. Same numeric value (50000), same behavior.

## Why

Validation of benedita showed every namespace's logs flowing to Loki including `kube-system` events (NGINX reload, etc). The chart's namespace-restriction filter was scoped only to one pipeline. Tightening it across signals makes the chart actually honor its BYOC privacy contract by default.

## Changes

### \`filter/include_midaz_namespaces\` now covers 3 signals

The processor previously had only the \`metrics:\` block. Added \`logs:\` (declarative form, same shape as metrics) and \`traces:\` (OTTL form, condition inverted — \`span:\` lists what to DROP):

\`\`\`yaml
filter/include_midaz_namespaces:
  error_mode: ignore
  metrics:
    include:
      match_type: regexp
      resource_attributes:
        - key: k8s.namespace.name
          value: '^(midaz|midaz-plugins)$'
  logs:
    include:
      match_type: regexp
      resource_attributes:
        - key: k8s.namespace.name
          value: '^(midaz|midaz-plugins)$'
  traces:
    span:
      - 'resource.attributes[\"k8s.namespace.name\"] == nil or not IsMatch(resource.attributes[\"k8s.namespace.name\"], \"^(midaz|midaz-plugins)$\")'
\`\`\`

### Pipelines updated

- \`metrics\` (OTLP push from apps) — adds \`filter/include_midaz_namespaces\` after \`resource/add_client_id\`, before \`batch\`
- \`metrics/cluster\` — unchanged (already had the filter)
- \`metrics/spanmetrics\` — **unchanged on purpose**: this pipeline derives from \`traces\` via the spanmetrics connector. Filtering at the source (\`traces\`) is enough; filtering again here would be redundant.
- \`traces\` — adds the filter after \`resource/add_client_id\`, before the transforms. The traces pipeline comment is updated to reflect the new processor count.
- \`logs\` — adds the filter after \`resource/add_client_id\`, before the 10 PII mask transforms (no point spending CPU on PII masks for records that will be dropped).

### \`aggregation_cardinality_limit\`

Single-line rename in the spanmetrics connector block.

## Validated

- \`helm template\` renders without errors.
- \`helm lint\` passes.
- Rendered ConfigMap shows \`filter/include_midaz_namespaces\` in all 4 pipelines and \`aggregation_cardinality_limit: 50000\` on the spanmetrics connector.

## Test plan

After deploy on the next BYOC environment / internal env that picks up this chart:

- [ ] Loki query for \`{client_id=\"<env>\", k8s_namespace_name=\"kube-system\"}\` returns empty for new logs.
- [ ] Tempo: no spans for new ingestion from outside midaz/midaz-plugins.
- [ ] Mimir: \`http_server_request_duration_seconds_*\` only for namespaces matching the include regex.
- [ ] Startup logs no longer print \`DimensionsCacheSize is deprecated\`.

## Out of scope (still in backlog)

- Making the namespace regex configurable via values (today it's hardcoded \`^(midaz|midaz-plugins)$\`). Tracked in \`lerian-o11y/docs/OTEL_COLLECTOR_CHART_BACKLOG.md\`.
- \`k8sobjects.namespaces\` configurable.
- Pipeline override ergonomics (helpers/extraFilters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)