### PR TITLE
fix(charts): register streaming-hub in release README + add install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,14 @@ For implementation and configuration details, see the [README](https://charts.le
 | :---: | :---: |
 | `1.0.0-beta.4` | 0.1.0 |
 -----------------
+
+### Streaming Hub
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/streaming-hub).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `1.0.0-beta.1` | 1.0.0 |
+-----------------

--- a/charts/streaming-hub/README.md
+++ b/charts/streaming-hub/README.md
@@ -21,6 +21,28 @@ infra, and OTEL is env-wired (see [External dependencies](#external-dependencies
 
 ---
 
+## Installing the Chart
+
+```bash
+helm install streaming-hub oci://registry-1.docker.io/lerianstudio/streaming-hub-helm --version <version> -n streaming-hub --create-namespace
+```
+
+With a custom values file:
+
+```bash
+helm install streaming-hub oci://registry-1.docker.io/lerianstudio/streaming-hub-helm --version <version> -n streaming-hub -f my-values.yaml
+```
+
+The chart is mirrored to `oci://ghcr.io/lerianstudio/streaming-hub-helm` as well.
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall streaming-hub -n streaming-hub
+```
+
+---
+
 ## The `mode` switch (read this first)
 
 `streamingHub.mode` decides the topology. It is an **either/or**:


### PR DESCRIPTION
## Why

The post-merge release of streaming-hub (#1569) **failed to publish**. The `release.yml` job ran `update-chart-version-readme --chart streaming-hub --version 1.0.0-beta.1`, which errored:

```
WARNING: Could not find section for chart 'streaming-hub'
ERROR: Could not find version matrix table in README.md
```

That release step rewrites a **per-chart section in the repo-root `README.md`** version matrix. Every other chart has one; streaming-hub's was never added when the chart landed. The PR-time `--strict` chart-standard gate doesn't check root-README membership, so #1569 was green but the publish aborted before pushing the OCI artifact.

## What

- **`README.md`** — add the `### Streaming Hub` version-matrix section (the missing piece the release step needs).
- **`charts/streaming-hub/README.md`** — add `Installing the Chart` / `Uninstalling the Chart` sections, matching the reporter/fetcher convention. This is also a `charts/streaming-hub/` change, which is required to re-trigger the release: `get-changed-paths` filters to `charts/`, so a root-README-only edit would not re-flag the chart for release.

## Verification

Ran the exact failing step locally against the patched README:

```
Found section for chart 'streaming-hub' at line 265: ### Streaming Hub
Found table at lines 271-274
Updated first row: Chart Version = `1.0.0-beta.1`
Successfully updated README.md   (exit 0)
```

Plus: `validate-helm-charts --strict` = 0 violations; `--render-gate --charts streaming-hub` = ok; `helm lint` clean.

(The tool emits a benign `Could not find app.image.tag in values.yaml` warning — streaming-hub's values root is `streamingHub`, not `app`, so the App Version column stays static at `1.0.0` = appVersion. Warning, not error; exit 0.)

## Effect

On merge, `release.yml` re-runs for streaming-hub and publishes `streaming-hub-helm 1.0.0-beta.1` to `ghcr.io/lerianstudio` and `registry-1.docker.io/lerianstudio`. This unblocks the gitops wiring (separate repo).

Follow-up to #1569. Sibling fix in flight: #1570 (bootstrap-postgres SQL escaping).

https://claude.ai/code/session_016Bv8y35GWdpgNdhGVs28JZ