### PR TITLE
feat(charts): add streaming-hub Helm chart

### DIFF
--- a/charts/streaming-hub/.helmignore
+++ b/charts/streaming-hub/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Chart docs are not part of the packaged artifact.
+docs/
+README.md

--- a/charts/streaming-hub/Chart.yaml
+++ b/charts/streaming-hub/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: streaming-hub-helm
+description: >-
+  Lerian streaming-hub — consumes lib-streaming CloudEvents from Kafka/Redpanda
+  and fans them out to per-tenant SaaS/BYOC subscribers. Multi-component chart
+  with a runtime STREAMING_HUB_ROLE model (mode: all | split).
+type: application
+# version is a PLACEHOLDER. semantic-release in the `helm` repo owns the real
+# chart version on merge — do NOT hand-pick a final number here.
+version: 0.1.0
+appVersion: "1.0.0"
+annotations:
+  lerian.studio/chart-type: multi-component
+home: https://github.com/LerianStudio/streaming-hub
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/streaming-hub
+  - https://github.com/LerianStudio/streaming-hub
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+keywords:
+  - streaming
+  - cloudevents
+  - kafka
+  - redpanda
+  - fan-out
+  - lerian
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+# NO dependencies block by deliberate design (deviation from reporter/midaz):
+# OTEL is env-wired via the OTEL_EXPORTER_OTLP_ENDPOINT downward-API override,
+# not bundled as an otel-collector-lerian subchart. Declaring it would force an
+# OCI pull on every `helm lint` / `helm template`. Kafka/Redpanda and Postgres
+# are shared external infra, never subcharts here.

--- a/charts/streaming-hub/README.md
+++ b/charts/streaming-hub/README.md
@@ -109,12 +109,14 @@ the per-role rationale (all 25/12, ingest 8/4, delivery 16/10).
 - **No `preStop` hook.** The hub **self-drains on SIGTERM**: the exec-form
   ENTRYPOINT delivers SIGTERM straight to PID 1, and the lib-commons Launcher
   runs the HTTP → consumer → dispatcher teardown.
-- **`terminationGracePeriodSeconds` (default 30) MUST exceed the drain ceiling.**
-  The hub's derived ceiling at the default `STREAMING_HUB_SHUTDOWN_TIMEOUT=30s` +
-  `STREAMING_HUB_PRE_STOP_DRAIN_TIMEOUT=5s` is ~80s. **Raise
-  `terminationGracePeriodSeconds` to at least that ceiling in any environment
-  that tunes those knobs up**, or the orchestrator SIGKILLs a still-draining
-  replica (risking a duplicate delivery). See `.env.reference`.
+- **`terminationGracePeriodSeconds` defaults to `80` — the hub's derived SIGTERM
+  drain ceiling — and MUST stay at or above it.** At the shipped
+  `STREAMING_HUB_SHUTDOWN_TIMEOUT=30s` + `STREAMING_HUB_PRE_STOP_DRAIN_TIMEOUT=5s`
+  the ceiling is `30s` (HTTP) + `5s` (consumer final-commit) + `30s` (dispatcher,
+  `min(ShutdownTimeout, 55s)`) + `10s` slack = `75s`, plus the `5s` pre-stop wait
+  = **`80s`**. If you tune those knobs up, recompute and raise this knob to match,
+  or the orchestrator SIGKILLs a still-draining replica (risking a duplicate
+  delivery). See `.env.reference`.
 
 ---
 
@@ -167,7 +169,7 @@ This chart provisions **none** of the following — they live outside it:
 | `streamingHub.service.port` | `8080` | Control-plane HTTP port. |
 | `streamingHub.ingress.enabled` | `false` | Control-plane API ingress (opt-in per env). |
 | `streamingHub.serviceAccount.create` | `true` | |
-| `streamingHub.terminationGracePeriodSeconds` | `30` | MUST exceed the drain ceiling. |
+| `streamingHub.terminationGracePeriodSeconds` | `80` | Defaults to the ~80s drain ceiling; keep at or above it. |
 | `streamingHub.securityContext` | nonroot 65532, drop ALL, RO rootfs, RuntimeDefault | Distroless:nonroot. |
 | `streamingHub.useExistingSecret` | `false` | `true` = Vault/gitops path. |
 | `streamingHub.existingSecretName` | `""` | Required when `useExistingSecret`. |

