### PR TITLE
fix(br-sta): add version matrix table to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,14 @@ For implementation and configuration details, see the [README](https://charts.le
 | :---: | :---: |
 | `1.0.0-beta.3` | 1.0.0 |
 -----------------
+
+### BR STA
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/br-sta).
+
+#### Application Version Mapping
+
+| Chart Version | Manager Version | Worker Version |
+| :---: | :---: | :---: |
+| `1.1.0` | 1.0.0-beta.32 | 1.0.0-beta.32 |
+-----------------


### PR DESCRIPTION
## Pull Request Type
- [ ] Midaz
- [ ] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [ ] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] Matcher
- [ ] Flowker
- [ ] Underwriter
- [x] Other: br-sta (root README version matrix)

## Checklist
- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
PR #1618 (br-sta chart + worker) merged to `develop` without a version-matrix
section in the root README.md. Every other chart has one, and the semantic
release `prepareCmd` hard-fails when it's missing:

```
ERROR: Could not find version matrix table in README.md
```

This broke the first `develop` release of br-sta
(https://github.com/LerianStudio/helm/actions/runs/28943489450/job/85871335307),
which also skipped the back-merge-to-develop and release-notification jobs.

Adds a `### BR STA` section following the Manager/Worker column pattern used
by Reporter and Fetcher (also manager+worker charts). Verified by running
`.github/scripts/update-chart-version-readme --chart br-sta --version
1.1.0-beta.1` against the updated README locally — it now finds and updates
the table instead of exiting 1 (two pre-existing, non-fatal warnings remain
about `manager.image.tag`/`worker.image.tag` not being found for
auto-updating the version columns, since this chart's component keys are
`br-sta`/`worker` rather than `manager`/`worker` — out of scope here).