### PR TITLE
chore(charts): deprecate plugin-br-payments-fakebtg, migrated to helm-internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ For implementation and configuration details, see the [README](https://charts.le
 | `1.1.0-beta.3` | 1.0.0-beta.9 |
 -----------------
 
-### Plugin BR Payments Fakebtg
+### Plugin BR Payments Fakebtg [DEPRECATED → helm-internal]
+
+> **Deprecated.** This chart moved to [helm-internal](https://github.com/LerianStudio/helm-internal/tree/main/charts/plugin-br-payments-fakebtg). Use `oci://ghcr.io/lerianstudio/helm-internal/plugin-br-payments-fakebtg-helm` (version `1.0.0`) instead. See `charts/plugin-br-payments-fakebtg/DEPRECATED.md`.
 
 For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/plugin-br-payments-fakebtg).
 
@@ -139,7 +141,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `1.1.0-beta.1` | 1.0.0-beta.22 |
+| `1.1.0-beta.2` | 1.0.0-beta.22 |
 -----------------
 
 ### Fetcher

--- a/charts/plugin-br-payments-fakebtg/Chart.yaml
+++ b/charts/plugin-br-payments-fakebtg/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 1.1.0-beta.1
+version: 1.1.0-beta.2
 deprecated: true
 appVersion: "1.0.0-beta.22"
 

--- a/charts/plugin-br-payments-fakebtg/Chart.yaml
+++ b/charts/plugin-br-payments-fakebtg/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: plugin-br-payments-fakebtg-helm
-description: A Helm chart for fakebtg, the BTG provider API stand-in used by
-  plugin-br-payments dev/staging environments
+description: '[DEPRECATED] Moved to helm-internal. Use oci://ghcr.io/lerianstudio/helm-internal/plugin-br-payments-fakebtg-helm instead.'
 type: application
 annotations:
   lerian.studio/chart-type: single-service
@@ -14,6 +13,7 @@ maintainers:
     email: "support@lerian.studio"
 
 version: 1.1.0-beta.1
+deprecated: true
 appVersion: "1.0.0-beta.22"
 
 keywords:

--- a/charts/plugin-br-payments-fakebtg/DEPRECATED.md
+++ b/charts/plugin-br-payments-fakebtg/DEPRECATED.md
@@ -1,0 +1,27 @@
+# ⚠️ DEPRECATED — plugin-br-payments-fakebtg-helm
+
+This chart has been **moved to [helm-internal](https://github.com/LerianStudio/helm-internal)**.
+
+fakebtg is an internal test double (BTG provider API stand-in) used only by
+`plugin-br-payments` dev/staging environments, so it now lives alongside the
+other internal charts (e.g. `mock-btg-server`, `go-boilerplate-ddd`).
+
+## New location
+
+```
+oci://ghcr.io/lerianstudio/helm-internal/plugin-br-payments-fakebtg-helm
+```
+
+## Migration
+
+Update your `helmfile.yaml`:
+
+```yaml
+chart: oci://ghcr.io/lerianstudio/helm-internal/plugin-br-payments-fakebtg-helm
+version: "1.0.0"
+```
+
+No values changes are required — the chart contents (templates, values,
+schema) are unchanged; only the registry location moved.
+
+See the [helm-internal chart](https://github.com/LerianStudio/helm-internal/tree/main/charts/plugin-br-payments-fakebtg) for the latest version.


### PR DESCRIPTION
## Objetivo
Depreciar o chart `plugin-br-payments-fakebtg` neste repo público — ele foi migrado para o **helm-internal** (`LerianStudio/helm-internal#26`). fakebtg é um test double interno (stand-in da API BTG) usado só por `plugin-br-payments` em dev/staging, então passa a viver junto dos demais charts internos (`mock-btg-server`, `go-boilerplate-ddd`).

## Mudança (espelha o precedente #1499 do go-boilerplate-ddd)
- `Chart.yaml`: `deprecated: true` + `description` apontando para o novo OCI path.
- Novo `DEPRECATED.md` com o guia de migração.
- **Não remove** o chart (precedente mantém o diretório) e **não toca** em templates/values → o artefato OCI já publicado continua disponível.

`helm lint` → 0 falhas.

## ⚠ Ordem de merge (parte 3 de 3) — MERGEAR POR ÚLTIMO
Só mergear **depois** de:
1. `LerianStudio/helm-internal#26` mergeado + released (chart no novo OCI).
2. PR do gitops (`midaz-firmino-gitops`/`lerian-internal-gitops#1112`) mergeada e ArgoCD Synced+Healthy nos consumidores (benedita dev-st / stg-mt).

Mergear antes deixaria a doc dizendo "migrado" enquanto consumidores ainda apontam pro chart aqui. (O artefato OCI antigo é imutável e permanece publicado mesmo após esta PR — rede de rollback.)

## Impacto
- Lifecycle Management: `vars.APPLICATION_IDS` **não contém** `plugin-br-payments-fakebtg` (verificado) → sem impacto.
- A imagem `ghcr.io/lerianstudio/plugin-br-payments-fakebtg` é buildada por outro repo (`plugin-br-payments/cmd/fakebtg`) → fora do escopo, intacta.