--- a/charts/streaming-hub/README.md
+++ b/charts/streaming-hub/README.md
@@ -1,0 +1,186 @@
+# streaming-hub Helm chart
+
+Deploys **streaming-hub** — the Lerian service that consumes
+[`lib-streaming`](https://github.com/LerianStudio) CloudEvents from
+Kafka/Redpanda and fans them out to per-tenant SaaS/BYOC subscribers.
+
+This is a **multi-component** chart built on one image and one binary, selected
+at runtime into a role via `STREAMING_HUB_ROLE`. There are **no** database,
+broker, or OTEL subcharts — Kafka/Redpanda and PostgreSQL are shared external
+infra, and OTEL is env-wired (see [External dependencies](#external-dependencies)).
+
+---
+
+## Chart Contract
+
+- Chart type: `multi-component`
+- Required secrets: `secrets.STREAMING_HUB_POSTGRES_DSN` (the DSN carries the DB password); `secrets.STREAMING_HUB_KAFKA_SCRAM_USERNAME` + `secrets.STREAMING_HUB_KAFKA_SCRAM_PASSWORD` (when the broker requires SASL/SCRAM); `secrets.STREAMING_HUB_KEK_REF` (KEK reference for the F10 envelope crypto — `secrets.STREAMING_HUB_DEV_KEK` for dev only). SaaS-only, required when `STREAMING_HUB_MULTI_TENANT_ENABLED=true`: `secrets.STREAMING_HUB_TENANT_MANAGER_SERVICE_API_KEY` and `secrets.STREAMING_HUB_MULTI_TENANT_REDIS_PASSWORD`. All blank by default — provide inline or set `streamingHub.useExistingSecret` + `streamingHub.existingSecretName` (the path GitOps uses, with a Vault-injected Secret).
+- Dependency notes: **No bundled subcharts.** Kafka/Redpanda and PostgreSQL are shared external infra — supply `common.configmap.STREAMING_HUB_KAFKA_BROKERS` and `secrets.STREAMING_HUB_POSTGRES_DSN`. OTEL is env-wired to a node-local collector (`HOST_IP:4317`, gated on `streamingHub.telemetry.enabled`) — there is no OTEL collector subchart. The optional `bootstrap-postgres` Job provisions the hub's single database when `global.externalPostgresDefinitions.enabled=true`.
+- Production overrides: choose `streamingHub.mode` (`all` vs `split`); size per-role `replicaCount` / `autoscaling` / `resources` and the Postgres pool (`poolMaxOpenConns` / `poolMaxIdleConns`) honoring **Σ(replicas × poolMaxOpenConns) ≤ Postgres `max_connections`**; set `image.tag`, `ingress`, and the secrets (inline or `useExistingSecret`).
+- Source/license: Source is in `github.com/LerianStudio/helm`; license is Apache-2.0.
+
+---
+
+## The `mode` switch (read this first)
+
+`streamingHub.mode` decides the topology. It is an **either/or**:
+
+| `mode`  | Renders | `STREAMING_HUB_ROLE` | When |
+|---------|---------|----------------------|------|
+| `all` (default) | ONE Deployment + Service (+ HPA/PDB) | `all` | Single co-resident deployment. The dev-st target. Byte-equivalent to the historical single binary. |
+| `split` | TWO Deployments + Services (ingest + delivery), each with its own HPA/PDB | `ingest` / `delivery` | Ingest and delivery scaled independently as N + M replicas. |
+
+### > **DOUBLE-CONSUME HAZARD — the load-bearing rule**
+
+> **NEVER run a `mode: all` release AND a `mode: split` release against the same
+> Kafka/Redpanda cluster.** All three roles (`all`, `ingest`) join the **one**
+> ingest consumer group. An `all` pod and an `ingest` pod consuming together
+> means **every event is double-consumed and double-delivered.** The `mode`
+> switch enforces either/or within a single release — do not defeat it by
+> deploying two releases that overlap.
+
+### Worked example — `mode: all` (dev-st)
+
+```yaml
+streamingHub:
+  mode: all
+  all:
+    replicaCount: 1
+    poolMaxOpenConns: 25   # role=all holds both planes' connections
+    poolMaxIdleConns: 12
+```
+
+Renders: `streaming-hub-all` Deployment + `streaming-hub-all` Service, plus the
+shared `streaming-hub` ConfigMap + Secret + ServiceAccount. One consumer-group
+member set — no double-consume possible.
+
+### Worked example — `mode: split` (independent scaling)
+
+```yaml
+streamingHub:
+  mode: split
+  ingest:
+    replicaCount: 3
+    poolMaxOpenConns: 8    # consume-poll + inbox tx + partition-cron
+    poolMaxIdleConns: 4
+    autoscaling: { enabled: true, minReplicas: 3, maxReplicas: 4 }
+  delivery:
+    replicaCount: 2
+    poolMaxOpenConns: 16   # 8 dispatch workers + reclaim + dlq + delivery /readyz
+    poolMaxIdleConns: 10
+    autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 4 }
+```
+
+Renders `streaming-hub-ingest` and `streaming-hub-delivery` Deployments +
+Services + HPAs, sharing the one ConfigMap + Secret. Each Deployment gets its
+own `STREAMING_HUB_ROLE` and pool sizing as **explicit per-Deployment env**
+(which wins over the shared `envFrom`).
+
+---
+
+## Connection-budget invariant
+
+streaming-hub owns **ONE** shared PostgreSQL database. Every open connection on
+every pod of every role draws from that single `max_connections` budget.
+
+> **Σ over all running pods of `(replicas × poolMaxOpenConns)` + headroom ≤ PostgreSQL `max_connections`.**
+> Under HPA, use `maxReplicas` (not `replicaCount`) in the sum.
+
+Worked example (`max_connections = 100`, `mode: split`):
+
+| Role | replicas | poolMaxOpenConns | connections |
+|------|----------|------------------|-------------|
+| ingest | 3 | 8 | 24 |
+| delivery | 4 | 16 | 64 |
+| **total** | | | **88** (leaves 12 for admin/migrations) ✅ |
+
+Adding an `all` pod (25) → `88 + 25 = 113 > 100` ❌. The `mode` either/or already
+forbids that combination; the budget math is why it also matters operationally.
+See `streaming-hub/.env.reference` (`STREAMING_HUB_POSTGRES_MAX_OPEN_CONNS`) for
+the per-role rationale (all 25/12, ingest 8/4, delivery 16/10).
+
+---
+
+## Health, drain, and termination
+
+- **Probes** (verified against the hub source / Dockerfile, on the `http` port `8080`):
+  - `livenessProbe`: `GET /healthz` — stays `200` throughout drain.
+  - `readinessProbe`: `GET /readyz` — flips `NotReady` (503) **first** on SIGTERM so the endpoints controller drains the pod from the Service.
+- **No `preStop` hook.** The hub **self-drains on SIGTERM**: the exec-form
+  ENTRYPOINT delivers SIGTERM straight to PID 1, and the lib-commons Launcher
+  runs the HTTP → consumer → dispatcher teardown.
+- **`terminationGracePeriodSeconds` (default 30) MUST exceed the drain ceiling.**
+  The hub's derived ceiling at the default `STREAMING_HUB_SHUTDOWN_TIMEOUT=30s` +
+  `STREAMING_HUB_PRE_STOP_DRAIN_TIMEOUT=5s` is ~80s. **Raise
+  `terminationGracePeriodSeconds` to at least that ceiling in any environment
+  that tunes those knobs up**, or the orchestrator SIGKILLs a still-draining
+  replica (risking a duplicate delivery). See `.env.reference`.
+
+---
+
+## Secrets sourcing
+
+Two mutually-exclusive paths:
+
+| `useExistingSecret` | Behavior |
+|---------------------|----------|
+| `false` (default) | The chart renders `templates/secret.yaml` from `streamingHub.secrets` (base64-encoded; **empty values are skipped**, so unset SaaS/dev keys never ship blank). |
+| `true` | **No** Secret is rendered. Deployments reference `existingSecretName`. This is the **gitops/Vault path** (an external secret is projected into the named Secret) and is the production default. |
+
+Sensitive keys (all in `streamingHub.secrets`, all default `""`):
+`STREAMING_HUB_POSTGRES_DSN`, `STREAMING_HUB_KAFKA_SCRAM_USERNAME`,
+`STREAMING_HUB_KAFKA_SCRAM_PASSWORD`, `STREAMING_HUB_KEK_REF`,
+`STREAMING_HUB_DEV_KEK` (dev only), `STREAMING_HUB_TENANT_MANAGER_SERVICE_API_KEY`,
+`STREAMING_HUB_MULTI_TENANT_REDIS_PASSWORD`.
+
+---
+
+## External dependencies
+
+This chart provisions **none** of the following — they live outside it:
+
+- **Kafka / Redpanda** — the CloudEvents bus the hub consumes. Point
+  `STREAMING_HUB_KAFKA_BROKERS` at the cluster; supply SASL/SCRAM creds via the
+  Secret when `STREAMING_HUB_KAFKA_SCRAM_MECHANISM` is set.
+- **PostgreSQL** — the single hub-owned database (`tenant_id` is a column, not a
+  per-tenant DB). Either point `STREAMING_HUB_POSTGRES_DSN` at a pre-provisioned
+  managed host, **or** enable `global.externalPostgresDefinitions.enabled` to run
+  the bootstrap Job that creates the hub's one DB + role on a shared host.
+- **OTEL collector** — **not** a subchart (deliberate; declaring it would force
+  an OCI pull on `helm lint`/`template`). When `streamingHub.telemetry.enabled=true`
+  (a chart-level toggle, not an app env var), the Deployment injects `HOST_IP` via
+  the downward API and sets `OTEL_EXPORTER_OTLP_ENDPOINT=$(HOST_IP):4317`
+  (node-local DaemonSet collector).
+
+---
+
+## Top-level values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `streamingHub.mode` | `all` | Topology switch: `all` \| `split`. Schema-enforced enum. |
+| `streamingHub.image.repository` | `ghcr.io/lerianstudio/streaming-hub` | Image repo. |
+| `streamingHub.image.tag` | `""` | Empty falls back to `Chart.appVersion`. |
+| `streamingHub.image.pullPolicy` | `IfNotPresent` | |
+| `streamingHub.imagePullSecrets` | `[{name: ghcr-credential}]` | Private registry pull secrets. |
+| `streamingHub.service.type` | `ClusterIP` | Lerian convention (Ingress fronts external). |
+| `streamingHub.service.port` | `8080` | Control-plane HTTP port. |
+| `streamingHub.ingress.enabled` | `false` | Control-plane API ingress (opt-in per env). |
+| `streamingHub.serviceAccount.create` | `true` | |
+| `streamingHub.terminationGracePeriodSeconds` | `30` | MUST exceed the drain ceiling. |
+| `streamingHub.securityContext` | nonroot 65532, drop ALL, RO rootfs, RuntimeDefault | Distroless:nonroot. |
+| `streamingHub.useExistingSecret` | `false` | `true` = Vault/gitops path. |
+| `streamingHub.existingSecretName` | `""` | Required when `useExistingSecret`. |
+| `streamingHub.common.configmap` | (documented set) | Shared non-sensitive env. Every key is verbatim in `.env.reference`. |
+| `streamingHub.secrets` | (all `""`) | Shared sensitive env. Empty values skipped. |
+| `streamingHub.<role>.replicaCount` | `1` | Per role: `all` / `ingest` / `delivery`. |
+| `streamingHub.<role>.poolMaxOpenConns` | all `25` / ingest `8` / delivery `16` | Postgres pool (connection-budget invariant). |
+| `streamingHub.<role>.poolMaxIdleConns` | all `12` / ingest `4` / delivery `10` | |
+| `streamingHub.<role>.autoscaling.enabled` | `false` | HPA per role (`autoscaling/v2`, CPU+memory). |
+| `streamingHub.<role>.pdb.enabled` | `false` | PodDisruptionBudget per role (`policy/v1`). |
+| `global.externalPostgresDefinitions.enabled` | `false` | Bootstrap Job for the hub's one DB/role. |
+
+For the full env contract (defaults, required-in-SaaS markers, the F4 tenant
+caution, KEK source vars), see `streaming-hub/.env.reference`.
+
+See [`docs/TOPOLOGY.md`](docs/TOPOLOGY.md) for the role model in depth.

--- a/charts/streaming-hub/docs/TOPOLOGY.md
+++ b/charts/streaming-hub/docs/TOPOLOGY.md
@@ -1,0 +1,55 @@
+# streaming-hub deployment topology
+
+streaming-hub ships as **one image, one binary**, selected into a role at
+**runtime** via `STREAMING_HUB_ROLE` ∈ `{all, ingest, delivery}`. There is no
+build-time split — no `cmd/ingest`/`cmd/delivery`, no `ARG ROLE`. This chart
+exposes that runtime choice through the single `streamingHub.mode` switch.
+
+## The role model
+
+Every role serves the **full** Fiber control plane on `:8080`
+(`/healthz`, `/readyz`, `/metrics`, `/v1`, `/admin`). The role gates **which
+background Launcher Apps register** and **which Kafka clients dial** — not which
+HTTP routes mount.
+
+| Role | Background apps | Kafka clients | Postgres pool (open/idle) |
+|------|-----------------|---------------|---------------------------|
+| `all` | every app (ingest + delivery co-resident) | all three | 25 / 12 |
+| `ingest` | consumer + manifest-refresh + partition-cron + idempotency-reaper | ingest consumer only | 8 / 4 |
+| `delivery` | dispatcher + dlq-consumer + dlq-prune + topic-reconciler | DLQ + reconciler-admin | 16 / 10 |
+
+## How the chart maps mode → workloads
+
+- **`mode: all`** → `templates/all/*` render: one `streaming-hub-all` Deployment
+  with `STREAMING_HUB_ROLE=all`, plus its Service (and HPA/PDB when enabled).
+- **`mode: split`** → `templates/ingest/*` and `templates/delivery/*` render:
+  two Deployments (`streaming-hub-ingest`, `streaming-hub-delivery`) with the
+  matching role env, plus their Services (and per-role HPA/PDB).
+
+The shared singletons (`templates/configmap.yaml`, `templates/secret.yaml`,
+`templates/serviceaccount.yaml`) are role-invariant and rendered exactly once
+regardless of mode. The Deployment/Service/HPA/PDB bodies are a single
+parameterized partial (`templates/_deployment.tpl`) invoked by thin
+mode-gated wrappers — no per-role body duplication.
+
+### Why the role-specific vars are explicit `env`, not in the ConfigMap
+
+`STREAMING_HUB_ROLE` and the Postgres pool sizes differ per role. Kubernetes env
+precedence is **`env` > `envFrom`**, so the chart injects those three vars as
+explicit per-Deployment `env:` while everything role-invariant stays in the one
+shared ConfigMap consumed via `envFrom`. A role's pool size therefore cleanly
+overrides any shared default, and the ConfigMap never has to fork per role.
+
+## Independent scaling and the consumer group
+
+In `mode: split`, ingest and delivery scale independently as **N + M** replicas
+in one ingest consumer group; delivery's DLQ consumer is a structurally-disjoint
+second group. Background singleton crons stay singleton across replicas via the
+hub's `internal/shared/dblock` advisory-lock registry — the chart does not need
+to pin them to a single replica.
+
+> **Never overlap `mode: all` with `mode: split` on the same Kafka cluster.**
+> `all` and `ingest` join the same consumer group → double-consume. See the
+> README's double-consume hazard callout.
+
+For the full architecture, see `streaming-hub/docs/architecture.md`.

--- a/charts/streaming-hub/templates/_deployment.tpl
+++ b/charts/streaming-hub/templates/_deployment.tpl
@@ -1,0 +1,250 @@
+{{/*
+=============================================================================
+streaming-hub.deployment — the shared, component-parameterized Deployment.
+Input: dict { root (the root context "."), component ("all"|"ingest"|"delivery") }.
+
+All three roles run the SAME image and serve the SAME full control plane on
+:8080. They differ ONLY in:
+  - STREAMING_HUB_ROLE (the literal component)
+  - Postgres pool sizing (poolMaxOpenConns / poolMaxIdleConns)
+  - replicas / resources / scheduling
+
+The role-specific vars are injected as EXPLICIT per-Deployment env, which WINS
+over envFrom (k8s precedence: env > envFrom). So a per-role pool size cleanly
+overrides any shared default, and the shared ConfigMap deliberately omits
+STREAMING_HUB_ROLE / the pool vars.
+=============================================================================
+*/}}
+{{- define "streaming-hub.deployment" -}}
+{{- $ := .root -}}
+{{- $component := .component -}}
+{{- $cfg := index $.Values.streamingHub $component -}}
+{{- $sh := $.Values.streamingHub -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "streaming-hub.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" $ }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $sh.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ $sh.revisionHistoryLimit | default 10 }}
+  {{- with $sh.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if not $cfg.autoscaling.enabled }}
+  replicas: {{ $cfg.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "streaming-hub.componentSelectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "streaming-hub.labels" (dict "context" $ "component" $component) | nindent 8 }}
+      {{- with $sh.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with $sh.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "streaming-hub.serviceAccountName" $ }}
+      terminationGracePeriodSeconds: {{ $sh.terminationGracePeriodSeconds | default 30 }}
+      {{- with $sh.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: streaming-hub
+          securityContext:
+            {{- toYaml $sh.securityContext | nindent 12 }}
+          image: "{{ $sh.image.repository }}:{{ include "streaming-hub.defaultTag" $ }}"
+          imagePullPolicy: {{ $sh.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $sh.service.port }}
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ include "streaming-hub.secretName" $ }}
+            - configMapRef:
+                name: {{ include "streaming-hub.fullname" $ }}
+          env:
+            # --- role differentiator (explicit env WINS over envFrom) ---
+            - name: STREAMING_HUB_ROLE
+              value: {{ $component | quote }}
+            - name: STREAMING_HUB_POSTGRES_MAX_OPEN_CONNS
+              value: {{ $cfg.poolMaxOpenConns | quote }}
+            - name: STREAMING_HUB_POSTGRES_MAX_IDLE_CONNS
+              value: {{ $cfg.poolMaxIdleConns | quote }}
+            {{- with $sh.extraEnvVars }}
+            {{- range . }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if $sh.telemetry.enabled }}
+            # OTEL endpoint is overridden per-pod via the node host IP (DaemonSet
+            # collector pattern). Gated on the CHART-level streamingHub.telemetry.enabled.
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "$(HOST_IP):4317"
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ $sh.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ $sh.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ $sh.livenessProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ $sh.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $sh.livenessProbe.failureThreshold | default 3 }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: {{ $sh.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ $sh.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ $sh.readinessProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ $sh.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $sh.readinessProbe.failureThreshold | default 3 }}
+          resources:
+            {{- toYaml $cfg.resources | nindent 12 }}
+      {{- with $cfg.nodeSelector | default $sh.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cfg.affinity | default $sh.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cfg.tolerations | default $sh.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}
+
+
+{{/*
+=============================================================================
+streaming-hub.service — the shared, component-parameterized ClusterIP Service.
+Input: dict { root, component }. One Service per active role, selecting only
+that role's pods via componentSelectorLabels.
+=============================================================================
+*/}}
+{{- define "streaming-hub.service" -}}
+{{- $ := .root -}}
+{{- $component := .component -}}
+{{- $sh := $.Values.streamingHub -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "streaming-hub.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" $ }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $sh.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $sh.service.type }}
+  ports:
+    - port: {{ $sh.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "streaming-hub.componentSelectorLabels" (dict "context" $ "component" $component) | nindent 4 }}
+{{- end -}}
+
+
+{{/*
+=============================================================================
+streaming-hub.hpa — the shared, component-parameterized HPA (autoscaling/v2).
+Input: dict { root, component }. Emitted only when that role's
+autoscaling.enabled. CONNECTION-BUDGET HAZARD: maxReplicas multiplies the
+Postgres connection draw — Σ(maxReplicas × poolMaxOpenConns) ≤ max_connections.
+=============================================================================
+*/}}
+{{- define "streaming-hub.hpa" -}}
+{{- $ := .root -}}
+{{- $component := .component -}}
+{{- $cfg := index $.Values.streamingHub $component -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "streaming-hub.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" $ }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "streaming-hub.componentFullname" (dict "context" $ "component" $component) }}
+  minReplicas: {{ $cfg.autoscaling.minReplicas }}
+  maxReplicas: {{ $cfg.autoscaling.maxReplicas }}
+  metrics:
+    {{- if $cfg.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $cfg.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end -}}
+
+
+{{/*
+=============================================================================
+streaming-hub.pdb — the shared, component-parameterized PDB (policy/v1).
+Input: dict { root, component }. Emitted only when that role's pdb.enabled.
+maxUnavailable wins over minAvailable when both are set (mirrors the template).
+=============================================================================
+*/}}
+{{- define "streaming-hub.pdb" -}}
+{{- $ := .root -}}
+{{- $component := .component -}}
+{{- $cfg := index $.Values.streamingHub $component -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "streaming-hub.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" $ }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $cfg.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $cfg.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- else }}
+  minAvailable: {{ $cfg.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "streaming-hub.componentSelectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+{{- end -}}

--- a/charts/streaming-hub/templates/_deployment.tpl
+++ b/charts/streaming-hub/templates/_deployment.tpl
@@ -57,7 +57,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "streaming-hub.serviceAccountName" $ }}
-      terminationGracePeriodSeconds: {{ $sh.terminationGracePeriodSeconds | default 30 }}
+      automountServiceAccountToken: {{ $sh.serviceAccount.automountServiceAccountToken | default false }}
+      terminationGracePeriodSeconds: {{ $sh.terminationGracePeriodSeconds | default 80 }}
       {{- with $sh.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -239,8 +240,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with $cfg.pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if and (hasKey $cfg.pdb "maxUnavailable") (ne $cfg.pdb.maxUnavailable nil) }}
