### PR TITLE
docs(charts): add br-spi version-matrix section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ For implementation and configuration details, see the [README](https://charts.le
 
 -----------------
 
+### BR SPI Helm Chart
+
+Brazilian SFN — SPI / Pix rail (components: core, spi, brcode, dict, plus a dedicated schema-migration Job).
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/br-spi).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `0.1.0-beta.1` | `0.1.0` |
+-----------------
+
 ### Reporter
 
 See the [official documentation](https://docs.lerian.studio/en/reporter) for details.


### PR DESCRIPTION
## Problem

The br-spi-helm release job failed on **both** channels (#1607 main, #1608 develop) with:
```
WARNING: Could not find section for chart 'br-spi'
ERROR: Could not find version matrix table in README.md
```
The release `prepareCmd` (`update-chart-version-readme --chart br-spi`) requires a `### ...br spi...` section with a `Chart Version` matrix table in the root README.md. It was missing → the chart **never published to OCI**.

## Fix

Add the section, matching the sibling format (e.g. Plugin BR Pix Switch).

## Verification

Built and ran the actual pipeline binary locally against this change:
```
Found section for chart 'br-spi' at line 56
Found table at lines 64-67
Updated first row: Chart Version = ...
Successfully updated README.md   (exit 0)
```
README-only ⇒ this merge triggers no release (`paths-ignore`); the first OCI publish rides the next `charts/br-spi` change.

https://claude.ai/code/session_012fNphWnucMKd84KskVFgvz