### PR TITLE
feat(plugin-br-pix-switch): expose all multi-tenant knobs across MT-aware components

### DIFF
--- a/charts/plugin-br-pix-switch/Chart.yaml
+++ b/charts/plugin-br-pix-switch/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 2.1.0-beta.1
+version: 2.1.0-beta.2
 
 # This is the version number of the application being deployed.
 appVersion: "1.0.0-beta.101"

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -241,9 +241,15 @@ spi:
     MIDAZ_CLIENT_ID: ""
     MIDAZ_LEDGER_ID: ""
     MIDAZ_ORGANIZATION_ID: ""
-    # Multi-tenant
+    # -- Multi-tenant (consumed when MULTI_TENANT_ENABLED=true). MULTI_TENANT_URL
+    # and MULTI_TENANT_API_KEY are seeds for the spi-systemplane store; once
+    # persisted there, env values become optional (a re-deploy without them is
+    # a supported rollback path). Circuit breaker defaults match the binary
+    # (pkg/config: DefaultMultiTenantCBThreshold=5, ...CBTimeoutSec=30).
     MULTI_TENANT_ENABLED: "false"
     MULTI_TENANT_URL: ""
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
 
   secrets:
     DATABASE_URL: ""
@@ -361,12 +367,21 @@ spiSystemplane:
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-pix-switch"
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "development"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    # -- Multi-tenant seeds. When MULTI_TENANT_ENABLED=true, MULTI_TENANT_URL
+    # and MULTI_TENANT_API_KEY (masked) are seeded into the systemplane store
+    # at tenant.manager_url / tenant.manager_api_key on first boot. After
+    # the systemplane row exists, env values can be removed.
+    MULTI_TENANT_ENABLED: "false"
+    MULTI_TENANT_URL: ""
 
   secrets:
     DATABASE_URL: ""
     SYSTEMPLANE_POSTGRES_DSN: ""
     LICENSE_KEY: ""
     SYSTEMPLANE_SECRET_MASTER_KEY: ""
+    # -- Tenant Manager API key (consumed when MULTI_TENANT_ENABLED=true on
+    # spi-systemplane). Seeded into the systemplane store on first boot.
+    MULTI_TENANT_API_KEY: ""
 
   useExistingSecret: false
   existingSecretName: ""
@@ -576,8 +591,14 @@ dictHub:
     CRM_ORGANIZATION_ID: ""
     KEY_CACHE_TTL_SEC: "60"
     MONGO_DB_NAME: "pix-dict"
+    # -- Multi-tenant (consumed when MULTI_TENANT_ENABLED=true). MULTI_TENANT_URL
+    # and MULTI_TENANT_API_KEY are seeds for the dict-systemplane store; the CB
+    # tunables size the tenant-manager client circuit breaker (defaults from
+    # pkg/config: threshold=5, timeoutSec=30).
     MULTI_TENANT_ENABLED: "false"
     MULTI_TENANT_URL: ""
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
 
   secrets:
     DATABASE_URL: ""
@@ -698,6 +719,10 @@ dictHubVsync:
     CRM_BASE_URL: ""
     CRM_CLIENT_ID: ""
     CRM_ORGANIZATION_ID: ""
+    # -- Multi-tenant (vsync uses the per-tenant DSN resolver only; no
+    # API key here, no CB tunables — the resolver shares the dict-hub
+    # tenant-manager client config).
+    MULTI_TENANT_ENABLED: "false"
     MULTI_TENANT_URL: ""
     # VSync tunables
     VSYNC_ENABLED: "true"
@@ -910,6 +935,10 @@ dictSystemplane:
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-pix-switch"
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "development"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    # -- Multi-tenant flag. dict-systemplane reads only the boolean (URL +
+    # API key live on spi-systemplane). When enabled, the systemplane store
+    # is bootstrapped in MT mode.
+    MULTI_TENANT_ENABLED: "false"
 
   secrets:
     DATABASE_URL: ""