+  maxUnavailable: {{ $cfg.pdb.maxUnavailable }}
   {{- else }}
   minAvailable: {{ $cfg.pdb.minAvailable | default 1 }}
   {{- end }}

--- a/charts/streaming-hub/templates/_helpers.tpl
+++ b/charts/streaming-hub/templates/_helpers.tpl
@@ -1,0 +1,111 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "streaming-hub.name" -}}
+{{- default "streaming-hub" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec). When fullnameOverride is set it wins verbatim.
+*/}}
+{{- define "streaming-hub.fullname" -}}
+{{- default (include "streaming-hub.name" .) .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "streaming-hub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Resolve the image tag, falling back to the chart appVersion when image.tag is "".
+*/}}
+{{- define "streaming-hub.defaultTag" -}}
+{{- default .Chart.AppVersion .Values.streamingHub.image.tag }}
+{{- end -}}
+
+{{/*
+Return a valid version label value (k8s label charset).
+*/}}
+{{- define "streaming-hub.versionLabelValue" -}}
+{{ regexReplaceAll "[^-A-Za-z0-9_.]" (include "streaming-hub.defaultTag" .) "-" | trunc 63 | trimAll "-" | trimAll "_" | trimAll "." | quote }}
+{{- end -}}
+
+{{/*
+Component fully-qualified name: <fullname>-<component>.
+Input: dict { context, component }. Truncated to 63 chars.
+Used by every per-role Deployment/Service/HPA/PDB so the three role variants
+never collide on a name.
+*/}}
+{{- define "streaming-hub.componentFullname" -}}
+{{- $fullname := include "streaming-hub.fullname" .context -}}
+{{- printf "%s-%s" $fullname .component | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Base selector labels (no component).
+Input: dict { context }.
+*/}}
+{{- define "streaming-hub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "streaming-hub.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- end }}
+
+{{/*
+Component-aware selector labels: base labels + app.kubernetes.io/component.
+Input: dict { context, component }. The component label is the load-bearing
+discriminator that keeps split-mode (ingest/delivery) Deployments from sharing
+one ReplicaSet selector.
+*/}}
+{{- define "streaming-hub.componentSelectorLabels" -}}
+{{ include "streaming-hub.selectorLabels" (dict "context" .context) }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Component-aware common labels (selector labels + chart/version/managed-by/part-of).
+Input: dict { context, component }.
+*/}}
+{{- define "streaming-hub.labels" -}}
+helm.sh/chart: {{ include "streaming-hub.chart" .context }}
+{{ include "streaming-hub.componentSelectorLabels" (dict "context" .context "component" .component) }}
+app.kubernetes.io/version: {{ include "streaming-hub.versionLabelValue" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: streaming-hub
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "streaming-hub.serviceAccountName" -}}
+{{- if .Values.streamingHub.serviceAccount.create }}
+{{- default (include "streaming-hub.fullname" .) .Values.streamingHub.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.streamingHub.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
+*/}}
+{{- define "global.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Resolve the shared Secret name a Deployment should reference:
+existingSecretName when useExistingSecret, otherwise the shared chart Secret.
+Input: root context (.).
+*/}}
+{{- define "streaming-hub.secretName" -}}
+{{- if .Values.streamingHub.useExistingSecret -}}
+{{- required "streamingHub.existingSecretName is required when streamingHub.useExistingSecret=true" .Values.streamingHub.existingSecretName -}}
+{{- else -}}
+{{- include "streaming-hub.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/streaming-hub/templates/all/deployment.yaml
+++ b/charts/streaming-hub/templates/all/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.streamingHub.mode "all" }}
+{{- include "streaming-hub.deployment" (dict "root" . "component" "all") }}
+{{- end }}

