### PR TITLE
fix(br-sta): worker command must match the image's /service entrypoint

### DIFF
--- a/charts/br-sta/templates/NOTES.txt
+++ b/charts/br-sta/templates/NOTES.txt
@@ -22,7 +22,7 @@ Manager Deployment ({{ $component.replicaCount }} replica(s)) running the /servi
 
 {{- if eq (include "br-sta.worker.enabled" .) "true" }}
 
-Worker Deployment ({{ (.Values.worker | default dict).replicaCount | default 1 }} replica(s)) running the /worker binary
+Worker Deployment ({{ (.Values.worker | default dict).replicaCount | default 1 }} replica(s)) running the /service binary
 (background jobs: audit outbox publisher/consumer, leader-gated scheduler, credential-recovery-on-boot).
 {{- end }}
 

--- a/charts/br-sta/templates/_helpers.tpl
+++ b/charts/br-sta/templates/_helpers.tpl
@@ -99,7 +99,7 @@ SERVICE ACCOUNT HELPER
 ================================================================================
 WORKER HELPERS
 ================================================================================
-The worker is a SECOND Deployment running the /worker binary (background jobs:
+The worker is a SECOND Deployment running the /service binary (background jobs:
 audit publisher/consumer, scheduler, credential-recovery sweep, inbound poll).
 It reuses the manager's ConfigMap + Secret (all shared infra config) and layers
 worker-only env on top. It gets its OWN app.kubernetes.io/name so its selector

--- a/charts/br-sta/templates/worker/deployment.yaml
+++ b/charts/br-sta/templates/worker/deployment.yaml
@@ -96,9 +96,10 @@ spec:
             {{- toYaml $secCtx | nindent 12 }}
           image: "{{ $repo }}:{{ $tag }}"
           imagePullPolicy: {{ $pullPolicy }}
-          # Same image as the manager; run the worker binary baked into it.
+          # Matches the worker image's own ENTRYPOINT (/service, built from
+          # cmd/worker) — see the worker.command comment in values.yaml.
           command:
-            {{- toYaml ($w.command | default (list "/worker")) | nindent 12 }}
+            {{- toYaml ($w.command | default (list "/service")) | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ $w.service.port | default 8081 }}

--- a/charts/br-sta/values.yaml
+++ b/charts/br-sta/values.yaml
@@ -336,22 +336,23 @@ br-sta:
 
 # ==============================================================================
 # WORKER
-# Second Deployment running the /worker binary from the SAME image as the
-# manager (command override — both binaries ship in one image). It runs the
-# background jobs: audit outbox publisher/consumer, the leader-gated scheduler
-# (credential expiry/rotation, retention, stale-protocol cleanup), the
-# credential-recovery-on-boot sweep, and the inbound BACEN poll loop. It serves
-# ONLY the probe endpoints (WorkerMode — no business HTTP API), reuses the
-# manager ConfigMap + Secret for all shared infra config, and layers the
-# worker-only knobs below on top.
+# Second Deployment running the br-sta worker component. Upstream builds the
+# manager (cmd/manager) and worker (cmd/worker) as two SEPARATE images, each
+# with its own ENTRYPOINT already set to the right compiled binary (both are
+# named /service inside their respective images by convention — see
+# github.com/LerianStudio/br-sta's per-component Dockerfiles). Set
+# worker.image to the dedicated worker image; do not point it at the manager
+# image. It runs the background jobs: audit outbox publisher/consumer, the
+# leader-gated scheduler (credential expiry/rotation, retention,
+# stale-protocol cleanup), the credential-recovery-on-boot sweep, and the
+# inbound BACEN poll loop. It serves ONLY the probe endpoints (WorkerMode —
+# no business HTTP API), reuses the manager ConfigMap + Secret for all shared
+# infra config, and layers the worker-only knobs below on top.
 # ==============================================================================
 worker:
-  # -- Enable the worker Deployment. REQUIRES a br-sta image that ships BOTH
-  # binaries (manager /service + worker /worker in one image, from the
-  # multi-binary Dockerfile) — or an explicit worker.image override pointing
-  # at a dedicated worker image. Older single-binary images have no /worker
-  # and the pod will CrashLoop on command:[/worker]; keep this false until
-  # a suitable image is confirmed available, then enable per-deployment.
+  # -- Enable the worker Deployment. REQUIRES worker.image to point at a
+  # dedicated worker image (built from cmd/worker) — keep this false until
+  # that image is confirmed available, then enable per-deployment.
   enabled: false
   # -- Replicas. The background jobs are leader-gated but the worker does NOT
   # run its own leader election yet — keep this at 1 (and do not add an HPA) to
@@ -363,17 +364,20 @@ worker:
   annotations: {}
   # -- Annotations applied to the pods
   podAnnotations: {}
-  # -- Worker image. Empty repository/tag inherit the manager image (same
-  # published image carries both binaries); override only to pin separately.
+  # -- Worker image. REQUIRED: point at the dedicated worker image (built
+  # from cmd/worker). Empty repository/tag fall back to the manager image,
+  # which does NOT run the worker's logic — only set for local testing.
   image:
     repository: ""
     tag: ""
     pullPolicy: IfNotPresent
   # -- Image pull secrets (empty inherits the manager's)
   imagePullSecrets: []
-  # -- Container command — the worker binary baked into the shared image
+  # -- Container command. The worker image's own ENTRYPOINT already runs the
+  # correct binary (/service, built from cmd/worker) — this override matches
+  # that ENTRYPOINT rather than replacing it with a different binary name.
   command:
-    - /worker
+    - /service
   # -- Termination grace period
   terminationGracePeriodSeconds: 60
   # -- Pod security context


### PR DESCRIPTION
## Pull Request Type
- [ ] Midaz
- [ ] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [ ] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] Matcher
- [ ] Flowker
- [ ] Underwriter
- [x] Other: br-sta

## Checklist
- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [ ] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
The worker pod in benedita's `br-sta-dev-st` crashed on every start:

```
Error: failed to create containerd task: failed to create shim task: OCI
runtime create failed: runc create failed: unable to start container
process: error during container init: exec: "/worker": stat /worker: no
such file or directory
```

**Root cause**: `LerianStudio/br-sta` ships the manager and worker as two
**separate** images (`cmd/manager/Dockerfile`, `cmd/worker/Dockerfile`), and
both Dockerfiles intentionally build/copy/`ENTRYPOINT` their binary as
`/service` — documented in the Dockerfile comments as the one deliberate
difference being `BINARY_PATH` and image labels, not the binary's name.
Confirmed by exporting `ghcr.io/lerianstudio/br-sta-worker:1.0.0-beta.38`
and inspecting its filesystem: the binary at the root is named `service`,
not `worker`. There is no `/worker` binary in any published br-sta image —
the chart's prior assumption of "one multi-binary image, `command` selects
which binary" doesn't match how the application is actually built and
released (two per-component images, each with the correct `ENTRYPOINT`
already baked in).

**Fix**: default `worker.command` to `/service` (matching the dedicated
worker image's own `ENTRYPOINT`) instead of `/worker`. Also corrects the
`WORKER` section comments in `values.yaml`, which described the same wrong
single-image/command-override model.

Verified with `helm lint` and `helm template --set worker.enabled=true`:
the worker container now renders `command: [/service]`.