### PR TITLE
feat(plugin-access-manager): support extraEnvVars on auth-backend

### DIFF
--- a/charts/plugin-access-manager/templates/auth-backend/configmap.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/configmap.yaml
@@ -20,3 +20,8 @@ data:
   quota: '{"organization": -1, "user": -1, "application": -1, "provider": -1}'
   logConfig: '{"filename": "logs/casdoor.log", "maxdays": 99999, "perm": "0770"}'
   initDataFile: {{ .Values.auth.backend.initDataFile | default "./init_data.json" | quote }}
+
+  # Extra Env Vars
+  {{- with .Values.auth.backend.extraEnvVars }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/plugin-access-manager/templates/auth-backend/configmap.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/configmap.yaml
@@ -20,6 +20,11 @@ data:
   quota: '{"organization": -1, "user": -1, "application": -1, "provider": -1}'
   logConfig: '{"filename": "logs/casdoor.log", "maxdays": 99999, "perm": "0770"}'
   initDataFile: {{ .Values.auth.backend.initDataFile | default "./init_data.json" | quote }}
+  # Allows the backend's outbox Postgres client to connect without a valid
+  # certificate. Same default and rationale as auth.configmap.ALLOW_INSECURE_TLS
+  # and identity.configmap.ALLOW_INSECURE_TLS. Casdoor ignores this key; only
+  # caradhras' outbox client reads it, and it fails closed without it.
+  ALLOW_INSECURE_TLS: {{ .Values.auth.backend.allowInsecureTLS | default "true" | quote }}
 
   # Extra Env Vars
   {{- with .Values.auth.backend.extraEnvVars }}


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [ ] Midaz
- [x] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [ ] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] Matcher
- [ ] Flowker
- [ ] Underwriter
- [ ] BR STA

## Checklist

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

### What

Two additions to `templates/auth-backend/configmap.yaml`:

1. `auth.backend.extraEnvVars` generic passthrough, mirroring the pattern already used by `auth` and `identity` (`.Values.auth.extraEnvVars` / `.Values.identity.extraEnvVars`).
2. An explicit `ALLOW_INSECURE_TLS` key, defaulting to `"true"` (`auth.backend.allowInsecureTLS` to override) — same default/rationale as `auth.configmap.ALLOW_INSECURE_TLS` and `identity.configmap.ALLOW_INSECURE_TLS`.

### Why

Testing caradhras as the `auth-backend` in stg-mt (LerianStudio/caradhras#15, #1622 in this repo), the backend fails to boot with:

```
Failed to initialize service {"error": "build outbox postgres client: bootstrap: building outbox postgres client: postgres new: postgres-primary: TLS required (set ALLOW_INSECURE_TLS=true to bypass)"}
```

Caradhras ships an outbox feature (absent in Casdoor) whose Postgres client reads `ALLOW_INSECURE_TLS` and fails closed without it. The `auth-backend` container had no way at all to receive this (or any other) env var — `auth`/`identity` already support `extraEnvVars`, `auth-backend` never did. Defaulting the key to `"true"` (rather than requiring every values.yaml to opt in) means existing and new caradhras installs work out of the box, consistent with how the same flag already defaults everywhere else in this chart.

### Impact

- Casdoor never reads `ALLOW_INSECURE_TLS`; existing installs are unaffected in behavior — only the rendered ConfigMap gains one new key (always `"true"` unless overridden).
- `extraEnvVars` renders nothing when unset ({{- with }}), no change there either.
- Caveat: setting `ALLOW_INSECURE_TLS` via `auth.backend.extraEnvVars` in addition to the new native key produces a duplicate map key in the rendered ConfigMap (last-wins in practice, invalid YAML strictly) — same latent risk already accepted for `auth`/`identity`. Prefer `auth.backend.allowInsecureTLS` to override.

### Testing

- `helm lint charts/plugin-access-manager` — clean.
- `helm template` render-equivalence: default values now render one new `ALLOW_INSECURE_TLS: "true"` line (expected, matches auth/identity convention); nothing else changed.
- `helm template` with `auth.backend.extraEnvVars` set — confirmed correctly merged, no interference with the new native key when not duplicated.