--- a/charts/streaming-hub/templates/all/hpa.yaml
+++ b/charts/streaming-hub/templates/all/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if and (eq .Values.streamingHub.mode "all") .Values.streamingHub.all.autoscaling.enabled }}
+{{- include "streaming-hub.hpa" (dict "root" . "component" "all") }}
+{{- end }}

--- a/charts/streaming-hub/templates/all/pdb.yaml
+++ b/charts/streaming-hub/templates/all/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if and (eq .Values.streamingHub.mode "all") .Values.streamingHub.all.pdb.enabled }}
+{{- include "streaming-hub.pdb" (dict "root" . "component" "all") }}
+{{- end }}

--- a/charts/streaming-hub/templates/all/service.yaml
+++ b/charts/streaming-hub/templates/all/service.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.streamingHub.mode "all" }}
+{{- include "streaming-hub.service" (dict "root" . "component" "all") }}
+{{- end }}

--- a/charts/streaming-hub/templates/bootstrap-postgres.yaml
+++ b/charts/streaming-hub/templates/bootstrap-postgres.yaml
@@ -1,0 +1,147 @@
+{{- if .Values.global.externalPostgresDefinitions.enabled }}
+{{/*
+Bootstrap Job for an external/shared PostgreSQL host: creates the hub's ONE
+database + role and grants privileges. streaming-hub owns a SINGLE database with
+a tenant_id COLUMN (NOT per-tenant DB), so exactly one DB/role is provisioned.
+
+Default OFF. Whether dev-st uses this Job or a pre-provisioned managed PG is a
+Phase 3 decision — the chart supports both. The created DB/role name is
+configurable (defaults: db "streaming-hub", role "streaming-hub") and must match
+the host/dbname/user encoded in STREAMING_HUB_POSTGRES_DSN.
+*/}}
+{{- $defs := .Values.global.externalPostgresDefinitions -}}
+{{- $dbName := $defs.database | default "streaming-hub" -}}
+{{- $roleName := $defs.role | default "streaming-hub" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "streaming-hub.fullname" . }}-bootstrap-postgres
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" . "component" "bootstrap") | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ $defs.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ $defs.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: psql
+        image: postgres:17
+        env:
+        - name: DB_HOST
+          value: {{ $defs.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ $defs.connection.port | quote }}
+        - name: DB_NAME
+          value: {{ $dbName | quote }}
+        - name: DB_ROLE
+          value: {{ $roleName | quote }}
+        - name: DB_USER_ADMIN
+          {{- if $defs.postgresAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $defs.postgresAdminLogin.useExistingSecret.name | quote }}
+              key: DB_USER_ADMIN
+          {{- else }}
+          value: {{ $defs.postgresAdminLogin.username | quote }}
+          {{- end }}
+        - name: DB_ADMIN_PASSWORD
+          {{- if $defs.postgresAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $defs.postgresAdminLogin.useExistingSecret.name | quote }}
+              key: DB_ADMIN_PASSWORD
+          {{- else }}
+          value: {{ $defs.postgresAdminLogin.password | quote }}
+          {{- end }}
+        - name: DB_PASSWORD_HUB
+          {{- if $defs.hubCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $defs.hubCredentials.useExistingSecret.name | quote }}
+              key: DB_PASSWORD_HUB
+          {{- else }}
+          value: {{ $defs.hubCredentials.password | quote }}
+          {{- end }}
+        - name: DB_DATABASE
+          value: postgres
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== streaming-hub PostgreSQL Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT  Database: $DB_NAME  Role: $DB_ROLE"
+          echo ""
+
+          echo "Checking existing PostgreSQL objects..."
+          DB_EXISTS=0
+          ROLE_EXISTS=0
+
+          if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1; then
+            DB_EXISTS=1
+          fi
+          if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_roles WHERE rolname='$DB_ROLE'" | grep -q 1; then
+            ROLE_EXISTS=1
+          fi
+
+          if [ "$DB_EXISTS" = "1" ] && [ "$ROLE_EXISTS" = "1" ]; then
+            echo "PostgreSQL bootstrap already complete (database '$DB_NAME' and role '$DB_ROLE' exist). Skipping creation."
+          else
+            # Create role if not exists
+            if [ "$ROLE_EXISTS" = "1" ]; then
+              echo "Role '$DB_ROLE' already exists. Skipping creation."
+            else
+              echo "Creating role '$DB_ROLE'..."
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE \"$DB_ROLE\" LOGIN PASSWORD '$DB_PASSWORD_HUB'"
+            fi
+
+            # Create database if not exists
+            if [ "$DB_EXISTS" = "1" ]; then
+              echo "Database '$DB_NAME' already exists. Skipping creation."
+            else
+              echo "Creating database '$DB_NAME'..."
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE DATABASE \"$DB_NAME\" OWNER \"$DB_ROLE\""
+            fi
+          fi
+
+          # Privileges (safe to run repeatedly)
+          echo "Ensuring privileges and schema permissions..."
+          PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "GRANT ALL PRIVILEGES ON DATABASE \"$DB_NAME\" TO \"$DB_ROLE\""
+          PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_NAME" -c "GRANT ALL ON SCHEMA public TO \"$DB_ROLE\""
+          PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \"$DB_ROLE\""
+          PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_NAME" -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO \"$DB_ROLE\""
+          PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO \"$DB_ROLE\""
+          PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO \"$DB_ROLE\""
+
+          echo ""
+          echo "=== streaming-hub PostgreSQL Bootstrap completed successfully ==="
+{{- end }}

