### PR TITLE
fix(charts): escape dynamic values in bootstrap-postgres SQL

### DIFF
--- a/charts/go-boilerplate-ddd/templates/bootstrap-postgres.yaml
+++ b/charts/go-boilerplate-ddd/templates/bootstrap-postgres.yaml
@@ -104,7 +104,7 @@ spec:
               echo "Role 'go-boilerplate-ddd' already exists. Skipping creation."
             else
               echo "Creating role 'go-boilerplate-ddd'..."
-              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE \"go-boilerplate-ddd\" LOGIN PASSWORD '$DB_PASSWORD_BOILERPLATE'"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -v pw="$DB_PASSWORD_BOILERPLATE" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE \"go-boilerplate-ddd\" LOGIN PASSWORD :'pw'"
             fi
 
             # Create database if not exists

--- a/charts/matcher/templates/bootstrap-postgres.yaml
+++ b/charts/matcher/templates/bootstrap-postgres.yaml
@@ -104,7 +104,7 @@ spec:
               echo "Role 'matcher' already exists. Skipping creation."
             else
               echo "Creating role 'matcher'..."
-              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE matcher LOGIN PASSWORD '$DB_PASSWORD_MATCHER'"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -v pw="$DB_PASSWORD_MATCHER" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE matcher LOGIN PASSWORD :'pw'"
             fi
 
             # Create database if not exists

--- a/charts/midaz/templates/bootstrap-postgres.yaml
+++ b/charts/midaz/templates/bootstrap-postgres.yaml
@@ -119,7 +119,7 @@ spec:
             echo "Role 'midaz' already exists. Skipping creation."
           else
             echo "Creating role 'midaz'..."
-            PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE midaz LOGIN PASSWORD '$DB_PASSWORD_MIDAZ'"
+            PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -v pw="$DB_PASSWORD_MIDAZ" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE midaz LOGIN PASSWORD :'pw'"
           fi
 
           # Privileges (safe to run repeatedly)

--- a/charts/plugin-br-payments/templates/bootstrap-postgres.yaml
+++ b/charts/plugin-br-payments/templates/bootstrap-postgres.yaml
@@ -94,10 +94,10 @@ spec:
               DB_EXISTS=0
               ROLE_EXISTS=0
 
-              if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_database WHERE datname='$APP_DB'" | grep -q 1; then
+              if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -v db="$APP_DB" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_database WHERE datname=:'db'" | grep -q 1; then
                 DB_EXISTS=1
               fi
-              if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_roles WHERE rolname='$APP_ROLE'" | grep -q 1; then
+              if PGPASSWORD="$DB_ADMIN_PASSWORD" psql -At -v ON_ERROR_STOP=1 -v role="$APP_ROLE" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_roles WHERE rolname=:'role'" | grep -q 1; then
                 ROLE_EXISTS=1
               fi
 

--- a/charts/plugin-br-pix-switch/templates/bootstrap-postgres.yaml
+++ b/charts/plugin-br-pix-switch/templates/bootstrap-postgres.yaml
@@ -105,10 +105,10 @@ spec:
               ROLE_EXISTS=0
               DB_EXISTS=0
 
-              if PGPASSWORD="${DB_ADMIN_PASSWORD}" psql -At -v ON_ERROR_STOP=1 -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER_ADMIN}" -d "${DB_DATABASE}" -c "SELECT 1 FROM pg_roles WHERE rolname='${DB_ROLE}'" | grep -q 1; then
+              if PGPASSWORD="${DB_ADMIN_PASSWORD}" psql -At -v ON_ERROR_STOP=1 -v role="${DB_ROLE}" -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER_ADMIN}" -d "${DB_DATABASE}" -c "SELECT 1 FROM pg_roles WHERE rolname=:'role'" | grep -q 1; then
                 ROLE_EXISTS=1
               fi
