### PR TITLE
feat(plugin-access-manager): add optional auth backend console (UI)

### DIFF
--- a/charts/plugin-access-manager/templates/_helpers.tpl
+++ b/charts/plugin-access-manager/templates/_helpers.tpl
@@ -19,6 +19,13 @@ Expand the name of the chart and plugin auth.
 {{- default "plugin-access-manager-auth-backend" .Values.auth.backend.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Expand the name of the chart and plugin auth ui.
+*/}}
+{{- define "plugin-auth-ui.name" -}}
+{{- default "plugin-access-manager-auth-ui" .Values.auth.ui.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 
 {{/*
 Create chart name and version as used by the chart label for plugin identity.
@@ -38,6 +45,13 @@ Create chart name and version as used by the chart label for plugin auth.
 Create chart name and version as used by the chart label for plugin auth.
 */}}
 {{- define "plugin-auth-backend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label for plugin auth ui.
+*/}}
+{{- define "plugin-auth-ui.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -66,6 +80,15 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "plugin-auth-backend.fullname" -}}
 {{- default "plugin-access-manager-auth-backend" .Values.auth.backend.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name auth ui.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "plugin-auth-ui.fullname" -}}
+{{- default "plugin-access-manager-auth-ui" .Values.auth.ui.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -106,6 +129,16 @@ app.kubernetes.io/instance: {{ .context.Release.Name }}
 {{- end }}
 
 {{/*
+Auth UI Selector labels
+*/}}
+{{- define "plugin-auth-ui.selectorLabels" -}}
+{{- if .name -}}
+app.kubernetes.io/name: {{ include "plugin-auth-ui.name" .context }}
+{{- end }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- end }}
+
+{{/*
 Identity Common labels
 */}}
 {{- define "plugin-identity.labels" -}}
@@ -131,6 +164,16 @@ Auth Backend Common labels
 {{- define "plugin-auth-backend.labels" -}}
 helm.sh/chart: {{ include "plugin-auth-backend.chart" .context }}
 {{ include "plugin-auth-backend.selectorLabels" (dict "context" .context "name" .name) }}
+app.kubernetes.io/version: {{ include "plugin.version" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+{{- end }}
+
+{{/*
+Auth UI Common labels
+*/}}
+{{- define "plugin-auth-ui.labels" -}}
+helm.sh/chart: {{ include "plugin-auth-ui.chart" .context }}
+{{ include "plugin-auth-ui.selectorLabels" (dict "context" .context "name" .name) }}
 app.kubernetes.io/version: {{ include "plugin.version" .context }}
 app.kubernetes.io/managed-by: {{ .context.Release.Service }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/auth/ui/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth/ui/deployment.yaml
@@ -26,8 +26,13 @@ spec:
         {{- toYaml .Values.auth.ui.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ include "plugin-auth-ui.fullname" . }}
+          # The image's envsubst-on-templates entrypoint writes the rendered
+          # nginx config to /etc/nginx/conf.d/ at container start, so root
+          # can't be read-only (same tradeoff as auth.backend's casdoor
+          # container — see values.yaml).
           securityContext:
-            {{- toYaml .Values.auth.ui.securityContext | nindent 12 }}
+            {{- toYaml (omit .Values.auth.ui.securityContext "readOnlyRootFilesystem") | nindent 12 }}
+            readOnlyRootFilesystem: false
           image: "{{ .Values.auth.ui.image.repository }}:{{ .Values.auth.ui.image.tag }}"
           imagePullPolicy: {{ .Values.auth.ui.image.pullPolicy }}
           ports:

--- a/charts/plugin-access-manager/templates/auth/ui/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth/ui/deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.auth.ui.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "plugin-auth-ui.fullname" . }}
+  labels:
+    {{- include "plugin-auth-ui.labels" (dict "context" . "name" .Values.auth.ui.name ) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .Values.auth.ui.revisionHistoryLimit | default 10 }}
+  strategy:
+    {{- toYaml .Values.auth.deploymentStrategy | nindent 4 }}
+  replicas: {{ .Values.auth.ui.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "plugin-auth-ui.selectorLabels" (dict "context" . "name" .Values.auth.ui.name) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "plugin-auth-ui.labels" (dict "context" . "name" .Values.auth.ui.name ) | nindent 8 }}
+    spec:
+      {{- with .Values.auth.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.auth.ui.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "plugin-auth-ui.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.auth.ui.securityContext | nindent 12 }}
+          image: "{{ .Values.auth.ui.image.repository }}:{{ .Values.auth.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.auth.ui.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+          # The image's own docker-entrypoint.d/20-envsubst-on-templates.sh
+          # renders ui/nginx.conf.template into /etc/nginx/conf.d/ at
+          # container start, substituting these two vars.
+          - name: CARADHRAS_BACKEND_ADDR
+            value: "{{ include "plugin-auth-backend.fullname" . }}:8000"
+          - name: NGINX_RESOLVER_ADDR
+            value: {{ .Values.auth.ui.nginxResolverAddr | quote }}
+          resources:
+            {{- toYaml .Values.auth.ui.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.auth.ui.readinessProbe.path | default "/healthz" }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.auth.ui.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.auth.ui.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ .Values.auth.ui.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.auth.ui.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.auth.ui.readinessProbe.failureThreshold | default 3 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.auth.ui.livenessProbe.path | default "/healthz" }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.auth.ui.livenessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.auth.ui.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.auth.ui.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.auth.ui.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.auth.ui.livenessProbe.failureThreshold | default 3 }}
+      {{- with .Values.auth.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/plugin-access-manager/templates/auth/ui/ingress.yaml
+++ b/charts/plugin-access-manager/templates/auth/ui/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.auth.ui.enabled .Values.auth.ui.ingress.enabled -}}
+{{- $fullName := include "plugin-auth-ui.fullname" . -}}
+{{- $svcPort := .Values.auth.ui.service.port -}}
+{{- if and .Values.auth.ui.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.auth.ui.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.auth.ui.ingress.annotations "kubernetes.io/ingress.class" .Values.auth.ui.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "plugin-auth-ui.labels" (dict "context" . "name" .Values.auth.ui.name ) | nindent 4 }}
+  {{- with .Values.auth.ui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.auth.ui.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.auth.ui.ingress.className }}
+  {{- end }}
+  {{- if .Values.auth.ui.ingress.tls }}
+  tls:
+    {{- range .Values.auth.ui.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.auth.ui.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/plugin-access-manager/templates/auth/ui/service.yaml
+++ b/charts/plugin-access-manager/templates/auth/ui/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.auth.ui.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "plugin-auth-ui.fullname" . }}
+  labels:
+    {{- include "plugin-auth-ui.labels" (dict "context" . "name" .Values.auth.ui.name ) | nindent 4 }}
+spec:
+  type: {{ .Values.auth.ui.service.type }}
+  ports:
+    - port: {{ .Values.auth.ui.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "plugin-auth-ui.selectorLabels" (dict "context" . "name" .Values.auth.ui.name) | nindent 4 }}
+{{- end }}

--- a/charts/plugin-access-manager/values.yaml
+++ b/charts/plugin-access-manager/values.yaml
@@ -351,6 +351,79 @@ auth:
         pullPolicy: Always
         # -- Image tag used for deployment
         tag: "2.6.3"
+  # -- Auth backend console (SPA). Opt-in: only the caradhras backend ships a
+  # matching UI image today, so this defaults to disabled to keep any other
+  # auth.backend.image consumer of this chart unaffected.
+  ui:
+    # -- Enable or disable the auth backend console Deployment/Service/Ingress
+    enabled: false
+    # -- Readiness probe configuration. All fields override chart defaults.
+    readinessProbe: {}
+    # -- Liveness probe configuration. All fields override chart defaults.
+    livenessProbe: {}
+    replicaCount: 1
+    revisionHistoryLimit: 10
+    name: "plugin-access-manager-auth-ui"
+    image:
+      # -- Repository for the console (SPA) container image
+      repository: ghcr.io/lerianstudio/caradhras-ui
+      # -- Image pull policy
+      pullPolicy: Always
+      # -- Image tag used for deployment
+      tag: ""
+    resources:
+      # -- CPU and memory limits for pods
+      limits:
+        cpu: 200m
+        memory: 128Mi
+      # -- Minimum CPU and memory requests
+      requests:
+        cpu: 50m
+        memory: 32Mi
+    # -- nginx (image entrypoint's envsubst-on-templates) resolves the backend
+    # Service name at request time via this DNS resolver. Defaults to the
+    # common CoreDNS Service name/namespace on kubeadm/EKS/GKE; override for
+    # clusters using a different in-cluster DNS Service.
+    nginxResolverAddr: "kube-dns.kube-system.svc.cluster.local"
+    podSecurityContext: {}
+    securityContext:
+      # -- nginx-unprivileged's default uid/gid (not 1000 like the other
+      # components in this chart)
+      runAsGroup: 101
+      runAsUser: 101
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
+      # -- The image's envsubst-on-templates entrypoint writes the rendered
+      # config to /etc/nginx/conf.d/ at container start, so root can't be
+      # read-only (same tradeoff as auth.backend's casdoor container).
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+    service:
+      # -- Kubernetes service type
+      type: ClusterIP
+      # -- Service port
+      port: 8080
+    ingress:
+      # -- Enable or disable ingress
+      enabled: false
+      # -- Ingress class name
+      className: ""
+      # -- Additional ingress annotations
+      annotations: {}
+      hosts:
+        - host: ""
+          paths:
+            - path: /
+              pathType: Prefix
+      # -- TLS configuration for ingress
+      tls: []
+      #  - secretName: chart-example-tls
+      #  hosts:
+      #      - chart-example.local
   # -- Init User Job configuration
   # -- Creates admin user on FIRST INSTALL ONLY (not on upgrades)
   # -- If the admin user is deleted by the customer, it will NOT be recreated

--- a/charts/plugin-access-manager/values.yaml
+++ b/charts/plugin-access-manager/values.yaml
@@ -386,6 +386,11 @@ auth:
     # clusters using a different in-cluster DNS Service.
     nginxResolverAddr: "kube-dns.kube-system.svc.cluster.local"
     podSecurityContext: {}
+    # -- readOnlyRootFilesystem here is the honest chart-standard default;
+    # templates/auth/ui/deployment.yaml overrides it to false for the
+    # container (the image's envsubst-on-templates entrypoint writes the
+    # rendered nginx config to /etc/nginx/conf.d/ at start), same pattern as
+    # auth.backend's casdoor container.
     securityContext:
       # -- nginx-unprivileged's default uid/gid (not 1000 like the other
       # components in this chart)
@@ -395,10 +400,7 @@ auth:
       capabilities:
         drop:
           - ALL
-      # -- The image's envsubst-on-templates entrypoint writes the rendered
-      # config to /etc/nginx/conf.d/ at container start, so root can't be
-      # read-only (same tradeoff as auth.backend's casdoor container).
-      readOnlyRootFilesystem: false
+      readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       seccompProfile:
         type: RuntimeDefault


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Plugin Access Manager

## Summary

Adds opt-in Helm support for the auth backend's SPA console (caradhras-ui): Deployment, Service, and Ingress under `templates/auth/ui/`, plus a new `auth.ui` values block and `plugin-auth-ui.*` helpers.

- Disabled by default (`auth.ui.enabled: false`) since only the caradhras backend image ships a matching UI image today; every other consumer of this chart (plain casdoor) is unaffected.
- The backend address and DNS resolver are injected via `CARADHRAS_BACKEND_ADDR` / `NGINX_RESOLVER_ADDR` env vars, which the UI image's own `envsubst-on-templates` nginx entrypoint substitutes into its config at container start (see [caradhras#18](https://github.com/LerianStudio/caradhras/pull/18)). No nginx config is duplicated in this chart.
- `NGINX_RESOLVER_ADDR` defaults to `kube-dns.kube-system.svc.cluster.local` (common CoreDNS Service on kubeadm/EKS/GKE), overridable per-cluster.
- UI container runs as the image's native uid/gid 101 (nginx-unprivileged), with its own `securityContext`/`podSecurityContext` separate from the rest of `auth.*` (which runs as uid 1000). `readOnlyRootFilesystem: false` because the envsubst entrypoint writes the rendered config to `/etc/nginx/conf.d/` at start (same tradeoff already applied to the `auth.backend` casdoor container).
- Ingress/Service/Deployment mirror the existing `templates/auth/` patterns (naming, labels, probes) for consistency.

## Checklist

- [x] I have tested these changes locally. (`helm lint` clean; `helm template` rendered and inspected for `auth.ui.enabled=true/false`, plus a full default-values render to confirm no regressions)
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Follow-up to [caradhras#18](https://github.com/LerianStudio/caradhras/pull/18) (nginx envsubst wiring). A separate gitops PR will enable `auth.ui` for the stg-mt caradhras test instance and repoint its ingress at the new UI Service.