--- a/charts/streaming-hub/templates/bootstrap-postgres.yaml
+++ b/charts/streaming-hub/templates/bootstrap-postgres.yaml
@@ -98,6 +98,13 @@ spec:
         - -c
         - |
           set -euo pipefail
+          # Escape single quotes so values embedded in SQL string literals can't
+          # break the statement (a Vault-generated password legitimately may
+          # contain a ' — that would otherwise abort CREATE ROLE).
+          sql_lit() { printf "%s" "$1" | sed "s/'/''/g"; }
+          DB_NAME_LIT="$(sql_lit "$DB_NAME")"
+          DB_ROLE_LIT="$(sql_lit "$DB_ROLE")"
+          DB_PASSWORD_HUB_LIT="$(sql_lit "$DB_PASSWORD_HUB")"
           echo "=== streaming-hub PostgreSQL Bootstrap ==="
           echo "Host: $DB_HOST:$DB_PORT  Database: $DB_NAME  Role: $DB_ROLE"
           echo ""
@@ -106,10 +113,10 @@ spec:
           DB_EXISTS=0
           ROLE_EXISTS=0
 
-          if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1; then
+          if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_database WHERE datname='${DB_NAME_LIT}'" | grep -q 1; then
             DB_EXISTS=1
           fi
-          if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_roles WHERE rolname='$DB_ROLE'" | grep -q 1; then
+          if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_roles WHERE rolname='${DB_ROLE_LIT}'" | grep -q 1; then
             ROLE_EXISTS=1
           fi
 
@@ -121,7 +128,7 @@ spec:
               echo "Role '$DB_ROLE' already exists. Skipping creation."
             else
               echo "Creating role '$DB_ROLE'..."
-              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE \"$DB_ROLE\" LOGIN PASSWORD '$DB_PASSWORD_HUB'"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE \"$DB_ROLE\" LOGIN PASSWORD '${DB_PASSWORD_HUB_LIT}'"
             fi
 
             # Create database if not exists

