### PR TITLE
feat: add background worker Deployment

### DIFF
--- a/charts/br-sta/Chart.yaml
+++ b/charts/br-sta/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: br-sta-helm
 description: A Helm chart for br-sta, a Lerian Studio Go/Fiber HTTP service
-  backed by PostgreSQL and Redis/Valkey.
+  (manager) plus its background worker, backed by PostgreSQL and Redis/Valkey.
 type: application
 annotations:
-  lerian.studio/chart-type: single-service
+  lerian.studio/chart-type: multi-component
 home: https://github.com/LerianStudio/br-sta
 sources:
   - https://github.com/LerianStudio/helm/tree/main/charts/br-sta
@@ -15,10 +15,10 @@ maintainers:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed.
-appVersion: "1.0.0-beta.5"
+appVersion: "1.0.0-beta.32"
 
 # A list of keywords about the chart. This helps others discover the chart.
 keywords:

--- a/charts/br-sta/templates/_helpers.tpl
+++ b/charts/br-sta/templates/_helpers.tpl
@@ -97,6 +97,65 @@ SERVICE ACCOUNT HELPER
 
 {{/*
 ================================================================================
+WORKER HELPERS
+================================================================================
+The worker is a SECOND Deployment running the /worker binary (background jobs:
+audit publisher/consumer, scheduler, credential-recovery sweep, inbound poll).
+It reuses the manager's ConfigMap + Secret (all shared infra config) and layers
+worker-only env on top. It gets its OWN app.kubernetes.io/name so its selector
+never overlaps the manager's (selectors are immutable across upgrades).
+================================================================================
+*/}}
+
+{{/* Worker resource name: "<fullname>-worker". */}}
+{{- define "br-sta.worker.fullname" -}}
+{{- printf "%s-worker" (include "br-sta.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/* Worker app name (distinct from the manager so selectors don't overlap). */}}
+{{- define "br-sta.worker.name" -}}
+{{- printf "%s-worker" (include "br-sta.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/* Worker selector labels — distinct name keeps the two Deployments apart. */}}
+{{- define "br-sta.worker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "br-sta.worker.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- end }}
+
+{{/* Worker common labels. */}}
+{{- define "br-sta.worker.labels" -}}
+helm.sh/chart: {{ include "br-sta.chart" .context }}
+{{ include "br-sta.worker.selectorLabels" (dict "context" .context) }}
+app.kubernetes.io/version: {{ include "br-sta.versionLabelValue" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: br-sta
+app.kubernetes.io/component: worker
+{{- end }}
+
+{{/* Worker ServiceAccount name (own SA, or reuse the manager's when not creating). */}}
+{{- define "br-sta.worker.serviceAccountName" -}}
+{{- $w := .Values.worker | default dict -}}
+{{- $sa := $w.serviceAccount | default dict -}}
+{{- if $sa.create }}
+{{- default (include "br-sta.worker.fullname" .) $sa.name }}
+{{- else }}
+{{- default (include "br-sta.serviceAccountName" .) $sa.name }}
+{{- end }}
+{{- end }}
+
+{{/* Worker enabled — nil-aware: unset/true enables, explicit false disables. */}}
+{{- define "br-sta.worker.enabled" -}}
+{{- $w := .Values.worker | default dict -}}
+{{- if ne (toString $w.enabled) "false" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+================================================================================
 NAMESPACE HELPER
 ================================================================================
 */}}

--- a/charts/br-sta/templates/worker/configmap.yaml
+++ b/charts/br-sta/templates/worker/configmap.yaml
@@ -1,0 +1,22 @@
+{{- if eq (include "br-sta.worker.enabled" .) "true" }}
+{{- $w := .Values.worker | default dict -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-sta.worker.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sta.worker.labels" (dict "context" .) | nindent 4 }}
+data:
+  # Worker-only environment. Layered on top of the manager ConfigMap + Secret
+  # (envFrom order in the worker Deployment), so keys here win over shared ones.
+  # The worker binds SERVER_ADDRESS only for its probe server (WorkerMode).
+  SERVER_ADDRESS: {{ printf "0.0.0.0:%v" ($w.service.port | default 8081) | quote }}
+  {{- with $w.configmap }}
+  {{- range $key, $value := . }}
+  {{- if ne $key "SERVER_ADDRESS" }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/br-sta/templates/worker/deployment.yaml
+++ b/charts/br-sta/templates/worker/deployment.yaml
@@ -1,0 +1,188 @@
+{{- if eq (include "br-sta.worker.enabled" .) "true" }}
+{{- $mgr := index .Values "br-sta" -}}
+{{- $w := .Values.worker | default dict -}}
+{{- $wImage := $w.image | default dict -}}
+{{- $repo := $wImage.repository | default $mgr.image.repository -}}
+{{- $tag := $wImage.tag | default (include "br-sta.defaultTag" .) -}}
+{{- $pullPolicy := $wImage.pullPolicy | default $mgr.image.pullPolicy -}}
+{{- $pullSecrets := $w.imagePullSecrets | default $mgr.imagePullSecrets -}}
+{{- $secCtx := $w.securityContext | default $mgr.securityContext -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "br-sta.worker.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sta.worker.labels" (dict "context" .) | nindent 4 }}
+  {{- with $w.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ $w.revisionHistoryLimit | default 10 }}
+  {{- with $w.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  # The worker is leader-gated but does NOT run its own leader election yet;
+  # keep this at 1 to avoid duplicate background processing (audit drain,
+  # scheduler, inbound poll). Do NOT add an HPA to the worker.
+  replicas: {{ $w.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "br-sta.worker.selectorLabels" (dict "context" .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-sta.worker.labels" (dict "context" .) | nindent 8 }}
+      {{- with $w.podAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "br-sta.worker.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ $w.terminationGracePeriodSeconds | default 60 }}
+      {{- with $w.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $w.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or (eq (include "postgresql.enabled" .) "true") (eq (include "valkey.enabled" .) "true") }}
+      initContainers:
+        - name: wait-for-infra
+          image: busybox:1.37
+          envFrom:
+            # POSTGRES_HOST / REDIS_HOST live in the manager ConfigMap.
+            - configMapRef:
+                name: {{ include "br-sta.fullname" . }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              {{- if eq (include "postgresql.enabled" .) "true" }}
+              echo "Waiting for PostgreSQL $POSTGRES_HOST:$POSTGRES_PORT...";
+              until nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
+                echo "$POSTGRES_HOST:$POSTGRES_PORT not ready, sleeping 5s";
+                sleep 5;
+              done;
+              echo "PostgreSQL is ready";
+              {{- end }}
+              {{- if eq (include "valkey.enabled" .) "true" }}
+              REDIS_SVC=$(echo "$REDIS_HOST" | cut -d: -f1);
+              REDIS_PORT_NUM=$(echo "$REDIS_HOST" | cut -d: -f2);
+              [ -z "$REDIS_PORT_NUM" ] && REDIS_PORT_NUM=6379;
+              echo "Waiting for Redis/Valkey $REDIS_SVC:$REDIS_PORT_NUM...";
+              until nc -z "$REDIS_SVC" "$REDIS_PORT_NUM"; do
+                echo "$REDIS_SVC:$REDIS_PORT_NUM not ready, sleeping 5s";
+                sleep 5;
+              done;
+              echo "Redis/Valkey is ready";
+              {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ include "br-sta.worker.fullname" . }}
+          securityContext:
+            {{- toYaml $secCtx | nindent 12 }}
+          image: "{{ $repo }}:{{ $tag }}"
+          imagePullPolicy: {{ $pullPolicy }}
+          # Same image as the manager; run the worker binary baked into it.
+          command:
+            {{- toYaml ($w.command | default (list "/worker")) | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ $w.service.port | default 8081 }}
+              protocol: TCP
+          envFrom:
+            # Shared config + secrets from the manager (single source of truth).
+            - configMapRef:
+                name: {{ include "br-sta.fullname" . }}
+            - secretRef:
+                name: {{ if $mgr.useExistingSecret }}{{ $mgr.existingSecretName }}{{ else }}{{ include "br-sta.fullname" . }}{{ end }}
+            # Worker-only overrides (SERVER_ADDRESS, background-job knobs) — last
+            # so its keys win over the shared manager ConfigMap.
+            - configMapRef:
+                name: {{ include "br-sta.worker.fullname" . }}
+          env:
+            {{- $secretName := ternary $mgr.existingSecretName (include "br-sta.fullname" .) $mgr.useExistingSecret }}
+            {{- $pg := .Values.postgresql | default dict }}
+            {{- $pgAuth := $pg.auth | default dict }}
+            {{- if or (and (ne (toString $pg.enabled) "false") (not $pg.external)) $pgAuth.existingSecret }}
+            {{- include "br-sta.infraSecretRef" (dict "context" $ "subchart" "postgresql" "key" "password" "envName" "POSTGRES_PASSWORD") | nindent 12 }}
+            {{- else if $mgr.secrets.POSTGRES_PASSWORD }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_PASSWORD
+            {{- end }}
+            {{- $vk := .Values.valkey | default dict }}
+            {{- $vkAuth := $vk.auth | default dict }}
+            {{- if or (and (ne (toString $vk.enabled) "false") (not $vk.external) $vkAuth.enabled) $vkAuth.existingSecret }}
+            {{- include "br-sta.infraSecretRef" (dict "context" $ "subchart" "valkey" "key" "valkey-password" "envName" "REDIS_PASSWORD") | nindent 12 }}
+            {{- else if $mgr.secrets.REDIS_PASSWORD }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: REDIS_PASSWORD
+            {{- end }}
+          {{- if (index .Values "otel-collector-lerian").enabled }}
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "$(HOST_IP):4317"
+          {{- end }}
+          {{- with $w.extraEnvVars }}
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml ($w.resources | default $mgr.resources) | nindent 12 }}
+          # The worker binary runs in WorkerMode: it serves ONLY the probe
+          # endpoints on SERVER_ADDRESS (no business HTTP API).
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ (($w.readinessProbe).initialDelaySeconds) | default 5 }}
+            periodSeconds: {{ (($w.readinessProbe).periodSeconds) | default 5 }}
+            timeoutSeconds: {{ (($w.readinessProbe).timeoutSeconds) | default 3 }}
+            successThreshold: {{ (($w.readinessProbe).successThreshold) | default 1 }}
+            failureThreshold: {{ (($w.readinessProbe).failureThreshold) | default 2 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ (($w.livenessProbe).initialDelaySeconds) | default 30 }}
+            periodSeconds: {{ (($w.livenessProbe).periodSeconds) | default 10 }}
+            timeoutSeconds: {{ (($w.livenessProbe).timeoutSeconds) | default 3 }}
+            successThreshold: {{ (($w.livenessProbe).successThreshold) | default 1 }}
+            failureThreshold: {{ (($w.livenessProbe).failureThreshold) | default 3 }}
+      {{- with $w.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $w.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $w.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/br-sta/templates/worker/serviceaccount.yaml
+++ b/charts/br-sta/templates/worker/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if eq (include "br-sta.worker.enabled" .) "true" }}
+{{- $w := .Values.worker | default dict -}}
+{{- $sa := $w.serviceAccount | default dict -}}
+{{- if $sa.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "br-sta.worker.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sta.worker.labels" (dict "context" .) | nindent 4 }}
+  {{- with $sa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/br-sta/values.yaml
+++ b/charts/br-sta/values.yaml
@@ -335,6 +335,129 @@ br-sta:
     name: ""
 
 # ==============================================================================
+# WORKER
+# Second Deployment running the /worker binary from the SAME image as the
+# manager (command override — both binaries ship in one image). It runs the
+# background jobs: audit outbox publisher/consumer, the leader-gated scheduler
+# (credential expiry/rotation, retention, stale-protocol cleanup), the
+# credential-recovery-on-boot sweep, and the inbound BACEN poll loop. It serves
+# ONLY the probe endpoints (WorkerMode — no business HTTP API), reuses the
+# manager ConfigMap + Secret for all shared infra config, and layers the
+# worker-only knobs below on top.
+# ==============================================================================
+worker:
+  # -- Enable the worker Deployment. REQUIRES a br-sta image that ships BOTH
+  # binaries (manager /service + worker /worker in one image, from the
+  # multi-binary Dockerfile). Older single-binary images have no /worker and
+  # the pod will CrashLoop on command:[/worker]; keep this false until such an
+  # image is published.
+  enabled: true
+  # -- Replicas. The background jobs are leader-gated but the worker does NOT
+  # run its own leader election yet — keep this at 1 (and do not add an HPA) to
+  # avoid duplicate processing.
+  replicaCount: 1
+  # -- Number of old ReplicaSets to retain for rollback
+  revisionHistoryLimit: 10
+  # -- Annotations applied to the Deployment resource
+  annotations: {}
+  # -- Annotations applied to the pods
+  podAnnotations: {}
+  # -- Worker image. Empty repository/tag inherit the manager image (same
+  # published image carries both binaries); override only to pin separately.
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+  # -- Image pull secrets (empty inherits the manager's)
+  imagePullSecrets: []
+  # -- Container command — the worker binary baked into the shared image
+  command:
+    - /worker
+  # -- Termination grace period
+  terminationGracePeriodSeconds: 60
+  # -- Pod security context
+  podSecurityContext: {}
+  # -- Container security context (empty inherits the manager's)
+  securityContext: {}
+  # -- ServiceAccount configuration
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+  # -- Probe server port. WorkerMode binds SERVER_ADDRESS here; no Service or
+  # Ingress is created for the worker.
+  service:
+    port: 8081
+  # -- Resource requests and limits
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  # -- Deployment strategy
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  # -- Readiness probe configuration
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    successThreshold: 1
+    failureThreshold: 2
+  # -- Liveness probe configuration
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 3
+    successThreshold: 1
+    failureThreshold: 3
+  # -- Node selector for scheduling pods on specific nodes
+  nodeSelector: {}
+  # -- Tolerations for scheduling on tainted nodes
+  tolerations: []
+  # -- Affinity rules for pod scheduling
+  affinity: {}
+  # -- Host aliases for custom DNS resolution inside the pod
+  hostAliases: []
+  # -- Worker-only environment (layered on top of the manager ConfigMap/Secret).
+  # SetConfigFromEnvVars ignores envDefault, so every knob a background job
+  # needs must be set explicitly. SERVER_ADDRESS is derived from service.port.
+  # @default -- templates/worker/configmap.yaml
+  configmap:
+    # OTEL identity for the worker process
+    OTEL_RESOURCE_SERVICE_NAME: "br-sta-worker"
+    # Leader-gated scheduler (credential expiry/rotation, retention, cleanup)
+    SCHEDULER_ENABLED: "true"
+    # Resolve credentials left mid-rotation by a prior worker death, at boot
+    CREDENTIALS_RECOVERY_ON_BOOT: "true"
+    # Audit outbox publisher (drains audit_outbox -> sta.audit.events).
+    # Requires the shared RABBITMQ_ENABLED="true".
+    AUDIT_PUBLISHER_ENABLED: "true"
+    AUDIT_PUBLISHER_INTERVAL_SEC: "2"
+    AUDIT_PUBLISHER_BATCH_SIZE: "100"
+    AUDIT_PUBLISHER_MAX_ATTEMPTS: "10"
+    AUDIT_PUBLISHER_EXCHANGE: "sta.audit.events"
+    AUDIT_PUBLISHER_LOCK_CLASS_ID: "7700"
+    AUDIT_PUBLISHER_SERVICE_NAME: "br-sta-worker"
+    # Audit consumer (writes hash-chained rows into the audit log tables)
+    AUDIT_CONSUMER_ENABLED: "true"
+    AUDIT_CONSUMER_QUEUE: "br-sta.audit.consume"
+    AUDIT_CONSUMER_EXCHANGE: "sta.audit.events"
+    AUDIT_CONSUMER_DEDUP_TTL_SEC: "5"
+    AUDIT_CONSUMER_LOCK_CLASS_ID: "7701"
+    AUDIT_CONSUMER_MAX_RETRY_ATTEMPTS: "10"
+    AUDIT_CONSUMER_DLQ_EXCHANGE: "sta.audit.dlq"
+    AUDIT_CONSUMER_SERVICE_NAME: "br-sta-worker"
+  # -- Extra environment variables (map of key:value pairs) rendered as inline
+  # container env (wins over both ConfigMaps).
+  extraEnvVars: {}
+
+# ==============================================================================
 # POSTGRESQL SUB-CHART (Bitnami)
 # Default: enabled with replication for in-cluster development/staging.
 # Production: set postgresql.enabled=false and configure


### PR DESCRIPTION
Add a second Deployment that runs the cmd/worker binary for br-sta's background jobs (audit outbox publisher/consumer, leader-gated scheduler for credential rotation/retention/stale-protocol cleanup, and the credential-recovery-on-boot sweep). Previously the chart deployed only the manager, so those jobs never ran.

The worker runs the SAME published image as the manager via a command override (command: [/worker]) — the image ships both binaries. It reuses the manager ConfigMap + Secret via envFrom for all shared infra config (Postgres/Redis/RabbitMQ/S3/master keys) and layers worker-only knobs on top. It serves only the probe endpoints (WorkerMode), gets its own app.kubernetes.io/name so its selector never overlaps the manager's, and defaults to a single replica (no leader election yet — do not scale out).

Requires a br-sta image built from the multi-binary Dockerfile; older single-binary images have no /worker and CrashLoop on command:[/worker].

- templates/worker/{deployment,configmap,serviceaccount}.yaml (new)
- _helpers.tpl: worker name/label/selector/SA helpers
- values.yaml: worker block (enabled, probes, resources, audit/scheduler env)
- Chart.yaml: chart-type single-service -> multi-component, 1.0.0 -> 1.1.0, appVersion -> 1.0.0-beta.32

# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Midaz
- [ ] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [ ] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] Matcher
- [ ] Flowker
- [ ] Underwriter
- [x] Plugin BR STA

## Checklist
Please check each item after it's completed.

- [ ] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [ ] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [ ] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [ ] I have confirmed this code is ready for review.

## Additional Notes
[//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
## Obs: Please, always remember to target your PR to develop branch instead of main.