### PR TITLE
fix(br-sta): require existingSecretName in schema when useExistingSecret is set

### DIFF
--- a/charts/br-sta/values.schema.json
+++ b/charts/br-sta/values.schema.json
@@ -40,9 +40,31 @@
         },
         "secrets": {
           "type": "object"
+        },
+        "useExistingSecret": {
+          "type": "boolean"
+        },
+        "existingSecretName": {
+          "type": "string"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": true,
+      "if": {
+        "properties": {
+          "useExistingSecret": {
+            "const": true
+          }
+        },
+        "required": ["useExistingSecret"]
+      },
+      "then": {
+        "properties": {
+          "existingSecretName": {
+            "minLength": 1
+          }
+        },
+        "required": ["existingSecretName"]
+      }
     }
   }
 }


### PR DESCRIPTION
## Pull Request Type
- [ ] Midaz
- [ ] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [ ] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] Matcher
- [ ] Flowker
- [ ] Underwriter
- [x] Other: br-sta

## Checklist
- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
Completes CodeRabbit finding 3539685868 from PR #1618: `br-sta.validateRequired`
already fails fast in `_helpers.tpl` when `useExistingSecret=true` and
`existingSecretName` is empty, but `values.schema.json` didn't enforce the
same pair, so the error only surfaced at template-render time instead of at
`helm lint`/schema-validation time.

Adds an `if/then` to the `br-sta` schema block requiring a non-empty
`existingSecretName` when `useExistingSecret=true`. Verified with `helm lint`
and `helm template` against both branches (missing name fails with a schema
error, present name renders normally).

This also touches `charts/br-sta/**`, which is needed to re-trigger the
`develop` release pipeline for br-sta (the version-matrix README fix in #1619
landed outside `charts/`, so it didn't register as a chart change).