--- a/charts/streaming-hub/templates/configmap.yaml
+++ b/charts/streaming-hub/templates/configmap.yaml
@@ -1,0 +1,23 @@
+{{/*
+ONE shared ConfigMap — role-INVARIANT, non-sensitive env. Identical across all
+roles, so it is NOT duplicated per role (DRY). The role-specific vars
+(STREAMING_HUB_ROLE, the Postgres pool sizes) are deliberately ABSENT here —
+they are injected as explicit per-Deployment env in templates/<role>/deployment.yaml
+(see templates/_deployment.tpl), which wins over this envFrom layer.
+
+Ranged over .Values.streamingHub.common.configmap so operators can add/override
+keys without editing this template. Every key in that map MUST exist verbatim in
+streaming-hub/.env.reference (the env-parity cross-check enforces this); OTEL_*
+keys are the documented exception (lib-observability vars, not LoadConfig vars).
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "streaming-hub.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" . "component" "all") | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.streamingHub.common.configmap }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/streaming-hub/templates/delivery/deployment.yaml
+++ b/charts/streaming-hub/templates/delivery/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.streamingHub.mode "split" }}
+{{- include "streaming-hub.deployment" (dict "root" . "component" "delivery") }}
+{{- end }}

--- a/charts/streaming-hub/templates/delivery/hpa.yaml
+++ b/charts/streaming-hub/templates/delivery/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if and (eq .Values.streamingHub.mode "split") .Values.streamingHub.delivery.autoscaling.enabled }}
+{{- include "streaming-hub.hpa" (dict "root" . "component" "delivery") }}
+{{- end }}

--- a/charts/streaming-hub/templates/delivery/pdb.yaml
+++ b/charts/streaming-hub/templates/delivery/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if and (eq .Values.streamingHub.mode "split") .Values.streamingHub.delivery.pdb.enabled }}
+{{- include "streaming-hub.pdb" (dict "root" . "component" "delivery") }}
+{{- end }}

--- a/charts/streaming-hub/templates/delivery/service.yaml
+++ b/charts/streaming-hub/templates/delivery/service.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.streamingHub.mode "split" }}
+{{- include "streaming-hub.service" (dict "root" . "component" "delivery") }}
+{{- end }}

--- a/charts/streaming-hub/templates/ingest/deployment.yaml
+++ b/charts/streaming-hub/templates/ingest/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.streamingHub.mode "split" }}
+{{- include "streaming-hub.deployment" (dict "root" . "component" "ingest") }}
+{{- end }}

--- a/charts/streaming-hub/templates/ingest/hpa.yaml
+++ b/charts/streaming-hub/templates/ingest/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if and (eq .Values.streamingHub.mode "split") .Values.streamingHub.ingest.autoscaling.enabled }}
+{{- include "streaming-hub.hpa" (dict "root" . "component" "ingest") }}
+{{- end }}

--- a/charts/streaming-hub/templates/ingest/pdb.yaml
+++ b/charts/streaming-hub/templates/ingest/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if and (eq .Values.streamingHub.mode "split") .Values.streamingHub.ingest.pdb.enabled }}
+{{- include "streaming-hub.pdb" (dict "root" . "component" "ingest") }}
+{{- end }}

--- a/charts/streaming-hub/templates/ingest/service.yaml
+++ b/charts/streaming-hub/templates/ingest/service.yaml
@@ -1,0 +1,3 @@
+{{- if eq .Values.streamingHub.mode "split" }}
+{{- include "streaming-hub.service" (dict "root" . "component" "ingest") }}
+{{- end }}

--- a/charts/streaming-hub/templates/ingress.yaml
+++ b/charts/streaming-hub/templates/ingress.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.streamingHub.ingress.enabled }}
+{{/*
+Control-plane API ingress (default OFF; opt-in per env in gitops).
+Backend Service is the active role's component Service:
+  - mode=all    -> the `all` Service.
+  - mode=split  -> the `ingest` Service (the control API is served on EVERY role,
+                   so ingest is an arbitrary-but-stable default; override the
+                   backend by editing this template if delivery is preferred).
+*/}}
+{{- $component := ternary "all" "ingest" (eq .Values.streamingHub.mode "all") -}}
+{{- $svcName := include "streaming-hub.componentFullname" (dict "context" . "component" $component) -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "streaming-hub.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" . "component" $component) | nindent 4 }}
+  {{- with .Values.streamingHub.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.streamingHub.ingress.className }}
+  ingressClassName: {{ .Values.streamingHub.ingress.className }}
+  {{- end }}
+  {{- if .Values.streamingHub.ingress.tls }}
+  tls:
+    {{- range .Values.streamingHub.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.streamingHub.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $.Values.streamingHub.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/streaming-hub/templates/secrets.yaml
+++ b/charts/streaming-hub/templates/secrets.yaml
@@ -1,0 +1,28 @@
+{{/*
+ONE shared Opaque Secret — role-INVARIANT sensitive env. Identical across all
+roles, so it is NOT duplicated per role.
+
+Rendered ONLY when NOT useExistingSecret. When useExistingSecret=true (the
+gitops/Vault path) this emits nothing and the Deployments reference
+existingSecretName instead — that branch is exercised by the chart and MUST stay
+working.
+
+Empty values are SKIPPED so unset SaaS/dev keys never ship as blank Secret
+entries. Values are base64-encoded into `data` (b64enc).
+*/}}
+{{- if not .Values.streamingHub.useExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "streaming-hub.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" . "component" "all") | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.streamingHub.secrets }}
+  {{- if $value }}
+  {{ $key }}: {{ $value | toString | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/streaming-hub/templates/serviceaccount.yaml
+++ b/charts/streaming-hub/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.streamingHub.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "streaming-hub.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "streaming-hub.labels" (dict "context" . "component" "all") | nindent 4 }}
+  {{- with .Values.streamingHub.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/streaming-hub/values-template.yaml
+++ b/charts/streaming-hub/values-template.yaml
@@ -1,0 +1,50 @@
+# streaming-hub — operator override template.
+#
+# Copy this file, fill the blanks per environment, and pass it with `-f`.
+# It documents only the keys an operator typically sets; every other key keeps
+# the default from values.yaml. See README "Chart Contract" for the full
+# secret/dependency/override contract. Secrets are blank here — provide them
+# inline or via `useExistingSecret` + `existingSecretName`.
+
+streamingHub:
+  # Topology: `all` (one Deployment) or `split` (ingest + delivery). Never both
+  # — the roles compete for one Kafka consumer group. See README.
+  mode: all
+
+  image:
+    tag: ""  # defaults to the chart appVersion
+
+  common:
+    configmap:
+      STREAMING_HUB_ENV: production          # local | staging | production
+      STREAMING_HUB_LOG_LEVEL: info
+      STREAMING_HUB_KAFKA_BROKERS: ""         # e.g. redpanda.dev-st.lerian.net:9092
+      STREAMING_HUB_KAFKA_SCRAM_MECHANISM: "" # e.g. SCRAM-SHA-256 (empty = no SASL)
+      STREAMING_HUB_ALLOW_INSECURE_KAFKA: "false"
+      STREAMING_HUB_KEK_SOURCE: ""            # env | aws-kms | ...
+      PLUGIN_AUTH_ENABLED: "true"
+      PLUGIN_AUTH_ADDRESS: ""
+      STREAMING_HUB_TENANT_ID: default
+      STREAMING_HUB_MULTI_TENANT_ENABLED: "false"
+
+  secrets:
+    STREAMING_HUB_POSTGRES_DSN: ""            # full Postgres DSN, credentials embedded
+    STREAMING_HUB_KAFKA_SCRAM_USERNAME: ""
+    STREAMING_HUB_KAFKA_SCRAM_PASSWORD: ""
+    STREAMING_HUB_KEK_REF: ""                 # KEK reference (KMS key id / ARN / ...)
+    # STREAMING_HUB_DEV_KEK: ""               # dev only
+    # SaaS-only — required when MULTI_TENANT_ENABLED=true:
+    # STREAMING_HUB_TENANT_MANAGER_SERVICE_API_KEY: ""
+    # STREAMING_HUB_MULTI_TENANT_REDIS_PASSWORD: ""
+
+  useExistingSecret: false
+  existingSecretName: ""
+
+  # Per-role sizing. Honor Σ(replicas × poolMaxOpenConns) ≤ Postgres max_connections.
+  all:
+    replicaCount: 1
+  # mode: split uses these instead:
+  # ingest:
+  #   replicaCount: 2
+  # delivery:
+  #   replicaCount: 2

--- a/charts/streaming-hub/values.schema.json
+++ b/charts/streaming-hub/values.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "streamingHub": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["all", "split"],
+          "description": "Topology switch. 'all' = one Deployment (role=all); 'split' = ingest + delivery. NEVER run both against one Kafka cluster (double-consume)."
+        },
+        "common": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "configmap": {
+              "type": "object"
+            }
+          }
+        },
+        "secrets": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/charts/streaming-hub/values.yaml
+++ b/charts/streaming-hub/values.yaml
@@ -149,14 +149,20 @@ streamingHub:
     annotations: {}
     # -- ServiceAccount name. Empty defaults to the chart fullname.
     name: ""
+    # -- Mount the SA API token into pods. Default false — the hub makes no
+    #    in-cluster Kubernetes API calls. (IRSA's projected token is injected by
+    #    the EKS webhook independently of this, so it stays functional.)
+    automountServiceAccountToken: false
 
-  # -- Graceful-shutdown window. MUST exceed the SIGTERM drain budget:
-  #    the hub's derived drain ceiling at STREAMING_HUB_SHUTDOWN_TIMEOUT=30s +
-  #    STREAMING_HUB_PRE_STOP_DRAIN_TIMEOUT=5s is ~80s (see .env.reference).
-  #    Raise this knob to AT LEAST that ceiling so the orchestrator never
-  #    SIGKILLs a still-draining replica. NO preStop hook is used — the hub
-  #    self-drains on SIGTERM (PID 1 receives it directly; exec-form ENTRYPOINT).
-  terminationGracePeriodSeconds: 30
+  # -- Graceful-shutdown window. Defaults to the hub's derived SIGTERM drain
+  #    ceiling (80s) at STREAMING_HUB_SHUTDOWN_TIMEOUT=30s +
+  #    STREAMING_HUB_PRE_STOP_DRAIN_TIMEOUT=5s: 30s HTTP + 5s consumer-commit +
+  #    30s dispatcher + 10s slack = 75s, + 5s pre-stop = 80s (see .env.reference).
+  #    If you tune those knobs up, recompute and keep this AT OR ABOVE the new
+  #    ceiling so the orchestrator never SIGKILLs a still-draining replica. NO
+  #    preStop hook is used — the hub self-drains on SIGTERM (PID 1 receives it
+  #    directly; exec-form ENTRYPOINT).
+  terminationGracePeriodSeconds: 80
 
   # -- Liveness probe tuning (GET /healthz on the http port; stays 200 during drain).
   livenessProbe:

--- a/charts/streaming-hub/values.yaml
+++ b/charts/streaming-hub/values.yaml
@@ -1,0 +1,398 @@
+# Default values for streaming-hub.
+# This is a YAML-formatted file.
+#
+# streaming-hub consumes lib-streaming CloudEvents from Kafka/Redpanda and fans
+# them out to per-tenant subscribers. ONE image, ONE binary, RUNTIME-selected
+# into a role via STREAMING_HUB_ROLE. This chart exposes that via a single
+# `mode` switch (see streamingHub.mode below).
+#
+# External infra (provisioned OUTSIDE this chart): Kafka/Redpanda and PostgreSQL.
+# There are NO database/broker/OTEL subcharts (deliberate — see Chart.yaml).
+
+# -- Override the chart name component of resource names.
+nameOverride: ""
+# -- Override the fully-qualified release name (wins verbatim).
+fullnameOverride: ""
+# -- Override the namespace (defaults to .Release.Namespace).
+namespaceOverride: ""
+
+global:
+  # -- Bootstrap Job for an external/shared PostgreSQL: creates the hub's ONE
+  #    database + role and grants privileges. The hub owns a SINGLE database with
+  #    a tenant_id column (NOT per-tenant DB). Default OFF — dev-st may instead
+  #    point STREAMING_HUB_POSTGRES_DSN at a pre-provisioned managed host.
+  externalPostgresDefinitions:
+    # -- Enable or disable the PostgreSQL bootstrap Job.
+    enabled: false
+    # -- Name of the database the Job creates (must match the DSN dbname).
+    database: "streaming-hub"
+    # -- Name of the login role the Job creates (must match the DSN user).
+    role: "streaming-hub"
+    # -- PostgreSQL connection settings for the bootstrap Job.
+    connection:
+      # -- PostgreSQL host.
+      host: "streaming-hub-postgresql"
+      # -- PostgreSQL port.
+      port: "5432"
+    # -- Admin credentials used by the Job to create the DB/role.
+    postgresAdminLogin:
+      useExistingSecret:
+        # -- Existing secret with DB_USER_ADMIN and DB_ADMIN_PASSWORD keys.
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set).
+      username: "postgres"
+      # -- Admin password (ignored if useExistingSecret.name is set).
+      password: ""
+    # -- Credentials for the hub role created by the Job.
+    hubCredentials:
+      useExistingSecret:
+        # -- Existing secret with DB_PASSWORD_HUB key.
+        name: ""
+      # -- Password for the hub role (ignored if useExistingSecret.name is set).
+      password: ""
+
+# =============================================================================
+# streamingHub — the single root key for everything the hub owns.
+# =============================================================================
+streamingHub:
+  # -- Deployment topology switch. One of: all | split.
+  #    all   (default) -> ONE Deployment with STREAMING_HUB_ROLE=all (ingest +
+  #          delivery co-resident; the dev-st target). Byte-equivalent to the
+  #          historical single binary.
+  #    split           -> TWO Deployments: ingest (role=ingest) and delivery
+  #          (role=delivery), each scaled independently.
+  #
+  #    !!! NEVER run both an `all` Deployment AND ingest/delivery against the same
+  #    Kafka cluster: they join ONE consumer group and DOUBLE-CONSUME every event.
+  #    The mode switch enforces either/or — do not work around it. !!!
+  #    The values.schema.json constrains this to the enum ["all","split"].
+  mode: all
+
+  image:
+    # -- Container image repository.
+    repository: ghcr.io/lerianstudio/streaming-hub
+    # -- Image pull policy.
+    pullPolicy: IfNotPresent
+    # -- Image tag. Empty falls back to Chart.appVersion via the defaultTag helper.
+    tag: ""
+
+  # -- Secrets for pulling the image from a private registry.
+  imagePullSecrets:
+    - name: ghcr-credential
+
+  # -- Number of old ReplicaSets to retain for rollback.
+  revisionHistoryLimit: 10
+
+  # -- Annotations applied to every Deployment resource.
+  annotations: {}
+  # -- Annotations applied to every pod.
+  podAnnotations: {}
+
+  # -- Deployment update strategy (shared by all roles).
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  # -- Pod-level security context. Empty by default (the hub needs no fsGroup).
+  podSecurityContext: {}
+
+  # -- Container-level security context (distroless:nonroot, uid/gid 65532).
+  securityContext:
+    # -- Group ID for the process inside the container.
+    runAsGroup: 65532
+    # -- User ID for the process inside the container.
+    runAsUser: 65532
+    # -- Never run as root.
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+    # -- Read-only root filesystem (the image carries no writable state).
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+
+  service:
+    # -- Service type. MUST be ClusterIP (Lerian convention; Ingress fronts external).
+    type: ClusterIP
+    # -- Control-plane HTTP port (the hub listens on :8080; see Dockerfile EXPOSE).
+    port: 8080
+    # -- Annotations for every Service.
+    annotations: {}
+
+  ingress:
+    # -- Enable or disable the control-plane Ingress (opt-in per env in gitops).
+    enabled: false
+    # -- Ingress class name.
+    className: "nginx"
+    # -- Additional ingress annotations.
+    annotations: {}
+    # -- Hosts (default empty; the control API is served on every role).
+    hosts: []
+    #  - host: "streaming-hub.lerian.net"
+    #    paths:
+    #      - path: /
+    #        pathType: Prefix
+    # -- TLS configuration.
+    tls: []
+    #  - secretName: streaming-hub-tls
+    #    hosts:
+    #      - streaming-hub.lerian.net
+
+  serviceAccount:
+    # -- Whether a ServiceAccount is created.
+    create: true
+    # -- Annotations for the ServiceAccount (e.g. AWS IRSA role-arn).
+    annotations: {}
+    # -- ServiceAccount name. Empty defaults to the chart fullname.
+    name: ""
+
+  # -- Graceful-shutdown window. MUST exceed the SIGTERM drain budget:
+  #    the hub's derived drain ceiling at STREAMING_HUB_SHUTDOWN_TIMEOUT=30s +
+  #    STREAMING_HUB_PRE_STOP_DRAIN_TIMEOUT=5s is ~80s (see .env.reference).
+  #    Raise this knob to AT LEAST that ceiling so the orchestrator never
+  #    SIGKILLs a still-draining replica. NO preStop hook is used — the hub
+  #    self-drains on SIGTERM (PID 1 receives it directly; exec-form ENTRYPOINT).
+  terminationGracePeriodSeconds: 30
+
+  # -- Liveness probe tuning (GET /healthz on the http port; stays 200 during drain).
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  # -- Readiness probe tuning (GET /readyz; flips NotReady first on SIGTERM).
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+
+  # -- Shared default scheduling (per-role blocks may override).
+  nodeSelector: {}
+  tolerations: {}
+  affinity: {}
+
+  # -- Extra non-sensitive env vars injected on every Deployment (list of {name,value}).
+  extraEnvVars: []
+
+  # ===========================================================================
+  # telemetry — CHART-LEVEL OTEL wiring toggle (NOT an app env var; never shipped
+  # to the container). When enabled, each Deployment injects HOST_IP via the
+  # downward API and sets OTEL_EXPORTER_OTLP_ENDPOINT=$(HOST_IP):4317 (node-local
+  # DaemonSet collector pattern; see templates/_deployment.tpl). The hub's own
+  # Prometheus exposition is governed by STREAMING_HUB_METRICS_ENABLED in the
+  # ConfigMap above — a separate, app-read knob.
+  # ===========================================================================
+  telemetry:
+    # -- Inject the per-pod OTLP endpoint override (HOST_IP downward API).
+    enabled: false
+
+  # ===========================================================================
+  # Secret sourcing.
+  # useExistingSecret=false -> the chart renders templates/secret.yaml (inline).
+  # useExistingSecret=true  -> NO Secret is rendered; Deployments reference
+  #                            existingSecretName (the gitops/Vault path).
+  # ===========================================================================
+  useExistingSecret: false
+  existingSecretName: ""
+
+  # ===========================================================================
+  # common.configmap — role-INVARIANT, NON-SENSITIVE env (one shared ConfigMap).
+  # Every key MUST exist verbatim in streaming-hub/.env.reference, EXCEPT the
+  # OTEL_* keys (lib-observability vars, not read by LoadConfig).
+  #
+  # DELIBERATELY ABSENT (injected per-Deployment, see the all/ingest/delivery
+  # blocks below): STREAMING_HUB_ROLE, STREAMING_HUB_POSTGRES_MAX_OPEN_CONNS,
+  # STREAMING_HUB_POSTGRES_MAX_IDLE_CONNS.
+  # ===========================================================================
+  common:
+    configmap:
+      # --- core ---
+      # Deployment environment: local | staging | production.
+      STREAMING_HUB_ENV: "production"
+      STREAMING_HUB_LOG_LEVEL: "info"
+      STREAMING_HUB_HTTP_LISTEN_ADDR: ":8080"
+      STREAMING_HUB_METRICS_ENABLED: "true"
+
+      # --- kafka / redpanda (external) ---
+      STREAMING_HUB_KAFKA_BROKERS: "localhost:19092"
+      STREAMING_HUB_KAFKA_SCRAM_MECHANISM: ""
+      # Plaintext Kafka opt-in. MUST stay "false" for staging/production
+      # (rejected at boot when STREAMING_HUB_ENV=production).
+      STREAMING_HUB_ALLOW_INSECURE_KAFKA: "false"
+
+      # --- crypto / KEK (the material itself is a Secret) ---
+      # env | secretsmanager. KEK material arrives via the var named by KEK_REF.
+      STREAMING_HUB_KEK_SOURCE: "env"
+
+      # --- auth (lib-auth / plugin-auth JWT; PLUGIN_AUTH_ prefix, NOT STREAMING_HUB_) ---
+      PLUGIN_AUTH_ENABLED: "true"
+      PLUGIN_AUTH_ADDRESS: "http://plugin-access-manager-auth:4000"
+
+      # --- tenancy (F4) ---
+      # default = BYOC single-tenant. A non-default value quarantines all
+      # other ce-tenantid events (zero-delivery risk) — confirm the producer.
+      STREAMING_HUB_TENANT_ID: "default"
+      # SaaS roster off by default (BYOC). When "true" the SaaS-only knobs below
+      # become required-when-SaaS (and several SECRET counterparts in secrets:).
+      STREAMING_HUB_MULTI_TENANT_ENABLED: "false"
+      STREAMING_HUB_TENANT_MANAGER_URL: ""
+      STREAMING_HUB_MULTI_TENANT_ALLOW_INSECURE_TM: "false"
+      STREAMING_HUB_MULTI_TENANT_TM_STALENESS_THRESHOLD: "12h"
+      STREAMING_HUB_MULTI_TENANT_LISTENER_STALENESS_THRESHOLD: "12h"
+      STREAMING_HUB_MULTI_TENANT_RECONCILE_INTERVAL: "6h"
+      STREAMING_HUB_MULTI_TENANT_CACHE_TTL: "12h"
+      STREAMING_HUB_TENANT_MANAGER_CB_THRESHOLD: "0"
+      STREAMING_HUB_TENANT_MANAGER_CB_TIMEOUT: "30s"
+      STREAMING_HUB_MULTI_TENANT_REDIS_HOST: ""
+      STREAMING_HUB_MULTI_TENANT_REDIS_PORT: ""
+      STREAMING_HUB_MULTI_TENANT_REDIS_TLS: "false"
+      STREAMING_HUB_MULTI_TENANT_REDIS_CA_CERT: ""
+      # lib-commons env name (NOT STREAMING_HUB_-prefixed). Required-in-SaaS:
+      # staging | production. Inert under BYOC. Leave empty unless SaaS.
+      ENVIRONMENT_NAME: ""
+
+      # --- reconciler (topic-drift detection; dark-ship, defaults on) ---
+      STREAMING_HUB_RECONCILER_ENABLED: "true"
+      STREAMING_HUB_RECONCILER_INTERVAL: "300"
+
+      # --- partition lifecycle cron ---
+      STREAMING_HUB_PARTITION_CRON_INTERVAL: "6h"
+      STREAMING_HUB_PARTITION_FUTURE_BUFFER_WEEKS: "4"
+      STREAMING_HUB_PARTITION_RETENTION_ENABLED: "false"
+      STREAMING_HUB_PARTITION_RETENTION_HORIZON: "0"
+
+      # --- DLQ visibility ---
+      STREAMING_HUB_DLQ_RETENTION: "168h"
+      STREAMING_HUB_DLQ_PRUNE_INTERVAL: "1h"
+
+      # --- lifecycle / drain (kept coherent with terminationGracePeriodSeconds) ---
+      STREAMING_HUB_SHUTDOWN_TIMEOUT: "30s"
+      STREAMING_HUB_PRE_STOP_DRAIN_TIMEOUT: "5s"
+
+      # --- observability (OTEL_* are lib-observability vars, NOT in .env.reference) ---
+      # OTEL_EXPORTER_OTLP_ENDPOINT is overridden per-pod with $(HOST_IP):4317 via
+      # the downward API when streamingHub.telemetry.enabled=true (a CHART-level
+      # toggle, see above — not an app env var; see templates/_deployment.tpl).
+      OTEL_LIBRARY_NAME: "github.com/LerianStudio/streaming-hub"
+      OTEL_RESOURCE_SERVICE_NAME: "streaming-hub"
+      OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
+      OTEL_EXPORTER_OTLP_ENDPOINT: ""
+
+  # ===========================================================================
+  # secrets — role-INVARIANT, SENSITIVE env (one shared Secret). All default "".
+  # Empty values are SKIPPED at render so unset SaaS/dev keys never ship blank.
+  # In gitops these come from Vault via useExistingSecret=true (this map is then
+  # unused). Every key exists verbatim in streaming-hub/.env.reference.
+  # ===========================================================================
+  secrets:
+    # Single hub-owned Postgres DSN (password embedded -> whole DSN is secret).
+    STREAMING_HUB_POSTGRES_DSN: ""
+    # SASL/SCRAM credentials (required when KAFKA_SCRAM_MECHANISM is set).
+    STREAMING_HUB_KAFKA_SCRAM_USERNAME: ""
+    STREAMING_HUB_KAFKA_SCRAM_PASSWORD: ""
+    # KEK reference: the NAME of the env var holding the KEK material.
+    STREAMING_HUB_KEK_REF: ""
+    # DEV-ONLY KEK material holder (local BYOC). Leave empty in real deploys.
+    STREAMING_HUB_DEV_KEK: ""
+    # SaaS tenant-manager X-API-Key (required-when-SaaS).
+    STREAMING_HUB_TENANT_MANAGER_SERVICE_API_KEY: ""
+    # SaaS tenant pub/sub Redis AUTH password (optional even in SaaS).
+    STREAMING_HUB_MULTI_TENANT_REDIS_PASSWORD: ""
+
+  # ===========================================================================
+  # Per-role blocks. Each carries replicaCount, resources, autoscaling, pdb, and
+  # the Postgres pool sizing injected as explicit per-Deployment env.
+  #
+  # !!! CONNECTION-BUDGET INVARIANT (the load-bearing operational rule) !!!
+  #   Σ over all running pods of (replicas × poolMaxOpenConns) + headroom
+  #     ≤ PostgreSQL max_connections.
+  #   Under HPA, use maxReplicas (not replicaCount) in the sum. Every open
+  #   connection on every pod draws from the ONE shared Postgres budget.
+  #   NEVER run mode=all alongside split — see streamingHub.mode.
+  # Pool defaults (from .env.reference): all 25/12, ingest 8/4, delivery 16/10.
+  # ===========================================================================
+  all:
+    replicaCount: 1
+    poolMaxOpenConns: 25
+    poolMaxIdleConns: 12
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    autoscaling:
+      # -- HPA off by default; replicaCount governs. maxReplicas × poolMaxOpenConns
+      #    must respect the connection-budget invariant above.
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
+    pdb:
+      enabled: false
+      minAvailable: 1
+      annotations: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}
+
+  ingest:
+    replicaCount: 1
+    poolMaxOpenConns: 8
+    poolMaxIdleConns: 4
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      # -- maxReplicas × 8 (poolMaxOpenConns) must fit the connection budget.
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
+    pdb:
+      enabled: false
+      minAvailable: 1
+      annotations: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}
+
+  delivery:
+    replicaCount: 1
+    poolMaxOpenConns: 16
+    poolMaxIdleConns: 10
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      # -- maxReplicas × 16 (poolMaxOpenConns) must fit the connection budget.
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
+    pdb:
+      enabled: false
+      minAvailable: 1
+      annotations: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}


