### PR TITLE
feat(plugin-access-manager): add optional configurable startupProbe for identity and auth

### DIFF
--- a/charts/plugin-access-manager/CHANGELOG.md
+++ b/charts/plugin-access-manager/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Plugin-access-manager Changelog
 
+## [8.3.0](https://github.com/LerianStudio/helm/releases/tag/plugin-access-manager-v8.3.0)
+
+- **Features:**
+  - Added optional, configurable `startupProbe` to the identity and auth components, following the existing readiness/liveness probe pattern. Disabled by default; enable via `identity.startupProbe.enabled` / `auth.startupProbe.enabled`. Defaults: `failureThreshold: 5`, `periodSeconds: 10`, `timeoutSeconds: 10`.
+
+[Compare changes](https://github.com/LerianStudio/helm/compare/plugin-access-manager-v8.2.0...plugin-access-manager-v8.3.0)
+
 ## [8.2.0](https://github.com/LerianStudio/helm/releases/tag/plugin-access-manager-v8.2.0)
 
 - **Features:**

--- a/charts/plugin-access-manager/Chart.yaml
+++ b/charts/plugin-access-manager/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 8.2.0
+version: 8.3.0
 # This is the version number of the application being deployed.
 appVersion: "2.6.7"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/plugin-access-manager/templates/auth/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth/deployment.yaml
@@ -85,6 +85,17 @@ spec:
             timeoutSeconds: {{ .Values.auth.livenessProbe.timeoutSeconds | default 1 }}
             successThreshold: {{ .Values.auth.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.auth.livenessProbe.failureThreshold | default 3 }}
+          {{- if .Values.auth.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.auth.startupProbe.path | default "/health" }}
+              port: {{ .Values.auth.service.port }}
+            initialDelaySeconds: {{ .Values.auth.startupProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.auth.startupProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.auth.startupProbe.timeoutSeconds | default 10 }}
+            successThreshold: {{ .Values.auth.startupProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.auth.startupProbe.failureThreshold | default 5 }}
+          {{- end }}
       {{- with .Values.auth.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/plugin-access-manager/templates/identity/deployment.yaml
+++ b/charts/plugin-access-manager/templates/identity/deployment.yaml
@@ -83,6 +83,17 @@ spec:
             timeoutSeconds: {{ .Values.identity.livenessProbe.timeoutSeconds | default 1 }}
             successThreshold: {{ .Values.identity.livenessProbe.successThreshold | default 1 }}
             failureThreshold: {{ .Values.identity.livenessProbe.failureThreshold | default 3 }}
+          {{- if .Values.identity.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.identity.startupProbe.path | default "/health" }}
+              port: {{ .Values.identity.service.port }}
+            initialDelaySeconds: {{ .Values.identity.startupProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.identity.startupProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.identity.startupProbe.timeoutSeconds | default 10 }}
+            successThreshold: {{ .Values.identity.startupProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.identity.startupProbe.failureThreshold | default 5 }}
+          {{- end }}
           {{ if (index .Values "otel-collector-lerian").enabled }}
           env:
           - name: "HOST_IP"

--- a/charts/plugin-access-manager/values.yaml
+++ b/charts/plugin-access-manager/values.yaml
@@ -9,6 +9,13 @@ identity:
   readinessProbe: {}
   # -- Liveness probe configuration. All fields override chart defaults.
   livenessProbe: {}
+  # -- Startup probe configuration. Disabled by default; enable to give slow-starting
+  # pods more time before liveness/readiness probes take over. All fields override chart defaults.
+  startupProbe:
+    enabled: false
+    failureThreshold: 5
+    periodSeconds: 10
+    timeoutSeconds: 10
   # Default values
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
@@ -149,6 +156,13 @@ auth:
   readinessProbe: {}
   # -- Liveness probe configuration. All fields override chart defaults.
   livenessProbe: {}
+  # -- Startup probe configuration. Disabled by default; enable to give slow-starting
+  # pods more time before liveness/readiness probes take over. All fields override chart defaults.
+  startupProbe:
+    enabled: false
+    failureThreshold: 5
+    periodSeconds: 10
+    timeoutSeconds: 10
   # Default values
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.


### PR DESCRIPTION
## What
Adds an optional, configurable `startupProbe` to the **identity** and **auth** components of the `plugin-access-manager` chart, following the existing readiness/liveness probe pattern.

## Why
GitOps needs to configure startup probes for the identity and auth components so slow-starting pods get more time before liveness/readiness probes take over. The chart previously only had readiness/liveness probes.

## Details
- Disabled by default; enabled via `identity.startupProbe.enabled` / `auth.startupProbe.enabled`.
- All fields override chart defaults, mirroring the readiness/liveness convention.
- Suggested defaults: `failureThreshold: 5`, `periodSeconds: 10`, `timeoutSeconds: 10`.
- `httpGet` defaults to `/health` on the component service port.

## Files changed
- `charts/plugin-access-manager/templates/identity/deployment.yaml`
- `charts/plugin-access-manager/templates/auth/deployment.yaml`
- `charts/plugin-access-manager/values.yaml`
- `charts/plugin-access-manager/Chart.yaml` (version 8.2.0 -> 8.3.0)
- `charts/plugin-access-manager/CHANGELOG.md`

## Verification
`helm template` renders the `startupProbe` for both components when enabled (identity port 4000, auth port 4001) and omits it when disabled (default). Output validated locally.