-              if PGPASSWORD="${DB_ADMIN_PASSWORD}" psql -At -v ON_ERROR_STOP=1 -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER_ADMIN}" -d "${DB_DATABASE}" -c "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1; then
+              if PGPASSWORD="${DB_ADMIN_PASSWORD}" psql -At -v ON_ERROR_STOP=1 -v db="${DB_NAME}" -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER_ADMIN}" -d "${DB_DATABASE}" -c "SELECT 1 FROM pg_database WHERE datname=:'db'" | grep -q 1; then
                 DB_EXISTS=1
               fi
 

--- a/charts/tracer/templates/bootstrap-postgres.yaml
+++ b/charts/tracer/templates/bootstrap-postgres.yaml
@@ -104,7 +104,7 @@ spec:
               echo "Role 'tracer' already exists. Skipping creation."
             else
               echo "Creating role 'tracer'..."
-              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE tracer LOGIN PASSWORD '$DB_PASSWORD_TRACER'"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -v pw="$DB_PASSWORD_TRACER" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE tracer LOGIN PASSWORD :'pw'"
             fi
 
             # Create database if not exists

--- a/charts/underwriter/templates/bootstrap-postgres.yaml
+++ b/charts/underwriter/templates/bootstrap-postgres.yaml
@@ -104,7 +104,7 @@ spec:
               echo "Role 'underwriter' already exists. Skipping creation."
             else
               echo "Creating role 'underwriter'..."
-              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE underwriter LOGIN PASSWORD '$DB_PASSWORD_UNDERWRITER'"
+              PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -v pw="$DB_PASSWORD_UNDERWRITER" -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE ROLE underwriter LOGIN PASSWORD :'pw'"
             fi
 
             # Create database if not exists


### PR DESCRIPTION
## What

The `bootstrap-postgres` Jobs across several charts embed shell variables **directly inside single-quoted SQL string literals** — e.g. `... PASSWORD '$DB_PASSWORD_X'` and `... WHERE datname='$APP_DB'`. A value containing a single quote (a Vault-generated password legitimately can) breaks the statement: `CREATE ROLE` aborts, or the existence check silently misfires.

Fix: switch to **psql's native parameter quoting** — `psql ... -v name="$VAR" ... -c "... :'name' ..."` — which quotes/escapes the value internally. This is **not a new pattern**: `plugin-bc-correios` and `plugin-br-bank-transfer` already do exactly this; this PR aligns the rest to it.

## Charts changed (7)

**Password literal (`CREATE ROLE … PASSWORD '$VAR'` → `:'pw'`):**
- `go-boilerplate-ddd`, `matcher`, `midaz`, `tracer`, `underwriter`

**WHERE-clause identifier literals (`datname='$VAR'` / `rolname='$VAR'` → `:'db'` / `:'role'`):**
- `plugin-br-payments` (its password already used `:'pw'`), `plugin-br-pix-switch` (its password already pre-escapes via `${ESCAPED_PW}` — left as-is, so that file intentionally mixes pre-escaped password + psql-var identifiers)

**Untouched (already safe):** `plugin-bc-correios`, `plugin-br-bank-transfer`.

## Not in this PR

- `streaming-hub` got the same class of fix separately in #1569 (it uses a shell `sql_lit()` helper rather than `:'pw'`; functionally equivalent — can be realigned later if a single org-wide pattern is wanted).
- `go-boilerplate-ddd` is the template these copies derive from; longer term a shared bootstrap partial would stop this re-diverging across 9 copies.

## Validation

- `validate-helm-charts --strict`: **0 violations**
- `--render-gate` for all 7 charts: **ok (render-ok)**
- Rendered Jobs confirmed to use `:'pw'`/`:'db'`/`:'role'` with **no** raw `'$VAR'` left in any SQL literal.

(Note: `midaz` `helm lint` has a pre-existing, unrelated schema-drift failure on the `otel-collector-lerian` subchart — present on `develop` too; render-gate certifies midaz `ok`. Not touched here.)

https://claude.ai/code/session_016Bv8y35GWdpgNdhGVs28JZ