### PR DESCRIPTION
## What

Adds the Helm chart for **streaming-hub** (`charts/streaming-hub/`) — the service that consumes `lib-streaming` CloudEvents from Kafka/Redpanda and fans them out to per-tenant SaaS/BYOC subscribers. New chart, 26 files, no existing chart touched.

Built on the `go-boilerplate-ddd` template + the `reporter` per-role multi-component convention.

## Topology — the one non-obvious decision

streaming-hub's binary selects a runtime role via `STREAMING_HUB_ROLE ∈ {all, ingest, delivery}`. `all` = ingest+delivery in one process, so the three roles **compete for the same Kafka consumer group** — enabling them together = double-consume. The chart models this with a single switch:

- `streamingHub.mode: all` (default) → **one** Deployment (`role=all`).
- `streamingHub.mode: split` → **two** Deployments (`ingest` + `delivery`), each with its own replicas/HPA/PDB and Postgres pool sizing.

A `values.schema.json` enum on `mode` rejects any other value at template time. One shared ConfigMap + one shared Secret serve all roles; the role-specific vars (`STREAMING_HUB_ROLE`, pool sizing) are injected as explicit per-Deployment `env:` which wins over `envFrom` — no per-role config duplication.

## Notable

- Probes `/healthz` (liveness) + `/readyz` (readiness); distroless nonroot 65532, RO rootfs, drop ALL, RuntimeDefault.
- SIGTERM self-drain → no preStop hook; `terminationGracePeriodSeconds` documented to exceed the drain budget.
- **No bundled subcharts** — Kafka/Redpanda + PostgreSQL are external shared infra; OTEL is env-wired (`HOST_IP:4317`). Optional `bootstrap-postgres` Job provisions the hub's single DB.
- Connection-budget invariant `Σ(replicas × poolMaxOpenConns) ≤ max_connections` documented on values + the HPA template.

## Verified locally

- `helm lint` clean.
- `helm template` renders correctly for **both** `mode=all` (1 Deploy/1 Svc) and `mode=split` (2 Deploy/2 Svc, distinct component selectors, ingest pool 8 / delivery pool 16).
- Schema enum rejects `mode=bogus`; `useExistingSecret` emits no Secret.
- Every `STREAMING_HUB_*` / `PLUGIN_AUTH_*` key verified 1:1 against `streaming-hub/.env.reference` (0 missing).
- Repo chart-standard validator green: `validate-helm-charts --strict` (0 violations) **and** `--render-gate` (`render-ok`).

## PR sequencing (1 of 2)

This is **PR 1**. On merge to `develop`, `release.yml` publishes `oci://ghcr.io/lerianstudio/streaming-hub-helm:<version>`.

**PR 2** (in `lerian-internal-gitops`, deploying to benedita `dev-st`) is **blocked** on this PR merging + publishing, since it references the chart by OCI version. I'll cross-link PR 2 here once it's open.

https://claude.ai/code/session_016Bv8y35GWdpgNdhGVs28JZ