### PR TITLE
chore(doc): refresh midaz + otel-collector-lerian READMEs for 8.4 / 4.1 releases

### DIFF
--- a/charts/midaz/README.md
+++ b/charts/midaz/README.md
@@ -554,13 +554,29 @@ ledger:
     RABBITMQ_PROTOCOL: "https" # was "http"
 ```
 
-### OpenTelemetry Collector (Lerian)
+### OpenTelemetry Collector wiring
 
-- **Note:** This OpenTelemetry collector is used to collect and export telemetry data from Midaz components.
- - By default, it is disabled.
- - You can enable it by setting `otel-collector-lerian.enabled` to `true` in the values file.
+Since `8.4.0` the `otel-collector-lerian` subchart is no longer installed as a dependency of this chart (the dependency was removed; see [`UPGRADE-8.4.md`](docs/UPGRADE-8.4.md) for the migration story). The `otel-collector-lerian.enabled` flag now only controls whether `HOST_IP`, `POD_IP`, `OTEL_EXPORTER_OTLP_ENDPOINT=$(HOST_IP):4317` and `OTEL_RESOURCE_ATTRIBUTES=k8s.pod.ip=$(POD_IP)` are injected into the `ledger` and `crm` deployments.
+
+By default `enabled: true` — Midaz expects a node-local OTel collector listening on `4317` (`hostPort` or `hostNetwork`). Install the [otel-collector-lerian chart](../otel-collector-lerian) separately or point your own collector at the same port.
 
 ```yaml
 otel-collector-lerian:
