### PR TITLE
fix(br-sta): pass ALLOW_INSECURE_TLS to migrations Job for non-TLS Postgres

### DIFF
--- a/charts/br-sta/templates/migrations.yaml
+++ b/charts/br-sta/templates/migrations.yaml
@@ -52,6 +52,21 @@
 {{- $migrationTag := get $migrationImage "tag" | default (get (get $app "image" | default dict) "tag" | default .Chart.AppVersion) -}}
 {{- $migrationDigest := get $migrationImage "digest" | default "" -}}
 {{- $migrationRepository := get $migrationImage "repository" | default "ghcr.io/lerianstudio/br-sta-migrations" -}}
+{{- /* lib-commons' migrator refuses to connect to a non-TLS Postgres unless
+     ALLOW_INSECURE_TLS=true — POSTGRES_SSLMODE=disable alone is not enough. The
+     app deployment gets this via extraEnvVars/configmap; the migration Job must
+     mirror it. Resolution order: migrations.allowInsecureTLS override →
+     app.extraEnvVars → app.configmap. Emitted only when set, so TLS tiers stay
+     secure by default. */}}
+{{- $extraEnv := get $app "extraEnvVars" | default dict -}}
+{{- $allowInsecureTLS := "" -}}
+{{- if get $migrations "allowInsecureTLS" -}}
+{{- $allowInsecureTLS = toString (get $migrations "allowInsecureTLS") -}}
+{{- else if get $extraEnv "ALLOW_INSECURE_TLS" -}}
+{{- $allowInsecureTLS = toString (get $extraEnv "ALLOW_INSECURE_TLS") -}}
+{{- else if get $configmap "ALLOW_INSECURE_TLS" -}}
+{{- $allowInsecureTLS = toString (get $configmap "ALLOW_INSECURE_TLS") -}}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -156,6 +171,12 @@ spec:
               value: {{ get $configmap "POSTGRES_NAME" | default "br_sta" | quote }}
             - name: POSTGRES_SSLMODE
               value: {{ get $configmap "POSTGRES_SSLMODE" | default "require" | quote }}
+            {{- if $allowInsecureTLS }}
+            # lib-commons migrator bypass for non-TLS Postgres (sslmode=disable
+            # alone is rejected). Mirrors the app's ALLOW_INSECURE_TLS.
+            - name: ALLOW_INSECURE_TLS
+              value: {{ $allowInsecureTLS | quote }}
+            {{- end }}
             - name: POSTGRES_CONNECT_TIMEOUT_SEC
               value: {{ get $configmap "POSTGRES_CONNECT_TIMEOUT_SEC" | default "10" | quote }}
             {{- with (get $migrations "timeoutSeconds") }}

--- a/charts/br-sta/values.yaml
+++ b/charts/br-sta/values.yaml
@@ -92,6 +92,11 @@ br-sta:
       pullPolicy: IfNotPresent
     # -- Path inside the image where the SQL migrations live.
     path: "/migrations"
+    # -- Bypass the lib-commons migrator TLS guard for a non-TLS Postgres
+    # (POSTGRES_SSLMODE=disable is rejected without it). When empty, inherits
+    # ALLOW_INSECURE_TLS from br-sta.extraEnvVars, then br-sta.configmap. Leave
+    # empty for a TLS-enabled Postgres.
+    allowInsecureTLS: ""
     # -- Maximum retries before the Job is considered failed.
     backoffLimit: 3
     # -- Hard wall-clock cap for the Job (seconds).


### PR DESCRIPTION
## What
The br-sta migrations Job now sets `ALLOW_INSECURE_TLS` when the app is configured for a non-TLS Postgres.

## Why
The lib-commons migrator (used by `init/postgres-migrations`) refuses to connect to a non-TLS Postgres unless `ALLOW_INSECURE_TLS=true` — `POSTGRES_SSLMODE=disable` alone is rejected. Observed live on dev-st:

```
apply migrations: postgres migrate_up: postgres-primary: TLS required (set ALLOW_INSECURE_TLS=true to bypass)
```

The app Deployment already receives this via `extraEnvVars`/`configmap`; the migration Job was missing it (regression vs the plugin-br-bank-transfer template, which set it).

## How
`templates/migrations.yaml` resolves `ALLOW_INSECURE_TLS` from `migrations.allowInsecureTLS` override → `br-sta.extraEnvVars` → `br-sta.configmap`, and emits it only when set (TLS tiers stay secure by default). Adds the `migrations.allowInsecureTLS` value.

## Validation
`helm template` against the benedita dev-st and stg-st values renders `ALLOW_INSECURE_TLS=true` alongside `sslmode=disable`; a TLS-like config (flag unset) omits it. `helm lint` clean.

Follow-up: bump the gitops helmfile chart pin (dev-st + stg-st) to the version this releases (expected 1.0.0-beta.5).