@@ -1011,8 +1040,14 @@ cobHub:
     PLUGIN_AUTH_URL: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
     LICENSE_ORGANIZATION_IDS: "global"
     ORGANIZATION_ID: ""
+    # -- Multi-tenant (consumed when MULTI_TENANT_ENABLED=true). MULTI_TENANT_URL
+    # and MULTI_TENANT_API_KEY are seeds for the cob-systemplane store; the CB
+    # tunables size the tenant-manager client circuit breaker (defaults from
+    # pkg/config: threshold=5, timeoutSec=30).
     MULTI_TENANT_ENABLED: "false"
     MULTI_TENANT_URL: ""
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
 
   secrets:
     DATABASE_URL: ""
@@ -1221,6 +1256,10 @@ cobSystemplane:
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-pix-switch"
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "development"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    # -- Multi-tenant flag. cob-systemplane reads only the boolean (URL +
+    # API key live on spi-systemplane). When enabled, the systemplane store
+    # is bootstrapped in MT mode.
+    MULTI_TENANT_ENABLED: "false"
 
   secrets:
     DATABASE_URL: ""


### PR DESCRIPTION
## Summary
The 2.1.0-beta.1 chart shipped partial multi-tenant exposure. The binaries read more `MULTI_TENANT_*` env vars than the chart exposes today, so enabling `MULTI_TENANT_ENABLED=true` required hand-patching the rendered ConfigMaps. This PR brings the chart in line with the actual binary surface.

## Scope
Every change is **additive** with safe defaults. Single-tenant deployments (`MULTI_TENANT_ENABLED=false`, the chart default) see zero behavioural change.

| Component | Added |
|---|---|
| `spi` | `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"`, `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"` |
| `spiSystemplane` | `MULTI_TENANT_ENABLED: "false"`, `MULTI_TENANT_URL: ""`, `MULTI_TENANT_API_KEY: ""` (Secret) |
| `dictHub` | `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"`, `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"` |
| `dictHubVsync` | `MULTI_TENANT_ENABLED: "false"` (was URL-only) |
| `dictSystemplane` | `MULTI_TENANT_ENABLED: "false"` (was missing entirely) |
| `cobHub` | `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"`, `MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"` |
| `cobSystemplane` | `MULTI_TENANT_ENABLED: "false"` (was missing entirely) |

Components left untouched: `adapterBtgMock`, `dictProxy`, `cobProxy` — these are not MT-aware (verified against their respective `.env.example` files).

## Why these defaults
- `THRESHOLD=5` and `TIMEOUT_SEC=30` mirror the binary defaults (`pkg/config/config.go`: `DefaultMultiTenantCBThreshold=5`, `DefaultMultiTenantCBTimeoutSec=30`).
- `MULTI_TENANT_ENABLED=false` everywhere — preserves current behaviour.
- `MULTI_TENANT_URL` / `MULTI_TENANT_API_KEY` stay empty until an operator sets them.

## Verification
- ✅ `helm lint charts/plugin-br-pix-switch` clean
- ✅ `helm template` renders defaults with `MULTI_TENANT_ENABLED=false` on every component
- ✅ `helm template` with `MT=true` override propagates user values into each ConfigMap/Secret
- ✅ Every added key cross-referenced against the corresponding component's `.env.example` in `LerianStudio/plugin-br-pix-switch` source

## Versioning
`Chart.yaml`: `2.1.0-beta.1` → `2.1.0-beta.2`

Conventional `feat:` commit so release-please bumps the minor on next chart release.

## Background context
The pix-switch app uses `lib-commons/v5 v5.8.0` (`tenant-manager/core`) and `lib-systemplane v1.0.0`. Runtime values like `MULTI_TENANT_URL` / `MULTI_TENANT_API_KEY` are seeded into the systemplane store on first boot of the systemplane components, after which env vars become optional. The new chart fields reflect that lifecycle.