-  enabled: true
+  enabled: true    # injects OTEL env vars (default)
 ```
+
+If you don't want telemetry exported, or you want to send telemetry to an endpoint that isn't a node-local collector on `:4317`, leave `enabled: false` and configure `OTEL_EXPORTER_OTLP_ENDPOINT` directly in the application configmap:
+
+```yaml
+otel-collector-lerian:
+  enabled: false
+
+ledger:
+  configmap:
+    OTEL_EXPORTER_OTLP_ENDPOINT: "https://your-collector.example.com:4317"
+crm:
+  configmap:
+    OTEL_EXPORTER_OTLP_ENDPOINT: "https://your-collector.example.com:4317"
+```
+
+Schema is strict: only `enabled` is accepted under `otel-collector-lerian:`. Legacy keys (`external`, `extraEnvs`, `exporters`, `opentelemetry-collector`) are rejected at `helm install/upgrade` time.

--- a/charts/otel-collector-lerian/README.md
+++ b/charts/otel-collector-lerian/README.md
@@ -48,18 +48,20 @@ This chart provides a pre-configured OpenTelemetry Collector with the following 
 
 ### Receivers
 - **OTLP**: Receives traces, logs, and metrics from instrumented applications via gRPC (port 4317) and HTTP (port 4318)
-- **k8s_cluster**: Collects cluster-level state information (pod status, deployments, etc.)
+- **k8s_cluster**: Collects cluster-level state information (pod status, deployments, HPA replicas, container status, node conditions)
 - **kubeletstats**: Collects pod/container performance metrics (CPU, memory) from the node's Kubelet
+- **k8sobjects**: Watches Kubernetes events (pod scheduling, image pulls, OOMKills, etc.) for the namespaces in `k8sobjects.objects[0].namespaces` (default: `midaz` and `midaz-plugins`)
 
 ### Processors
-- **memory_limiter**: Prevents out-of-memory situations
-- **batch**: Batches telemetry data for efficient export
-- **k8sattributes**: Enriches telemetry with Kubernetes metadata (pod name, namespace, deployment)
-- **resource/add_client_id**: Adds client ID for multi-tenancy support
-- **transform/remove_sensitive_attributes**: Removes sensitive payload data from spans
+- **memory_limiter**: Prevents out-of-memory situations (`check_interval: 1s`, `limit_percentage: 80`)
+- **batch**: Batches telemetry data for efficient export (last in every pipeline, after enrichment)
+- **k8sattributes**: Enriches telemetry with Kubernetes metadata (pod name, namespace, deployment). Uses a two-tier `pod_association` strategy: primary resolves identity from the `k8s.pod.ip` resource attribute (set by `lib-observability`-based apps via `OTEL_RESOURCE_ATTRIBUTES`); fallback uses the connection source IP (requires `hostNetwork: true` on the collector pod).
+- **resource/add_client_id**: Adds `client.id` for multi-tenancy support
+- **transform/remove_sensitive_attributes**: Removes sensitive payload data from spans (`app.request.payload`)
+- **transform/normalize_http_semconv**: Bidirectional mirror between legacy HTTP attrs (`http.method`, `http.status_code`) and OTel stable (`http.request.method`, `http.response.status_code`). Keeps both forms populated on every span/log during the lib-observability migration window. Skips when the new method attr is `_OTHER` (cardinality protection sentinel).
 - **transform/mask_body_sensitive_data**: Masks PII data in logs (documents, names, emails, addresses, phone numbers, PIX keys)
 - **filter/drop_node_metrics**: Excludes node-level metrics
-- **filter/include_midaz_namespaces**: BYOC privacy filter — restricts metrics, logs, and traces to the `midaz` and `midaz-plugins` namespaces only. Telemetry from any other namespace is dropped at the collector before being exported.
+- **filter/include_midaz_namespaces**: BYOC privacy filter — restricts **metrics, logs and traces** to the `midaz` and `midaz-plugins` namespaces only. Telemetry from any other namespace is dropped at the collector before being exported.
 
 ### Connectors
 - **spanmetrics**: Generates RED metrics (Rate, Errors, Duration) from trace spans
@@ -134,38 +136,56 @@ This chart provides a pre-configured OpenTelemetry Collector with the following 
 
 ## Telemetry Pipelines
 
-The chart configures the following pipelines:
+The chart configures the following pipelines. All pipelines follow the same processor ordering: `memory_limiter` first, `k8sattributes` before `batch` (batch drops the connection context that pod_association relies on), and `batch` last so all enrichment runs on individual records.
 
 ### Traces Pipeline
 1. Receives traces via OTLP
-2. Applies memory limiter and batching
-3. Enriches with Kubernetes metadata
-4. Adds client ID
-5. Removes sensitive attributes
-6. Exports to central backend and spanmetrics connector
+2. `memory_limiter` (admission control)
+3. `k8sattributes` (pod identity via k8s.pod.ip resource attribute or connection IP fallback)
+4. `resource/add_client_id` (multi-tenancy)
+5. `filter/include_midaz_namespaces` (BYOC privacy — drop spans from non-midaz namespaces)
+6. `transform/remove_sensitive_attributes` (strip `app.request.payload`)
+7. `transform/normalize_http_semconv` (mirror legacy ↔ OTel-stable HTTP attrs)
+8. `batch`
+9. Exports to central backend AND feeds the `spanmetrics` connector
+
+### Metrics Pipeline (OTLP-pushed application metrics)
+Accepts OTLP-pushed metrics from applications. Required so apps using `lib-observability` (which emits `http.server.request.duration` and other OTel-native metrics directly via the OTel SDK) deliver those to the central backend.
+
+1. Receives metrics via OTLP
+2. `memory_limiter` → `k8sattributes` → `resource/add_client_id` → `filter/include_midaz_namespaces` → `batch`
+3. Exports to central backend
 
 ### Metrics/Spanmetrics Pipeline
-1. Receives span-derived metrics from the spanmetrics connector
-2. Applies memory limiter and batching
-3. Enriches with Kubernetes metadata
-4. Adds client ID
-5. Exports to central backend
+Carries the RED metrics derived from spans by the `spanmetrics` connector.
+
+1. Receives metrics from the `spanmetrics` connector
+2. `memory_limiter` → `k8sattributes` → `resource/add_client_id` → `batch`
+3. Exports to central backend
+
+(No `filter/include_midaz_namespaces` here because spans were already filtered upstream in the `traces` pipeline.)
 
 ### Metrics/Cluster Pipeline
-1. Receives metrics from OTLP, k8s_cluster, and kubeletstats receivers
-2. Applies memory limiter and batching
-3. Adds client ID and Kubernetes metadata
-4. Filters to include only midaz namespaces
-5. Drops node-level metrics
-6. Exports to central backend
+1. Receives metrics from `k8s_cluster` and `kubeletstats` receivers (OTLP is **not** in this pipeline — application OTLP metrics flow through the `Metrics` pipeline above to avoid double export)
+2. `memory_limiter` → `k8sattributes` → `resource/add_client_id` → `filter/include_midaz_namespaces` → `filter/drop_node_metrics` → `batch`
+3. Exports to central backend
 
 ### Logs Pipeline
-1. Receives logs via OTLP
-2. Applies memory limiter and batching
-3. Enriches with Kubernetes metadata
-4. Adds client ID
-5. Masks sensitive data (PII) in log bodies
-6. Exports to central backend
+1. Receives logs via OTLP and Kubernetes events via `k8sobjects`
+2. `memory_limiter` → `k8sattributes` → `resource/add_client_id` → `filter/include_midaz_namespaces` (drops logs from non-midaz namespaces before masking) → 10 `transform/mask_body_sensitive_data_replace_*` (PII masking) → `batch`
+3. Exports to central backend
+
+## Pod identity (hostNetwork + pod_association)
+
+The chart deploys the collector as a DaemonSet with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`. `hostPort` mappings are set to `0` (since hostNetwork binds the container directly to the node's network stack, hostPort would be redundant and could fight for ports during rolling updates).
+
+This is required so the `k8sattributes` processor can resolve pod identity from the connection source IP — without `hostNetwork`, hostPort hairpin NAT would rewrite the source IP to the node IP and `k8sattributes` couldn't match telemetry to its originating pod.
+
+Two-tier `pod_association`:
+1. **Primary**: `from: resource_attribute, name: k8s.pod.ip` — works for any pod, no hostNetwork required. Apps need to emit `OTEL_RESOURCE_ATTRIBUTES=k8s.pod.ip=$(POD_IP)` (the `midaz` chart's `ledger`/`crm` templates set this automatically when `otel-collector-lerian.enabled=true`).
+2. **Fallback**: `from: connection` — kicks in for apps that don't emit `k8s.pod.ip` (e.g. apps still on `lib-commons v2`). Requires the collector's `hostNetwork: true` to be honored by the cluster's Pod Security policy.
+
+If your cluster's Pod Security Standards forbid `hostNetwork: true` you can still run the chart in a restricted mode by setting `hostNetwork: false` and ensuring **every** application emits the `k8s.pod.ip` resource attribute — the primary path is enough on its own.
 
 ---
 


### PR DESCRIPTION
## Summary

Polishes the README for both charts before promoting `midaz 8.4` and `otel-collector-lerian 4.1` from `develop` to `main`. No values.yaml, schema, or template changes.

## Why

Validation of the 4.1.0-beta.2 chart on benedita-dev-st surfaced several inaccuracies in the README files:

**charts/midaz/README.md**:
- Said "By default, it is disabled" but values now default to `enabled: true`.
- Still described `otel-collector-lerian` as a bundled subchart (removed in PR #1508 — the chart only injects env vars now).
- No mention of the schema strictness (only `enabled` accepted under `otel-collector-lerian:`).

**charts/otel-collector-lerian/README.md**:
- Receivers list missing `k8sobjects`.
- Processors list missing `transform/normalize_http_semconv` (added in 4.1).
- `filter/include_midaz_namespaces` described as metrics-only — now applies to all 3 signals (extended in PR #1550).
- Pipelines section listed 4 pipelines but the chart has 5 (the `metrics` OTLP-push pipeline was added in 4.1).
- Said `metrics/cluster` receives OTLP — no longer true (PR #1550 removed OTLP from that pipeline to avoid double-export with the `metrics` pipeline).
- No mention of `hostNetwork: true` requirement or the two-tier `pod_association` design.

## Changes

### `charts/midaz/README.md`

- Rewrites the OTel Collector section to:
  - Explain that the subchart is no longer installed by this chart.
  - Document the new `enabled: true` default (injects env vars only).
  - Show how to point apps at a custom endpoint via the application configmap.
  - Note the schema rejects legacy keys (`external`, `extraEnvs`, `exporters`, `opentelemetry-collector`).
- Links to `docs/UPGRADE-8.4.md` (will be auto-generated by the release pipeline).

### `charts/otel-collector-lerian/README.md`

- Adds `k8sobjects` to the Receivers list.
- Expands `k8sattributes` description with the two-tier `pod_association` design.
- Adds `transform/normalize_http_semconv` to the Processors list with the bidirectional mirror + `_OTHER` skip explanation.
- Updates the `filter/include_midaz_namespaces` description to "metrics, logs, and traces".
- Rewrites the Telemetry Pipelines section as 5 pipelines with the actual processor ordering (memory_limiter first, batch last, k8sattributes before batch).
- Removes the inaccurate claim that `metrics/cluster` receives OTLP.
- Adds a new "Pod identity (hostNetwork + pod_association)" section.

## Validated

- `helm lint charts/midaz` passes.
- `helm lint charts/otel-collector-lerian` passes.
- No values.yaml / template / schema / Chart.yaml changes — pure docs.

## Out of scope (not in this PR)

- The 21 gitops `external: true` migrations (tracked separately for Monday).
- Bump of `lib-commons` in midaz to consume `OTEL_RESOURCE_ATTRIBUTES` (apps are migrating to `lib-observability` which already does).
- `UPGRADE-8.4.md` / `UPGRADE-4.1.md` (release pipeline generates these on tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)