### PR TITLE
feat(plugin-access-manager): mirror POSTGRES_* env in migrations Job

### DIFF
--- a/charts/plugin-access-manager/templates/auth-backend/migrations.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/migrations.yaml
@@ -68,4 +68,36 @@ spec:
                 configMapKeyRef:
                   name: {{ include "plugin-auth.fullname" . }}
                   key: DB_SSLMODE
+            # POSTGRES_* mirrors of the DB_* vars above, mapped from the same
+            # ConfigMap/Secret keys. The caradhras migration runner
+            # (cmd/postgres-migrations) reads POSTGRES_HOST/PORT/USER/PASSWORD/DB/SSLMODE
+            # instead of Casdoor's DB_* contract; keeping both sets lets this single
+            # Job template run either migrations image via auth.backend.migrations.image,
+            # with no functional effect on casdoor-migrations (which ignores POSTGRES_*).
+            - name: POSTGRES_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_PORT
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_NAME
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_USER
+            {{- include "plugin-auth.dbPasswordEnv" (dict "context" $ "envName" "POSTGRES_PASSWORD") | nindent 12 }}
+            - name: POSTGRES_SSLMODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_SSLMODE
       restartPolicy: OnFailure


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [ ] Midaz
- [x] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [ ] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] Matcher
- [ ] Flowker
- [ ] Underwriter
- [ ] BR STA

## Checklist

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

### What

The Casdoor migrations Job (`templates/auth-backend/migrations.yaml`) only injects `DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASS/DB_SSLMODE`, hardcoded to match `casdoor-migrations`' env contract. Adds `POSTGRES_HOST/PORT/USER/PASSWORD/DB/SSLMODE` mirrors, sourced from the exact same ConfigMap/Secret keys.

### Why

Caradhras (Lerian's Casdoor fork) ships its own dedicated migration runner (`cmd/postgres-migrations`, published as `ghcr.io/lerianstudio/caradhras-postgres-migrations`). It reads `POSTGRES_*`, not `DB_*`. Without this change, pointing `auth.backend.migrations.image` at the caradhras image silently fails (DSN falls back to defaults / connects nowhere), which is exactly the failure mode we hit testing caradhras as the auth-backend in stg-mt.

### Impact

- No new value, no flag. Existing `casdoor-migrations` installs are unaffected — that binary simply ignores the unused `POSTGRES_*` vars.
- `helm template` diff against `develop` shows only the 6 added env entries in the migrations Job; nothing else changed.
- Lets `auth.backend.migrations.image` be swapped to `caradhras-postgres-migrations` purely via values, no further chart changes needed.

### Testing

- `helm lint charts/plugin-access-manager` — clean.
- `helm template` render-equivalence check: diffed the migrations Job output before/after this change; only the new `POSTGRES_*` entries appear, all pre-existing output is byte-identical.
