### PR TITLE
feat(flowker): add worker, XSD sidecar, valkey, AWS auth and ship 3.1.0

### DIFF
--- a/charts/flowker/CHANGELOG.md
+++ b/charts/flowker/CHANGELOG.md
@@ -1,3 +1,47 @@
+## [3.1.0] — Unreleased
+
+### Added
+
+- **Scheduler worker Deployment** (`worker.enabled`, default on): a second
+  Deployment running the `/worker` binary from the same flowker image (queue
+  consume server + background jobs), single replica with a `Recreate` strategy
+  and no HPA. Reuses the api ConfigMap + Secret with a worker-only ConfigMap
+  layered last. Dedicated worker helpers, ServiceAccount, and ConfigMap.
+- **Full runtime env surface** in the ConfigMap/Secret: Schema Registry S3,
+  secrets backend, token cache, internal provider URLs, scheduler
+  (`SCHEDULER_*`), CORS/body caps, and the XSD knobs. WorkOS Tenant Manager
+  token mint (`flowker.workosTmEnabled`) is all-or-none gated with fail-fast
+  `required` guards.
+- **In-pod XSD validator sidecar** (`flowker.xsdValidator.enabled`, default on):
+  injected into the api and worker pods (port 8081, hardened securityContext).
+  `XSD_VALIDATOR_URL` auto-wires to loopback; the cleartext acknowledgement is
+  scoped to the in-pod hop only (an off-pod URL override defaults back to secure).
+- **valkey subchart** (`valkey.enabled`, default off) backing the scheduler
+  queue. `SCHEDULER_REDIS_HOST` auto-derives to the subchart Service when
+  enabled; an explicit override or an external Redis is honored.
+- **AWS authentication**: IRSA via the api/worker ServiceAccount annotations,
+  and an optional IAM Roles Anywhere signing sidecar (`aws.rolesAnywhere.enabled`,
+  default off) for non-EKS clusters, serving credentials over a loopback IMDS
+  endpoint with the client cert mounted read-only.
+
+### Changed
+
+- Chart type annotation `single-service` → `multi-component`.
+- Default `flowker.image.tag` bumped to `1.2.0-beta.82` (the first image that
+  bundles the `/worker` binary and has a published `flowker-xsd-validator`
+  sidecar image). `appVersion` updated to match.
+- Shared init/env helpers (`flowker.waitForMongoInit`, `flowker.otelHostEnv`)
+  extracted and reused across the api and worker Deployments.
+
+### Migration notes
+
+- The worker and XSD sidecar default on and require an app image
+  >= `1.2.0-beta.82`. Pin `flowker.image.tag` accordingly, or set
+  `worker.enabled=false` / `flowker.xsdValidator.enabled=false` to opt out.
+- To run the scheduler, either set `valkey.enabled=true` or point
+  `flowker.configmap.SCHEDULER_REDIS_HOST` at an external Redis; otherwise the
+  scheduler stays a nil-safe no-op.
+
 ## [2.1.0-beta.5] — Unreleased
 
 ### Changed

--- a/charts/flowker/Chart.lock
+++ b/charts/flowker/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
   version: 16.4.0
-digest: sha256:9ba722b7a43665565e6d93958986982b93d8714781b099c10e7bad5fde723b72
-generated: "2026-06-06T17:02:25.916332-03:00"
+- name: valkey
+  repository: https://valkey.io/valkey-helm
+  version: 0.7.4
+digest: sha256:def3a0242b6481c271017af40ec0685770301e0e550979023cd1fc7b3e1712c9
+generated: "2026-07-10T12:46:18.152659-03:00"

--- a/charts/flowker/Chart.yaml
+++ b/charts/flowker/Chart.yaml
@@ -25,3 +25,7 @@ dependencies:
     version: "16.4.0"
     repository: "https://charts.bitnami.com/bitnami"
     condition: mongodb.enabled
+  - name: valkey
+    version: "0.7.4"
+    repository: "https://valkey.io/valkey-helm"
+    condition: valkey.enabled

--- a/charts/flowker/Chart.yaml
+++ b/charts/flowker/Chart.yaml
@@ -4,15 +4,15 @@ description: A Helm chart for Flowker - Workflow orchestration platform for
   financial validation
 type: application
 annotations:
-  lerian.studio/chart-type: single-service
+  lerian.studio/chart-type: multi-component
 home: https://github.com/LerianStudio/flowker
 sources:
   - https://github.com/LerianStudio/flowker
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 3.0.0
-appVersion: "1.0.0"
+version: 3.1.0
+appVersion: "1.2.0-beta.82"
 keywords:
   - flowker
   - workflow

--- a/charts/flowker/README.md
+++ b/charts/flowker/README.md
@@ -2,13 +2,29 @@
 
 ## Chart Contract
 
-- Chart type: `single-service`
+- Chart type: `multi-component`
 - Required secrets: `flowker.secrets.AUDIT_DB_PASSWORD` for the default non-multi-tenant render. With the bundled MongoDB subchart, `MONGO_URI` is assembled automatically from the subchart-generated Secret; supply `flowker.secrets.MONGO_URI` only when pointing at external MongoDB.
 - Dependency notes: Bundles the Bitnami MongoDB subchart unless external MongoDB is configured. MongoDB credentials are single-sourced from the subchart Secret (`mongodb-root-password`) — operators do not supply them for the bundled instance. The audit PostgreSQL (required when `MULTI_TENANT_ENABLED=false`) is always external — no PostgreSQL dependency chart is bundled.
 - Production overrides: Provide production database credentials through chart secrets or an existing Secret where supported; override image tags, ingress, resources, and dependency persistence for the target environment.
 - Source/license: Source is in `github.com/LerianStudio/helm`; license is Apache-2.0.
 
 A Helm chart for deploying Flowker - Workflow orchestration platform for financial validation.
+
+## Components
+
+The chart renders these workloads (all but the api are toggleable):
+
+| Component | Toggle | Default | Description |
+|-----------|--------|---------|-------------|
+| api | `flowker.enabled` | on | The Flowker HTTP API Deployment (port 4021). |
+| worker | `worker.enabled` | on | A second Deployment running the `/worker` binary from the same flowker image: the queue-backed scheduler consume server and background jobs (single replica, no HPA). |
+| xsd-validator sidecar | `flowker.xsdValidator.enabled` | on | In-pod XML/XSD validation sidecar (port 8081) injected into the api and worker pods; reached over loopback. |
+| valkey | `valkey.enabled` | off | Bundled Redis-compatible store backing the scheduler queue. When off, set `flowker.configmap.SCHEDULER_REDIS_HOST` to an external Redis. |
+| aws-signing-helper sidecar | `aws.rolesAnywhere.enabled` | off | IAM Roles Anywhere credential sidecar for non-EKS clusters. On EKS use IRSA via `flowker.serviceAccount.annotations` instead. |
+
+> The worker and XSD sidecar require an app image that bundles the `/worker` binary and a published `flowker-xsd-validator` sidecar image (>= `1.2.0-beta.82`).
+>
+> The worker and XSD sidecar are also gated on `flowker.enabled` — setting `flowker.enabled=false` disables them regardless of their own toggle.
 
 ## Prerequisites
 
@@ -65,13 +81,18 @@ The secret must contain the keys defined in `flowker.secrets` (e.g., `MONGO_URI`
 | `flowker.enabled` | Enable flowker deployment | `true` |
 | `flowker.replicaCount` | Number of replicas | `1` |
 | `flowker.image.repository` | Image repository | `ghcr.io/lerianstudio/flowker` |
-| `flowker.image.tag` | Image tag | `1.0.0-beta.22` |
+| `flowker.image.tag` | Image tag (must bundle `/worker`, >= `1.2.0-beta.82`) | `1.2.0-beta.82` |
 | `flowker.service.port` | Service port | `4021` |
 | `flowker.ingress.enabled` | Enable ingress | `false` |
 | `flowker.autoscaling.enabled` | Enable HPA | `true` |
 | `flowker.pdb.enabled` | Enable PodDisruptionBudget | `true` |
 | `flowker.useExistingSecret` | Use an existing secret | `false` |
 | `flowker.existingSecretName` | Name of the existing secret | `""` |
+| `flowker.workosTmEnabled` | Enable WorkOS Tenant Manager token mint (all-or-none) | `false` |
+| `flowker.xsdValidator.enabled` | Inject the in-pod XSD validator sidecar | `true` |
+| `worker.enabled` | Deploy the scheduler worker Deployment | `true` |
+| `valkey.enabled` | Bundle valkey as the scheduler queue Redis | `false` |
+| `aws.rolesAnywhere.enabled` | Inject the IAM Roles Anywhere signing sidecar | `false` |
 | `mongodb.enabled` | Enable bundled MongoDB subchart | `true` |
 
 For full configuration options, see [values.yaml](values.yaml).

--- a/charts/flowker/README.md
+++ b/charts/flowker/README.md
@@ -12,7 +12,7 @@ A Helm chart for deploying Flowker - Workflow orchestration platform for financi
 
 ## Components
 
-The chart renders these workloads (all but the api are toggleable):
+The chart renders these workloads (all are toggleable; the api via `flowker.enabled`):
 
 | Component | Toggle | Default | Description |
 |-----------|--------|---------|-------------|

--- a/charts/flowker/templates/_helpers.tpl
+++ b/charts/flowker/templates/_helpers.tpl
@@ -248,6 +248,84 @@ is enabled. Shared by the api and worker Deployments. Input (dict): context (roo
 {{- end }}
 
 {{/*
+flowker.xsdValidator.enabled — nil-aware: unset/true enables, explicit false disables.
+*/}}
+{{- define "flowker.xsdValidator.enabled" -}}
+{{- $x := .Values.flowker.xsdValidator | default dict -}}
+{{- if and .Values.flowker.enabled (ne (toString $x.enabled) "false") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+flowker.xsdValidatorContainer — the in-pod XSD validator sidecar container, shared
+by the api and worker pods. Flowker reaches it over loopback (XSD_VALIDATOR_URL).
+Its own /v1 authorization delegates to the Access Manager (PLUGIN_AUTH_*), defaulting
+to the app's PLUGIN_AUTH_* config. Input (dict): context (root .).
+*/}}
+{{- define "flowker.xsdValidatorContainer" -}}
+{{- $ctx := .context -}}
+{{- $x := $ctx.Values.flowker.xsdValidator | default dict -}}
+{{- $img := $x.image | default dict -}}
+{{- $repo := $img.repository | default "ghcr.io/lerianstudio/flowker-xsd-validator" -}}
+{{- $tag := $img.tag | default (include "flowker.defaultTag" $ctx) -}}
+{{- $pullPolicy := $img.pullPolicy | default $ctx.Values.flowker.image.pullPolicy -}}
+{{- $port := (($x.port) | default 8081) -}}
+{{- $pa := $x.pluginAuth | default dict -}}
+{{- $lp := $x.livenessProbe | default dict -}}
+{{- $rp := $x.readinessProbe | default dict -}}
+- name: xsd-validator
+  image: "{{ $repo }}:{{ $tag }}"
+  imagePullPolicy: {{ $pullPolicy }}
+  securityContext:
+    {{- toYaml $x.securityContext | nindent 4 }}
+  env:
+    - name: PORT
+      value: {{ $port | quote }}
+    - name: ENV_NAME
+      value: {{ $x.envName | default $ctx.Values.flowker.configmap.ENV_NAME | default "development" | quote }}
+    - name: MAX_BODY_BYTES
+      value: {{ $x.maxBodyBytes | default "5242880" | quote }}
+    - name: READ_TIMEOUT
+      value: {{ $x.readTimeout | default "10s" | quote }}
+    - name: WRITE_TIMEOUT
+      value: {{ $x.writeTimeout | default "10s" | quote }}
+    - name: PLUGIN_AUTH_ENABLED
+      {{- /* toString distinguishes set-vs-unset so a typed bool false is honored (not swallowed by default) */}}
+      value: {{ (ne (toString $pa.enabled) "") | ternary (toString $pa.enabled) ($ctx.Values.flowker.configmap.PLUGIN_AUTH_ENABLED | default "false") | quote }}
+    - name: PLUGIN_AUTH_ADDRESS
+      value: {{ $pa.address | default $ctx.Values.flowker.configmap.PLUGIN_AUTH_ADDRESS | default "" | quote }}
+    - name: PLUGIN_AUTH_ALLOW_INSECURE_HTTP
+      value: {{ $pa.allowInsecureHttp | default "false" | quote }}
+  ports:
+    - name: xsd
+      containerPort: {{ $port }}
+      protocol: TCP
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: xsd
+    initialDelaySeconds: {{ $lp.initialDelaySeconds | default 10 }}
+    periodSeconds: {{ $lp.periodSeconds | default 20 }}
+    timeoutSeconds: {{ $lp.timeoutSeconds | default 5 }}
+    successThreshold: {{ $lp.successThreshold | default 1 }}
+    failureThreshold: {{ $lp.failureThreshold | default 3 }}
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: xsd
+    initialDelaySeconds: {{ $rp.initialDelaySeconds | default 5 }}
+    periodSeconds: {{ $rp.periodSeconds | default 10 }}
+    timeoutSeconds: {{ $rp.timeoutSeconds | default 5 }}
+    successThreshold: {{ $rp.successThreshold | default 1 }}
+    failureThreshold: {{ $rp.failureThreshold | default 3 }}
+  resources:
+    {{- toYaml $x.resources | nindent 4 }}
+{{- end }}
+
+{{/*
 Vendored from Bitnami common (charts/common/templates/_names.tpl) so infra
 Secret/Service names render even when all bundled subcharts are disabled
 (external-infra path). Self-contained: no other common.* helpers required.

--- a/charts/flowker/templates/_helpers.tpl
+++ b/charts/flowker/templates/_helpers.tpl
@@ -248,6 +248,14 @@ is enabled. Shared by the api and worker Deployments. Input (dict): context (roo
 {{- end }}
 
 {{/*
+flowker.valkey.enabled — true only for an explicit enable (default off). Backs the
+scheduler queue Redis; an external Redis is used by overriding SCHEDULER_REDIS_HOST instead.
+*/}}
+{{- define "flowker.valkey.enabled" -}}
+{{- eq (toString (.Values.valkey | default dict).enabled) "true" -}}
+{{- end -}}
+
+{{/*
 flowker.xsdValidator.enabled — nil-aware: unset/true enables, explicit false disables.
 */}}
 {{- define "flowker.xsdValidator.enabled" -}}

--- a/charts/flowker/templates/_helpers.tpl
+++ b/charts/flowker/templates/_helpers.tpl
@@ -303,7 +303,7 @@ Roles Anywhere trust anchor/profile/role over a loopback IMDS endpoint. Args: co
 {{- $img := $sc.image | default dict -}}
 {{- $port := ($sc.port | default 9911) -}}
 - name: aws-signing-helper
-  image: "{{ $img.repository | default "public.ecr.aws/rolesanywhere/credential-helper" }}:{{ $img.tag | default "latest-amd64" }}"
+  image: "{{ $img.repository | default "public.ecr.aws/rolesanywhere/credential-helper" }}:{{ $img.tag | default "1.8.4-2026.06.09.14.59" }}"
   imagePullPolicy: {{ $img.pullPolicy | default "IfNotPresent" }}
   args:
     - serve

--- a/charts/flowker/templates/_helpers.tpl
+++ b/charts/flowker/templates/_helpers.tpl
@@ -67,6 +67,65 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+================================================================================
+WORKER HELPERS
+The scheduler worker is a SECOND Deployment running the SAME flowker image with
+its command overridden to /worker. It reuses the api ConfigMap + Secret and
+layers worker-only env on top. It gets its OWN app.kubernetes.io/name so its
+(immutable) selector never overlaps the api Deployment's.
+================================================================================
+*/}}
+
+{{/* Worker resource name: "<fullname>-worker". */}}
+{{- define "flowker.worker.fullname" -}}
+{{- printf "%s-worker" (include "flowker.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/* Worker app name (distinct from the api so selectors don't overlap). */}}
+{{- define "flowker.worker.name" -}}
+{{- printf "%s-worker" (include "flowker.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/* Worker selector labels — distinct name keeps the two Deployments apart. */}}
+{{- define "flowker.worker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "flowker.worker.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- end }}
+
+{{/* Worker common labels. */}}
+{{/* FIXME(nitpick): app.kubernetes.io/version tracks the api image tag, not
+     worker.image.tag when overridden (ring-helm, 2026-07-10, Cosmetic). */}}
+{{- define "flowker.worker.labels" -}}
+helm.sh/chart: {{ include "flowker.chart" .context }}
+{{ include "flowker.worker.selectorLabels" (dict "context" .context) }}
+app.kubernetes.io/version: {{ include "flowker.versionLabelValue" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/component: worker
+{{- end }}
+
+{{/* Worker ServiceAccount name (own SA, or reuse the api's when not creating). */}}
+{{- define "flowker.worker.serviceAccountName" -}}
+{{- $w := .Values.worker | default dict -}}
+{{- $sa := $w.serviceAccount | default dict -}}
+{{- if $sa.create }}
+{{- default (include "flowker.worker.fullname" .) $sa.name }}
+{{- else }}
+{{- default (include "flowker.serviceAccountName" .) $sa.name }}
+{{- end }}
+{{- end }}
+
+{{/* Worker enabled — gated by flowker.enabled; nil-aware on worker.enabled
+     (unset/true enables, explicit false disables). */}}
+{{- define "flowker.worker.enabled" -}}
+{{- $w := .Values.worker | default dict -}}
+{{- if and .Values.flowker.enabled (ne (toString $w.enabled) "false") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the namespace of the release.
 Allows overriding it for multi-namespace deployments in combined charts.
 */}}
@@ -141,6 +200,50 @@ Input (dict): context (root .), secretName (app Secret name for the external-inl
 {{- end }}
 - name: MONGO_URI
   value: {{ printf "mongodb://%s:$(MONGO_PASSWORD)@%s:27017/?authSource=admin" $mongo.auth.rootUser (include "flowker.mongoHost" $ctx) | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+flowker.waitForMongoInit — the shared wait-for-mongodb init container, used by
+both the api and worker Deployments so they never drift. Input (dict): context (root .).
+*/}}
+{{- define "flowker.waitForMongoInit" -}}
+{{- $ctx := .context -}}
+- name: wait-for-mongodb
+  image: busybox:1.37
+  command:
+    - /bin/sh
+    - -c
+    - >
+      TIMEOUT=300;
+      ELAPSED=0;
+      {{- $mongoHost := include "flowker.mongoHost" $ctx }}
+      echo "Checking {{ $mongoHost }}:27017...";
+      while ! nc -z "{{ $mongoHost }}" 27017; do
+        if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "Timeout waiting for MongoDB after ${TIMEOUT}s";
+          exit 1;
+        fi;
+        echo "MongoDB is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+        sleep 5;
+        ELAPSED=$((ELAPSED + 5));
+      done;
+      echo "MongoDB is ready!";
+{{- end }}
+
+{{/*
+flowker.otelHostEnv — HOST_IP + OTEL endpoint env, emitted only when telemetry
+is enabled. Shared by the api and worker Deployments. Input (dict): context (root .).
+*/}}
+{{- define "flowker.otelHostEnv" -}}
+{{- $ctx := .context -}}
+{{- if eq (toString $ctx.Values.flowker.configmap.ENABLE_TELEMETRY) "true" }}
+- name: "HOST_IP"
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+- name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+  value: "$(HOST_IP):4317"
 {{- end }}
 {{- end }}
 

--- a/charts/flowker/templates/_helpers.tpl
+++ b/charts/flowker/templates/_helpers.tpl
@@ -256,6 +256,114 @@ scheduler queue Redis; an external Redis is used by overriding SCHEDULER_REDIS_H
 {{- end -}}
 
 {{/*
+flowker.awsRolesAnywhere.enabled — true only when aws.rolesAnywhere.enabled is set
+(default off). Used to gate the IAM Roles Anywhere signing sidecar on non-EKS clusters.
+*/}}
+{{- define "flowker.awsRolesAnywhere.enabled" -}}
+{{- $ra := (.Values.aws | default dict).rolesAnywhere | default dict -}}
+{{- eq (toString $ra.enabled) "true" -}}
+{{- end -}}
+
+{{/*
+flowker.podSecurityContext — renders the pod securityContext. When Roles Anywhere is
+enabled it FORCES fsGroup 65532 (the sidecar runs uid/gid 65532 and reads the 0440 cert
+Secret via that group; any other fsGroup would break credential serving) while preserving
+all other base keys. Args: context (root $), base (the map).
+*/}}
+{{- define "flowker.podSecurityContext" -}}
+{{- $base := .base | default dict -}}
+{{- if eq (include "flowker.awsRolesAnywhere.enabled" .context) "true" -}}
+{{- toYaml (merge (dict "fsGroup" 65532) (deepCopy $base)) -}}
+{{- else -}}
+{{- toYaml $base -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+flowker.awsImdsEnv — env pointing the AWS SDK at the local signing-helper IMDS endpoint.
+Args: context (root $).
+*/}}
+{{- define "flowker.awsImdsEnv" -}}
+{{- $ra := (.context.Values.aws | default dict).rolesAnywhere | default dict -}}
+{{- $port := (($ra.sidecar).port | default 9911) -}}
+- name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+  value: "http://127.0.0.1:{{ $port }}"
+- name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
+  value: "IPv4"
+{{- end -}}
+
+{{/*
+flowker.awsSigningSidecar — the aws-signing-helper container serving credentials from the
+Roles Anywhere trust anchor/profile/role over a loopback IMDS endpoint. Args: context (root $).
+*/}}
+{{- define "flowker.awsSigningSidecar" -}}
+{{- $ctx := .context -}}
+{{- $ra := ($ctx.Values.aws | default dict).rolesAnywhere | default dict -}}
+{{- $sc := $ra.sidecar | default dict -}}
+{{- $img := $sc.image | default dict -}}
+{{- $port := ($sc.port | default 9911) -}}
+- name: aws-signing-helper
+  image: "{{ $img.repository | default "public.ecr.aws/rolesanywhere/credential-helper" }}:{{ $img.tag | default "latest-amd64" }}"
+  imagePullPolicy: {{ $img.pullPolicy | default "IfNotPresent" }}
+  args:
+    - serve
+    - --certificate
+    - /certs/tls.crt
+    - --private-key
+    - /certs/tls.key
+    - --trust-anchor-arn
+    - "{{ required "aws.rolesAnywhere.trustAnchorArn is required when aws.rolesAnywhere.enabled=true" $ra.trustAnchorArn }}"
+    - --profile-arn
+    - "{{ required "aws.rolesAnywhere.profileArn is required when aws.rolesAnywhere.enabled=true" $ra.profileArn }}"
+    - --role-arn
+    - "{{ required "aws.rolesAnywhere.roleArn is required when aws.rolesAnywhere.enabled=true" $ra.roleArn }}"
+    - --region
+    - "{{ $ra.region | default "us-east-2" }}"
+    - --session-duration
+    - "{{ $ra.sessionDuration | default 3600 }}"
+    - --port
+    - "{{ $port }}"
+  ports:
+    - name: imds
+      containerPort: {{ $port }}
+      protocol: TCP
+  volumeMounts:
+    - name: iam-certs
+      mountPath: /certs
+      readOnly: true
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+  resources:
+    {{- toYaml ($sc.resources | default dict) | nindent 4 }}
+{{- end -}}
+
+{{/*
+flowker.awsCertsVolume — the iam-certs Secret volume backing the signing sidecar.
+Args: context (root $).
+*/}}
+{{- define "flowker.awsCertsVolume" -}}
+{{- $ra := (.context.Values.aws | default dict).rolesAnywhere | default dict -}}
+- name: iam-certs
+  secret:
+    secretName: {{ $ra.certificateSecretName | default "flowker-iam-tls" }}
+    defaultMode: 0440
+    items:
+      - key: tls.crt
+        path: tls.crt
+      - key: tls.key
+        path: tls.key
+{{- end -}}
+
+{{/*
 flowker.xsdValidator.enabled — nil-aware: unset/true enables, explicit false disables.
 */}}
 {{- define "flowker.xsdValidator.enabled" -}}

--- a/charts/flowker/templates/configmap.yaml
+++ b/charts/flowker/templates/configmap.yaml
@@ -130,12 +130,18 @@ data:
   {{- /* cleartext is auto-acknowledged ONLY for the in-pod loopback URL; an explicit off-pod override must opt in deliberately */}}
   XSD_VALIDATOR_ALLOW_INSECURE_HTTP: {{ .Values.flowker.configmap.XSD_VALIDATOR_ALLOW_INSECURE_HTTP | default (ternary "true" "false" (and $xsdOn (not $xsdUrlOverridden))) | quote }}
 
-  # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. SCHEDULER_REDIS_HOST
-  # is derived from the valkey subchart in a follow-up phase; empty keeps the
-  # scheduler queue a nil-safe no-op. This dedicated queue Redis MUST stay
-  # isolated from the tenant Pub/Sub Redis (MULTI_TENANT_REDIS_*).
+  # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. When the bundled
+  # valkey subchart is enabled, SCHEDULER_REDIS_HOST auto-derives to its Service
+  # name; empty (valkey off, no override) keeps the scheduler queue a nil-safe
+  # no-op. This dedicated queue Redis MUST stay isolated from the tenant Pub/Sub
+  # Redis (MULTI_TENANT_REDIS_*).
   SCHEDULER_ENABLED: {{ .Values.flowker.configmap.SCHEDULER_ENABLED | default "true" | quote }}
-  SCHEDULER_REDIS_HOST: {{ .Values.flowker.configmap.SCHEDULER_REDIS_HOST | default "" | quote }}
+  {{- /* Derive the queue host from the valkey subchart's actual Service name (<release>-valkey, or fullnameOverride) so it resolves under any release name; an explicit override always wins. */}}
+  {{- $valkeyHost := "" }}
+  {{- if eq (include "flowker.valkey.enabled" .) "true" }}
+  {{- $valkeyHost = include "common.names.dependency.fullname" (dict "chartName" "valkey" "chartValues" (.Values.valkey | default dict) "context" .) }}
+  {{- end }}
+  SCHEDULER_REDIS_HOST: {{ .Values.flowker.configmap.SCHEDULER_REDIS_HOST | default $valkeyHost | quote }}
   SCHEDULER_REDIS_PORT: {{ .Values.flowker.configmap.SCHEDULER_REDIS_PORT | default "6379" | quote }}
   SCHEDULER_REDIS_TLS: {{ .Values.flowker.configmap.SCHEDULER_REDIS_TLS | default "false" | quote }}
   SCHEDULER_REDIS_DB: {{ .Values.flowker.configmap.SCHEDULER_REDIS_DB | default "0" | quote }}

--- a/charts/flowker/templates/configmap.yaml
+++ b/charts/flowker/templates/configmap.yaml
@@ -119,11 +119,16 @@ data:
   FLOWKER_SECRETS_CACHE_TTL_SEC: {{ .Values.flowker.configmap.FLOWKER_SECRETS_CACHE_TTL_SEC | default "" | quote }}
   FLOWKER_SECRETS_APPLICATION_NAME: {{ .Values.flowker.configmap.FLOWKER_SECRETS_APPLICATION_NAME | default "" | quote }}
 
-  # XSD validator (app-side knobs). The in-pod sidecar container and the loopback
-  # URL are wired in a follow-up phase; empty URL keeps the feature unconfigured
-  # (never a hard boot dependency). ALLOW_INSECURE_HTTP secure-by-default false.
-  XSD_VALIDATOR_URL: {{ .Values.flowker.configmap.XSD_VALIDATOR_URL | default "" | quote }}
-  XSD_VALIDATOR_ALLOW_INSECURE_HTTP: {{ .Values.flowker.configmap.XSD_VALIDATOR_ALLOW_INSECURE_HTTP | default "false" | quote }}
+  # XSD validator (app-side knobs). When the in-pod sidecar is enabled, the URL
+  # defaults to the loopback sidecar and cleartext http is acknowledged for that
+  # same-pod hop; an explicit override always wins. When the sidecar is disabled
+  # the URL is empty (feature unconfigured — never a hard boot dependency).
+  {{- $xsdOn := eq (include "flowker.xsdValidator.enabled" .) "true" }}
+  {{- $xsdPort := ((.Values.flowker.xsdValidator).port | default 8081) }}
+  {{- $xsdUrlOverridden := ne (.Values.flowker.configmap.XSD_VALIDATOR_URL | default "") "" }}
+  XSD_VALIDATOR_URL: {{ .Values.flowker.configmap.XSD_VALIDATOR_URL | default (ternary (printf "http://localhost:%v" $xsdPort) "" $xsdOn) | quote }}
+  {{- /* cleartext is auto-acknowledged ONLY for the in-pod loopback URL; an explicit off-pod override must opt in deliberately */}}
+  XSD_VALIDATOR_ALLOW_INSECURE_HTTP: {{ .Values.flowker.configmap.XSD_VALIDATOR_ALLOW_INSECURE_HTTP | default (ternary "true" "false" (and $xsdOn (not $xsdUrlOverridden))) | quote }}
 
   # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. SCHEDULER_REDIS_HOST
   # is derived from the valkey subchart in a follow-up phase; empty keeps the

--- a/charts/flowker/templates/configmap.yaml
+++ b/charts/flowker/templates/configmap.yaml
@@ -87,6 +87,65 @@ data:
   MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.flowker.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
   {{- end }}
 
+  # HTTP egress body cap (bytes). Caps request/response bodies on provider calls.
+  HTTP_MAX_BODY_BYTES: {{ .Values.flowker.configmap.HTTP_MAX_BODY_BYTES | default "10485760" | quote }}
+
+  # CORS wildcard (lib-commons parity). Secure-by-default false; local overrides to true.
+  ALLOW_CORS_WILDCARD: {{ .Values.flowker.configmap.ALLOW_CORS_WILDCARD | default "false" | quote }}
+
+  # Internal (Lerian-managed) provider base URLs. Empty = stored config doc value used.
+  MIDAZ_BASE_URL: {{ .Values.flowker.configmap.MIDAZ_BASE_URL | default "" | quote }}
+  TRACER_BASE_URL: {{ .Values.flowker.configmap.TRACER_BASE_URL | default "" | quote }}
+
+  # Schema Registry auth gates (secure default: true)
+  XSD_SCHEMAS_AUTH_ENABLED: {{ .Values.flowker.configmap.XSD_SCHEMAS_AUTH_ENABLED | default "true" | quote }}
+  OPENAPI_SCHEMAS_AUTH_ENABLED: {{ .Values.flowker.configmap.OPENAPI_SCHEMAS_AUTH_ENABLED | default "true" | quote }}
+
+  # Schema Registry blob storage (S3). Graceful-off: empty bucket disables the S3
+  # backend (boot proceeds Mongo-only). AWS creds come from the credential chain
+  # (IRSA / Roles Anywhere). Empty region resolves via the standard AWS SDK chain.
+  SCHEMA_REGISTRY_S3_BUCKET: {{ .Values.flowker.configmap.SCHEMA_REGISTRY_S3_BUCKET | default "" | quote }}
+  SCHEMA_REGISTRY_S3_REGION: {{ .Values.flowker.configmap.SCHEMA_REGISTRY_S3_REGION | default "" | quote }}
+
+  # Shared OAuth2 token cache
+  TOKEN_CACHE_MAX_TTL_SEC: {{ .Values.flowker.configmap.TOKEN_CACHE_MAX_TTL_SEC | default "3600" | quote }}
+  TOKEN_CACHE_JANITOR_INTERVAL_SEC: {{ .Values.flowker.configmap.TOKEN_CACHE_JANITOR_INTERVAL_SEC | default "300" | quote }}
+  TOKEN_CACHE_REFRESH_BUFFER_SEC: {{ .Values.flowker.configmap.TOKEN_CACHE_REFRESH_BUFFER_SEC | default "60" | quote }}
+  TOKEN_CACHE_TENANT_SCOPED_DISABLED: {{ .Values.flowker.configmap.TOKEN_CACHE_TENANT_SCOPED_DISABLED | default "false" | quote }}
+
+  # Secrets backend. unset = disabled (boots fine); tenant-manager = AWS Secrets
+  # Manager reader. WORKOS_TM_SERVICE_NAME MUST match FLOWKER_SECRETS_APPLICATION_NAME.
+  FLOWKER_SECRETS_BACKEND: {{ .Values.flowker.configmap.FLOWKER_SECRETS_BACKEND | default "" | quote }}
+  FLOWKER_SECRETS_CACHE_TTL_SEC: {{ .Values.flowker.configmap.FLOWKER_SECRETS_CACHE_TTL_SEC | default "" | quote }}
+  FLOWKER_SECRETS_APPLICATION_NAME: {{ .Values.flowker.configmap.FLOWKER_SECRETS_APPLICATION_NAME | default "" | quote }}
+
+  # XSD validator (app-side knobs). The in-pod sidecar container and the loopback
+  # URL are wired in a follow-up phase; empty URL keeps the feature unconfigured
+  # (never a hard boot dependency). ALLOW_INSECURE_HTTP secure-by-default false.
+  XSD_VALIDATOR_URL: {{ .Values.flowker.configmap.XSD_VALIDATOR_URL | default "" | quote }}
+  XSD_VALIDATOR_ALLOW_INSECURE_HTTP: {{ .Values.flowker.configmap.XSD_VALIDATOR_ALLOW_INSECURE_HTTP | default "false" | quote }}
+
+  # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. SCHEDULER_REDIS_HOST
+  # is derived from the valkey subchart in a follow-up phase; empty keeps the
+  # scheduler queue a nil-safe no-op. This dedicated queue Redis MUST stay
+  # isolated from the tenant Pub/Sub Redis (MULTI_TENANT_REDIS_*).
+  SCHEDULER_ENABLED: {{ .Values.flowker.configmap.SCHEDULER_ENABLED | default "true" | quote }}
+  SCHEDULER_REDIS_HOST: {{ .Values.flowker.configmap.SCHEDULER_REDIS_HOST | default "" | quote }}
+  SCHEDULER_REDIS_PORT: {{ .Values.flowker.configmap.SCHEDULER_REDIS_PORT | default "6379" | quote }}
+  SCHEDULER_REDIS_TLS: {{ .Values.flowker.configmap.SCHEDULER_REDIS_TLS | default "false" | quote }}
+  SCHEDULER_REDIS_DB: {{ .Values.flowker.configmap.SCHEDULER_REDIS_DB | default "0" | quote }}
+  SCHEDULER_CONCURRENCY: {{ .Values.flowker.configmap.SCHEDULER_CONCURRENCY | default "10" | quote }}
+
+  # WorkOS Tenant Manager token mint (feature #300) — ALL-OR-NONE. When enabled,
+  # URL + CLIENT_ID (here) + CLIENT_SECRET (Secret) are all required; a partial
+  # config is rejected at template time (mirrors the app's fail-fast boot check).
+  {{- if .Values.flowker.workosTmEnabled }}
+  WORKOS_TM_TOKEN_URL: {{ required "flowker.configmap.WORKOS_TM_TOKEN_URL is required when flowker.workosTmEnabled=true" .Values.flowker.configmap.WORKOS_TM_TOKEN_URL | quote }}
+  WORKOS_TM_CLIENT_ID: {{ required "flowker.configmap.WORKOS_TM_CLIENT_ID is required when flowker.workosTmEnabled=true" .Values.flowker.configmap.WORKOS_TM_CLIENT_ID | quote }}
+  WORKOS_TM_SCOPE: {{ .Values.flowker.configmap.WORKOS_TM_SCOPE | default "" | quote }}
+  WORKOS_TM_SERVICE_NAME: {{ .Values.flowker.configmap.WORKOS_TM_SERVICE_NAME | default "flowker" | quote }}
+  {{- end }}
+
   # Extra Env Vars
   {{- with .Values.flowker.extraEnvVars }}
   {{- range $key, $value := . }}

--- a/charts/flowker/templates/deployment.yaml
+++ b/charts/flowker/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
             failureThreshold: {{ .Values.flowker.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.flowker.resources | nindent 12 }}
+        {{- if eq (include "flowker.xsdValidator.enabled" .) "true" }}
+        {{- include "flowker.xsdValidatorContainer" (dict "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.flowker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/flowker/templates/deployment.yaml
+++ b/charts/flowker/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "flowker.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.flowker.podSecurityContext | nindent 8 }}
+        {{- include "flowker.podSecurityContext" (dict "context" $ "base" .Values.flowker.podSecurityContext) | nindent 8 }}
       initContainers:
         {{- include "flowker.waitForMongoInit" (dict "context" $) | nindent 8 }}
       containers:
@@ -54,6 +54,9 @@ spec:
           {{- $secretName := ternary .Values.flowker.existingSecretName (include "flowker.fullname" .) .Values.flowker.useExistingSecret }}
           {{- include "flowker.mongoEnv" (dict "context" $ "secretName" $secretName) | nindent 10 }}
           {{- include "flowker.otelHostEnv" (dict "context" $) | nindent 10 }}
+          {{- if eq (include "flowker.awsRolesAnywhere.enabled" .) "true" }}
+          {{- include "flowker.awsImdsEnv" (dict "context" $) | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.flowker.service.port }}
@@ -81,6 +84,13 @@ spec:
         {{- if eq (include "flowker.xsdValidator.enabled" .) "true" }}
         {{- include "flowker.xsdValidatorContainer" (dict "context" $) | nindent 8 }}
         {{- end }}
+        {{- if eq (include "flowker.awsRolesAnywhere.enabled" .) "true" }}
+        {{- include "flowker.awsSigningSidecar" (dict "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if eq (include "flowker.awsRolesAnywhere.enabled" .) "true" }}
+      volumes:
+        {{- include "flowker.awsCertsVolume" (dict "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.flowker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/flowker/templates/deployment.yaml
+++ b/charts/flowker/templates/deployment.yaml
@@ -38,26 +38,7 @@ spec:
       securityContext:
         {{- toYaml .Values.flowker.podSecurityContext | nindent 8 }}
       initContainers:
-        - name: wait-for-mongodb
-          image: busybox:1.37
-          command:
-            - /bin/sh
-            - -c
-            - >
-              TIMEOUT=300;
-              ELAPSED=0;
-              {{- $mongoHost := include "flowker.mongoHost" . }}
-              echo "Checking {{ $mongoHost }}:27017...";
-              while ! nc -z "{{ $mongoHost }}" 27017; do
-                if [ $ELAPSED -ge $TIMEOUT ]; then
-                  echo "Timeout waiting for MongoDB after ${TIMEOUT}s";
-                  exit 1;
-                fi;
-                echo "MongoDB is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
-                sleep 5;
-                ELAPSED=$((ELAPSED + 5));
-              done;
-              echo "MongoDB is ready!";
+        {{- include "flowker.waitForMongoInit" (dict "context" $) | nindent 8 }}
       containers:
         - name: {{ include "flowker.fullname" . }}
           securityContext:
@@ -72,14 +53,7 @@ spec:
           env:
           {{- $secretName := ternary .Values.flowker.existingSecretName (include "flowker.fullname" .) .Values.flowker.useExistingSecret }}
           {{- include "flowker.mongoEnv" (dict "context" $ "secretName" $secretName) | nindent 10 }}
-          {{- if eq (toString .Values.flowker.configmap.ENABLE_TELEMETRY) "true" }}
-          - name: "HOST_IP"
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-          - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
-            value: "$(HOST_IP):4317"
-          {{- end }}
+          {{- include "flowker.otelHostEnv" (dict "context" $) | nindent 10 }}
           ports:
             - name: http
               containerPort: {{ .Values.flowker.service.port }}

--- a/charts/flowker/templates/secrets.yaml
+++ b/charts/flowker/templates/secrets.yaml
@@ -32,8 +32,8 @@ stringData:
   WORKOS_TM_CLIENT_SECRET: {{ required "flowker.secrets.WORKOS_TM_CLIENT_SECRET is required when flowker.workosTmEnabled=true" .Values.flowker.secrets.WORKOS_TM_CLIENT_SECRET | quote }}
   {{- end }}
 
-  # Scheduler queue Redis password (optional for the external-Redis path; when the
-  # valkey subchart is bundled this is replaced by a secretKeyRef in a follow-up phase).
+  # Scheduler queue Redis password (optional). Set for an external/managed Redis, or
+  # when the bundled valkey subchart has auth enabled (its ACL must match this value).
   {{- if .Values.flowker.secrets.SCHEDULER_REDIS_PASSWORD }}
   SCHEDULER_REDIS_PASSWORD: {{ .Values.flowker.secrets.SCHEDULER_REDIS_PASSWORD | quote }}
   {{- end }}

--- a/charts/flowker/templates/secrets.yaml
+++ b/charts/flowker/templates/secrets.yaml
@@ -23,7 +23,24 @@ stringData:
   MONGO_TLS_CA_CERT: {{ .Values.flowker.secrets.MONGO_TLS_CA_CERT | quote }}
   {{- end }}
 
+  # WorkOS Tenant Manager client secret (feature #300) — required when
+  # flowker.workosTmEnabled=true (all-or-none with WORKOS_TM_TOKEN_URL/CLIENT_ID).
+  # TODO(review): on the useExistingSecret=true path this whole Secret is skipped,
+  # so the client-secret required() is not enforced at template time (the app still
+  # fail-fasts at boot) (ring-helm, 2026-07-10, Low).
+  {{- if .Values.flowker.workosTmEnabled }}
+  WORKOS_TM_CLIENT_SECRET: {{ required "flowker.secrets.WORKOS_TM_CLIENT_SECRET is required when flowker.workosTmEnabled=true" .Values.flowker.secrets.WORKOS_TM_CLIENT_SECRET | quote }}
+  {{- end }}
+
+  # Scheduler queue Redis password (optional for the external-Redis path; when the
+  # valkey subchart is bundled this is replaced by a secretKeyRef in a follow-up phase).
+  {{- if .Values.flowker.secrets.SCHEDULER_REDIS_PASSWORD }}
+  SCHEDULER_REDIS_PASSWORD: {{ .Values.flowker.secrets.SCHEDULER_REDIS_PASSWORD | quote }}
+  {{- end }}
+
   # API key (when API_KEY_ENABLED=true)
+  # TODO(review): API_KEY has no required() guard when API_KEY_ENABLED=true — a
+  # partial config ships silently (ring-security-reviewer, 2026-07-10, Low).
   {{- if .Values.flowker.secrets.API_KEY }}
   API_KEY: {{ .Values.flowker.secrets.API_KEY | quote }}
   {{- end }}

--- a/charts/flowker/templates/worker/configmap.yaml
+++ b/charts/flowker/templates/worker/configmap.yaml
@@ -1,0 +1,25 @@
+{{- if eq (include "flowker.worker.enabled" .) "true" }}
+{{- $w := .Values.worker | default dict -}}
+{{- $port := (($w.service).port | default 4022) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "flowker.worker.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "flowker.worker.labels" (dict "context" .) | nindent 4 }}
+data:
+  # Worker-only environment. Layered on top of the api ConfigMap + Secret (envFrom
+  # order in the worker Deployment), so keys here win over the shared api values.
+  # The worker binary serves its /health + /readyz probes on WORKER_SERVER_*.
+  WORKER_SERVER_PORT: {{ $port | quote }}
+  WORKER_SERVER_ADDRESS: {{ printf ":%v" $port | quote }}
+  OTEL_RESOURCE_SERVICE_NAME: {{ (($w.configmap).OTEL_RESOURCE_SERVICE_NAME) | default "flowker-worker" | quote }}
+  {{- with $w.configmap }}
+  {{- range $key, $value := . }}
+  {{- if not (has $key (list "WORKER_SERVER_PORT" "WORKER_SERVER_ADDRESS" "OTEL_RESOURCE_SERVICE_NAME")) }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/flowker/templates/worker/deployment.yaml
+++ b/charts/flowker/templates/worker/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   # Fixed single replica: the scheduler consume server and background jobs are
   # not leader-gated yet, so a second replica would double-process. Do NOT add an HPA.
-  replicas: {{ $w.replicaCount | default 1 }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "flowker.worker.selectorLabels" (dict "context" .) | nindent 6 }}

--- a/charts/flowker/templates/worker/deployment.yaml
+++ b/charts/flowker/templates/worker/deployment.yaml
@@ -1,0 +1,113 @@
+{{- if eq (include "flowker.worker.enabled" .) "true" }}
+{{- $w := .Values.worker | default dict -}}
+{{- $wImage := $w.image | default dict -}}
+{{- $repo := $wImage.repository | default .Values.flowker.image.repository -}}
+{{- $tag := $wImage.tag | default (include "flowker.defaultTag" .) -}}
+{{- $pullPolicy := $wImage.pullPolicy | default .Values.flowker.image.pullPolicy -}}
+{{- $pullSecrets := $w.imagePullSecrets | default .Values.flowker.imagePullSecrets -}}
+{{- $secCtx := $w.securityContext | default .Values.flowker.securityContext -}}
+{{- $podSecCtx := $w.podSecurityContext | default .Values.flowker.podSecurityContext -}}
+{{- $port := (($w.service).port | default 4022) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "flowker.worker.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "flowker.worker.labels" (dict "context" .) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ $w.revisionHistoryLimit | default 10 }}
+  {{- with $w.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  # Fixed single replica: the scheduler consume server and background jobs are
+  # not leader-gated yet, so a second replica would double-process. Do NOT add an HPA.
+  replicas: {{ $w.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "flowker.worker.selectorLabels" (dict "context" .) | nindent 6 }}
+  template:
+    metadata:
+      {{- with $w.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "flowker.worker.labels" (dict "context" .) | nindent 8 }}
+    spec:
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "flowker.worker.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ $w.terminationGracePeriodSeconds | default 60 }}
+      securityContext:
+        {{- toYaml $podSecCtx | nindent 8 }}
+      initContainers:
+        {{- include "flowker.waitForMongoInit" (dict "context" $) | nindent 8 }}
+      containers:
+        - name: {{ include "flowker.worker.fullname" . }}
+          securityContext:
+            {{- toYaml $secCtx | nindent 12 }}
+          image: "{{ $repo }}:{{ $tag }}"
+          imagePullPolicy: {{ $pullPolicy }}
+          # Runs the worker binary bundled in the shared flowker image.
+          command:
+            {{- toYaml ($w.command | default (list "/worker")) | nindent 12 }}
+          envFrom:
+          # Shared config + secrets from the api (single source of truth).
+          - secretRef:
+              name: {{ if .Values.flowker.useExistingSecret }}{{ .Values.flowker.existingSecretName }}{{ else }}{{ include "flowker.fullname" . }}{{ end }}
+          - configMapRef:
+              name: {{ include "flowker.fullname" . }}
+          # Worker-only overrides (WORKER_SERVER_*, OTEL name) — last so its keys win.
+          - configMapRef:
+              name: {{ include "flowker.worker.fullname" . }}
+          env:
+          {{- $secretName := ternary .Values.flowker.existingSecretName (include "flowker.fullname" .) .Values.flowker.useExistingSecret }}
+          {{- include "flowker.mongoEnv" (dict "context" $ "secretName" $secretName) | nindent 10 }}
+          {{- include "flowker.otelHostEnv" (dict "context" $) | nindent 10 }}
+          {{- with $w.extraEnvVars }}
+          {{- range $key, $value := . }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ (($w.livenessProbe).path) | default "/health" }}
+              port: http
+            initialDelaySeconds: {{ (($w.livenessProbe).initialDelaySeconds) | default 15 }}
+            periodSeconds: {{ (($w.livenessProbe).periodSeconds) | default 20 }}
+            timeoutSeconds: {{ (($w.livenessProbe).timeoutSeconds) | default 5 }}
+            successThreshold: {{ (($w.livenessProbe).successThreshold) | default 1 }}
+            failureThreshold: {{ (($w.livenessProbe).failureThreshold) | default 3 }}
+          readinessProbe:
+            httpGet:
+              path: {{ (($w.readinessProbe).path) | default "/readyz" }}
+              port: http
+            initialDelaySeconds: {{ (($w.readinessProbe).initialDelaySeconds) | default 5 }}
+            periodSeconds: {{ (($w.readinessProbe).periodSeconds) | default 10 }}
+            timeoutSeconds: {{ (($w.readinessProbe).timeoutSeconds) | default 5 }}
+            successThreshold: {{ (($w.readinessProbe).successThreshold) | default 1 }}
+            failureThreshold: {{ (($w.readinessProbe).failureThreshold) | default 3 }}
+          resources:
+            {{- toYaml ($w.resources | default .Values.flowker.resources) | nindent 12 }}
+      {{- with $w.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $w.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $w.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/flowker/templates/worker/deployment.yaml
+++ b/charts/flowker/templates/worker/deployment.yaml
@@ -98,6 +98,9 @@ spec:
             failureThreshold: {{ (($w.readinessProbe).failureThreshold) | default 3 }}
           resources:
             {{- toYaml ($w.resources | default .Values.flowker.resources) | nindent 12 }}
+        {{- if eq (include "flowker.xsdValidator.enabled" .) "true" }}
+        {{- include "flowker.xsdValidatorContainer" (dict "context" $) | nindent 8 }}
+        {{- end }}
       {{- with $w.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/flowker/templates/worker/deployment.yaml
+++ b/charts/flowker/templates/worker/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: {{ include "flowker.worker.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ $w.terminationGracePeriodSeconds | default 60 }}
       securityContext:
-        {{- toYaml $podSecCtx | nindent 8 }}
+        {{- include "flowker.podSecurityContext" (dict "context" $ "base" $podSecCtx) | nindent 8 }}
       initContainers:
         {{- include "flowker.waitForMongoInit" (dict "context" $) | nindent 8 }}
       containers:
@@ -68,6 +68,9 @@ spec:
           {{- $secretName := ternary .Values.flowker.existingSecretName (include "flowker.fullname" .) .Values.flowker.useExistingSecret }}
           {{- include "flowker.mongoEnv" (dict "context" $ "secretName" $secretName) | nindent 10 }}
           {{- include "flowker.otelHostEnv" (dict "context" $) | nindent 10 }}
+          {{- if eq (include "flowker.awsRolesAnywhere.enabled" .) "true" }}
+          {{- include "flowker.awsImdsEnv" (dict "context" $) | nindent 10 }}
+          {{- end }}
           {{- with $w.extraEnvVars }}
           {{- range $key, $value := . }}
           - name: {{ $key }}
@@ -101,6 +104,13 @@ spec:
         {{- if eq (include "flowker.xsdValidator.enabled" .) "true" }}
         {{- include "flowker.xsdValidatorContainer" (dict "context" $) | nindent 8 }}
         {{- end }}
+        {{- if eq (include "flowker.awsRolesAnywhere.enabled" .) "true" }}
+        {{- include "flowker.awsSigningSidecar" (dict "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if eq (include "flowker.awsRolesAnywhere.enabled" .) "true" }}
+      volumes:
+        {{- include "flowker.awsCertsVolume" (dict "context" $) | nindent 8 }}
+      {{- end }}
       {{- with $w.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/flowker/templates/worker/serviceaccount.yaml
+++ b/charts/flowker/templates/worker/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if eq (include "flowker.worker.enabled" .) "true" }}
+{{- $w := .Values.worker | default dict -}}
+{{- $sa := $w.serviceAccount | default dict -}}
+{{- if $sa.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "flowker.worker.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "flowker.worker.labels" (dict "context" .) | nindent 4 }}
+  {{- with $sa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/flowker/values-template.yaml
+++ b/charts/flowker/values-template.yaml
@@ -8,8 +8,9 @@ flowker:
   replicaCount: 1
 
   image:
-    repository: lerianstudio/flowker
+    repository: ghcr.io/lerianstudio/flowker
     pullPolicy: IfNotPresent
+    # Empty inherits the chart default (>= 1.2.0-beta.82, required for worker + xsd).
     tag: ""
 
   imagePullSecrets: []
@@ -60,6 +61,32 @@ flowker:
 
   useExistingSecret: false
   existingSecretName: ""
+
+  # WorkOS Tenant Manager token mint (all-or-none; requires WORKOS_TM_* config + secret).
+  workosTmEnabled: false
+
+  # In-pod XSD validator sidecar (default on; disable if XML validation is unused).
+  xsdValidator:
+    enabled: true
+
+# Scheduler worker Deployment (runs the /worker binary from the flowker image).
+worker:
+  enabled: true
+
+# In-cluster Redis for the scheduler queue. Enable for a bundled valkey, or leave
+# off and point flowker.configmap.SCHEDULER_REDIS_HOST at an external Redis.
+valkey:
+  enabled: false
+
+# AWS auth. On EKS use IRSA via flowker.serviceAccount.annotations; on non-EKS
+# clusters enable IAM Roles Anywhere and supply the ARNs + certificate secret.
+aws:
+  rolesAnywhere:
+    enabled: false
+    trustAnchorArn: ""
+    profileArn: ""
+    roleArn: ""
+    certificateSecretName: "flowker-iam-tls"
 
 mongodb:
   enabled: true

--- a/charts/flowker/values.schema.json
+++ b/charts/flowker/values.schema.json
@@ -24,6 +24,51 @@
         },
         "secrets": {
           "type": "object"
+        },
+        "workosTmEnabled": {
+          "type": "boolean"
+        },
+        "xsdValidator": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "worker": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "valkey": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "aws": {
+      "type": "object",
+      "properties": {
+        "rolesAnywhere": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": true
         }
       },
       "additionalProperties": true

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -64,8 +64,9 @@ flowker:
     repository: ghcr.io/lerianstudio/flowker
     # -- Image pull policy
     pullPolicy: IfNotPresent
-    # -- Image tag used for deployment
-    tag: "1.0.0-beta.22"
+    # -- Image tag used for deployment. Must be >= 1.2.0-beta.82: that image bundles
+    # the /worker binary (scheduler worker Deployment) alongside the api entrypoint.
+    tag: "1.2.0-beta.82"
 
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -173,6 +173,12 @@ flowker:
   # -- Affinity rules for pod scheduling
   affinity: {}
 
+  # -- Enable the WorkOS Tenant Manager token-mint feature (#300). ALL-OR-NONE:
+  # when true, WORKOS_TM_TOKEN_URL + WORKOS_TM_CLIENT_ID (configmap) and
+  # WORKOS_TM_CLIENT_SECRET (secrets) are all required (rejected at template time
+  # if partial). WORKOS_TM_SERVICE_NAME must match FLOWKER_SECRETS_APPLICATION_NAME.
+  workosTmEnabled: false
+
   # -- ConfigMap for environment variables and configurations
   # @default -- templates/configmap.yaml
   configmap:
@@ -281,6 +287,61 @@ flowker:
     MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
     MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
 
+    # HTTP egress body cap (bytes). Caps request/response bodies on provider calls.
+    HTTP_MAX_BODY_BYTES: "10485760"
+    # -- Allow CORS wildcard (lib-commons parity). Secure-by-default false; local overrides to true.
+    ALLOW_CORS_WILDCARD: "false"
+
+    # Internal (Lerian-managed) provider base URLs. Empty = stored config doc value used.
+    MIDAZ_BASE_URL: ""
+    TRACER_BASE_URL: ""
+
+    # Schema Registry auth gates (secure default: true)
+    XSD_SCHEMAS_AUTH_ENABLED: "true"
+    OPENAPI_SCHEMAS_AUTH_ENABLED: "true"
+
+    # Schema Registry blob storage (S3). Graceful-off when bucket empty (Mongo-only
+    # boot). AWS creds come from the credential chain (IRSA / Roles Anywhere).
+    SCHEMA_REGISTRY_S3_BUCKET: ""
+    # -- AWS region for the Schema Registry S3 store. Empty = resolved by the AWS SDK chain.
+    SCHEMA_REGISTRY_S3_REGION: ""
+
+    # Shared OAuth2 token cache
+    TOKEN_CACHE_MAX_TTL_SEC: "3600"
+    TOKEN_CACHE_JANITOR_INTERVAL_SEC: "300"
+    TOKEN_CACHE_REFRESH_BUFFER_SEC: "60"
+    TOKEN_CACHE_TENANT_SCOPED_DISABLED: "false"
+
+    # Secrets backend. Empty = disabled (boots fine); "tenant-manager" = AWS Secrets
+    # Manager reader. FLOWKER_SECRETS_APPLICATION_NAME must match WORKOS_TM_SERVICE_NAME.
+    FLOWKER_SECRETS_BACKEND: ""
+    FLOWKER_SECRETS_CACHE_TTL_SEC: ""
+    FLOWKER_SECRETS_APPLICATION_NAME: ""
+
+    # XSD validator (app-side knobs). The in-pod sidecar + loopback URL are wired in
+    # a follow-up phase; empty URL keeps the feature unconfigured (never a boot dep).
+    XSD_VALIDATOR_URL: ""
+    # -- Allow cleartext http:// to the in-pod XSD sidecar. Secure-by-default false.
+    XSD_VALIDATOR_ALLOW_INSECURE_HTTP: "false"
+
+    # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. SCHEDULER_REDIS_HOST is
+    # derived from the valkey subchart in a follow-up phase; empty keeps the scheduler
+    # queue a nil-safe no-op. Keep this queue Redis isolated from MULTI_TENANT_REDIS_*.
+    SCHEDULER_ENABLED: "true"
+    SCHEDULER_REDIS_HOST: ""
+    SCHEDULER_REDIS_PORT: "6379"
+    SCHEDULER_REDIS_TLS: "false"
+    SCHEDULER_REDIS_DB: "0"
+    SCHEDULER_CONCURRENCY: "10"
+
+    # WorkOS Tenant Manager token mint (#300). Emitted only when flowker.workosTmEnabled=true.
+    WORKOS_TM_TOKEN_URL: ""
+    WORKOS_TM_CLIENT_ID: ""
+    # -- Optional space-delimited scope (e.g. backoffice:tm:m2m:write).
+    WORKOS_TM_SCOPE: ""
+    # -- Flowker service name as the Tenant Manager knows it. Must match FLOWKER_SECRETS_APPLICATION_NAME.
+    WORKOS_TM_SERVICE_NAME: "flowker"
+
   # -- Secrets for storing sensitive data
   # @default -- templates/secrets.yaml
   secrets:
@@ -299,6 +360,11 @@ flowker:
     MULTI_TENANT_SERVICE_API_KEY: ""
     # -- Redis password for tenant Pub/Sub (optional)
     MULTI_TENANT_REDIS_PASSWORD: ""
+    # -- WorkOS Tenant Manager client secret (required when flowker.workosTmEnabled=true)
+    WORKOS_TM_CLIENT_SECRET: ""
+    # -- Scheduler queue Redis password (external-Redis path; the valkey subchart
+    # supplies this via secretKeyRef in a follow-up phase)
+    SCHEDULER_REDIS_PASSWORD: ""
 
   # -- Use an existing secret instead of creating one
   useExistingSecret: false
@@ -315,6 +381,78 @@ flowker:
     annotations: {}
     # -- Name of the service account
     # @default -- `flowker.fullname`
+    name: ""
+
+# -- Scheduler worker: a second Deployment running the SAME flowker image with
+# its command overridden to /worker. Runs the queue-backed scheduler consume
+# server and background jobs. Reuses the api ConfigMap + Secret.
+worker:
+  # -- Enable or disable the worker Deployment
+  enabled: true
+  # -- Number of replicas (fixed; the worker is not leader-gated — do NOT add an HPA)
+  replicaCount: 1
+  # -- Number of old ReplicaSets to retain
+  revisionHistoryLimit: 10
+
+  # -- Image override. Empty repository/tag inherit the api image (flowker.image).
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  # -- Container entrypoint (the worker binary bundled in the flowker image)
+  command:
+    - /worker
+
+  # -- Secrets for pulling images from a private registry (inherits api when empty)
+  imagePullSecrets: []
+
+  # -- Deployment update strategy. Recreate avoids two schedulers overlapping mid-rollout.
+  deploymentStrategy:
+    type: Recreate
+
+  # -- Grace period (s) for the scheduler consume server to drain in-flight jobs on SIGTERM.
+  terminationGracePeriodSeconds: 60
+
+  service:
+    # -- Worker probe port (WORKER_SERVER_PORT). The worker serves only /health + /readyz.
+    port: 4022
+
+  # -- Pod-level security context (inherits flowker.podSecurityContext when empty)
+  podSecurityContext: {}
+  # -- Container-level security context (inherits flowker.securityContext when empty)
+  securityContext: {}
+
+  # -- Resource requests/limits (inherits flowker.resources when empty)
+  resources: {}
+
+  # -- Readiness probe overrides
+  readinessProbe: {}
+  # -- Liveness probe overrides
+  livenessProbe: {}
+
+  # -- Pod annotations
+  podAnnotations: {}
+  # -- Node selector
+  nodeSelector: {}
+  # -- Tolerations
+  tolerations: {}
+  # -- Affinity rules
+  affinity: {}
+
+  # -- Extra environment variables (rendered as literal name/value pairs)
+  extraEnvVars: {}
+
+  # -- Worker-only ConfigMap overrides (layered last; wins over the api ConfigMap)
+  configmap: {}
+
+  serviceAccount:
+    # -- Create a dedicated worker ServiceAccount (false reuses the api SA)
+    create: true
+    # -- Annotations for the worker ServiceAccount (e.g. IRSA role-arn)
+    annotations: {}
+    # -- Name override
+    # @default -- `flowker.worker.fullname`
     name: ""
 
 mongodb:

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -528,6 +528,36 @@ valkey:
     # on the app side to a credential that matches the ACL. Off by default (in-cluster ClusterIP).
     enabled: false
 
+# -- AWS authentication. On EKS, prefer IRSA: set
+# flowker.serviceAccount.annotations."eks.amazonaws.com/role-arn" (and worker.serviceAccount)
+# and leave this disabled. For non-EKS clusters (e.g. Proxmox), enable IAM Roles Anywhere:
+# an aws-signing-helper sidecar serves a loopback IMDS endpoint (127.0.0.1:9911) that the AWS
+# SDK uses to exchange the client cert (trust anchor/profile/role) for temporary credentials.
+aws:
+  rolesAnywhere:
+    enabled: false
+    # -- Required when enabled (template fails fast if missing).
+    trustAnchorArn: ""
+    profileArn: ""
+    roleArn: ""
+    region: "us-east-2"
+    sessionDuration: 3600
+    # -- Secret holding the Roles Anywhere client cert (tls.crt) and key (tls.key).
+    certificateSecretName: "flowker-iam-tls"
+    sidecar:
+      image:
+        repository: public.ecr.aws/rolesanywhere/credential-helper
+        tag: "latest-amd64"
+        pullPolicy: IfNotPresent
+      port: 9911
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+
 mongodb:
   # MongoDB document database for flowker data storage
   enabled: true

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -179,6 +179,63 @@ flowker:
   # if partial). WORKOS_TM_SERVICE_NAME must match FLOWKER_SECRETS_APPLICATION_NAME.
   workosTmEnabled: false
 
+  # -- In-pod XSD validator sidecar (stateless Go + libxml2). Injected into the api
+  # and worker pods; Flowker reaches it over loopback (XSD_VALIDATOR_URL is wired
+  # automatically when enabled). Its /v1 authorization delegates to the Access
+  # Manager (pluginAuth.*), defaulting to the app's PLUGIN_AUTH_* config.
+  xsdValidator:
+    # -- Enable or disable the sidecar
+    enabled: true
+    image:
+      # -- Sidecar image repository
+      repository: ghcr.io/lerianstudio/flowker-xsd-validator
+      # -- Image tag (empty inherits the flowker app tag)
+      tag: ""
+      # -- Image pull policy
+      pullPolicy: IfNotPresent
+    # -- Listen port (also the loopback URL port Flowker targets)
+    port: 8081
+    # -- ENV_NAME (empty inherits flowker.configmap.ENV_NAME)
+    envName: ""
+    # -- Inbound body size cap in bytes (XML + XSD + imports)
+    maxBodyBytes: "5242880"
+    # -- Max time to read a full request (Go duration)
+    readTimeout: "10s"
+    # -- Max time to write the response (Go duration)
+    writeTimeout: "10s"
+    pluginAuth:
+      # -- Delegate /v1 authorization to the Access Manager (empty inherits flowker PLUGIN_AUTH_ENABLED)
+      enabled: ""
+      # -- Access Manager base URL (empty inherits flowker PLUGIN_AUTH_ADDRESS)
+      address: ""
+      # -- Acknowledge cleartext http:// to the Access Manager. Secure-by-default false.
+      allowInsecureHttp: "false"
+    resources:
+      # -- CPU/memory limits
+      limits:
+        cpu: 250m
+        memory: 256Mi
+      # -- CPU/memory requests
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    # -- Hardened container security context (matches the sidecar image: uid/gid 65532, read-only rootfs)
+    securityContext:
+      runAsUser: 65532
+      runAsGroup: 65532
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    # -- Liveness probe overrides (httpGet /health on the sidecar port)
+    livenessProbe: {}
+    # -- Readiness probe overrides
+    readinessProbe: {}
+
   # -- ConfigMap for environment variables and configurations
   # @default -- templates/configmap.yaml
   configmap:
@@ -318,11 +375,13 @@ flowker:
     FLOWKER_SECRETS_CACHE_TTL_SEC: ""
     FLOWKER_SECRETS_APPLICATION_NAME: ""
 
-    # XSD validator (app-side knobs). The in-pod sidecar + loopback URL are wired in
-    # a follow-up phase; empty URL keeps the feature unconfigured (never a boot dep).
+    # XSD validator (app-side knobs). Leave EMPTY to auto-derive from the in-pod
+    # sidecar (flowker.xsdValidator.enabled): URL -> http://localhost:<port> and
+    # ALLOW_INSECURE_HTTP -> true (the same-pod cleartext hop). Set a value here to
+    # override (e.g. an external https:// validator). Empty + sidecar disabled keeps
+    # the feature unconfigured (never a hard boot dependency).
     XSD_VALIDATOR_URL: ""
-    # -- Allow cleartext http:// to the in-pod XSD sidecar. Secure-by-default false.
-    XSD_VALIDATOR_ALLOW_INSECURE_HTTP: "false"
+    XSD_VALIDATOR_ALLOW_INSECURE_HTTP: ""
 
     # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. SCHEDULER_REDIS_HOST is
     # derived from the valkey subchart in a follow-up phase; empty keeps the scheduler

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -383,9 +383,10 @@ flowker:
     XSD_VALIDATOR_URL: ""
     XSD_VALIDATOR_ALLOW_INSECURE_HTTP: ""
 
-    # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. SCHEDULER_REDIS_HOST is
-    # derived from the valkey subchart in a follow-up phase; empty keeps the scheduler
-    # queue a nil-safe no-op. Keep this queue Redis isolated from MULTI_TENANT_REDIS_*.
+    # Scheduler (queue-backed `schedule` trigger). DEFAULT ON. Leave SCHEDULER_REDIS_HOST
+    # empty to auto-derive the bundled valkey Service name when valkey.enabled=true, or
+    # set it to point at an external/managed Redis; empty with valkey off keeps the
+    # scheduler queue a nil-safe no-op. Keep this queue Redis isolated from MULTI_TENANT_REDIS_*.
     SCHEDULER_ENABLED: "true"
     SCHEDULER_REDIS_HOST: ""
     SCHEDULER_REDIS_PORT: "6379"
@@ -421,8 +422,8 @@ flowker:
     MULTI_TENANT_REDIS_PASSWORD: ""
     # -- WorkOS Tenant Manager client secret (required when flowker.workosTmEnabled=true)
     WORKOS_TM_CLIENT_SECRET: ""
-    # -- Scheduler queue Redis password (external-Redis path; the valkey subchart
-    # supplies this via secretKeyRef in a follow-up phase)
+    # -- Scheduler queue Redis password (optional): set for an external/managed Redis,
+    # or when the bundled valkey subchart has auth enabled (its ACL must match this).
     SCHEDULER_REDIS_PASSWORD: ""
 
   # -- Use an existing secret instead of creating one
@@ -513,6 +514,19 @@ worker:
     # -- Name override
     # @default -- `flowker.worker.fullname`
     name: ""
+
+# -- Valkey (Redis-compatible) in-cluster store backing the scheduler queue.
+# Disabled by default: enable for an in-cluster queue Redis, or leave off and
+# point flowker.configmap.SCHEDULER_REDIS_HOST at an external/managed Redis.
+# When enabled, SCHEDULER_REDIS_HOST auto-derives to the subchart Service (<release>-valkey).
+# This queue Redis MUST stay isolated from the tenant Pub/Sub Redis (MULTI_TENANT_REDIS_*).
+valkey:
+  enabled: false
+  auth:
+    # -- The valkey.io subchart uses inline ACL config (valkey.auth.aclConfig), not a
+    # password Secret; if you enable auth here, also set flowker.secrets.SCHEDULER_REDIS_PASSWORD
+    # on the app side to a credential that matches the ACL. Off by default (in-cluster ClusterIP).
+    enabled: false
 
 mongodb:
   # MongoDB document database for flowker data storage

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -177,7 +177,9 @@ flowker:
   # -- Enable the WorkOS Tenant Manager token-mint feature (#300). ALL-OR-NONE:
   # when true, WORKOS_TM_TOKEN_URL + WORKOS_TM_CLIENT_ID (configmap) and
   # WORKOS_TM_CLIENT_SECRET (secrets) are all required (rejected at template time
-  # if partial). WORKOS_TM_SERVICE_NAME must match FLOWKER_SECRETS_APPLICATION_NAME.
+  # if partial). The WORKOS_TM_CLIENT_SECRET check applies only to chart-managed
+  # Secrets (flowker.useExistingSecret=false); with an existing Secret you must
+  # supply that key yourself. WORKOS_TM_SERVICE_NAME must match FLOWKER_SECRETS_APPLICATION_NAME.
   workosTmEnabled: false
 
   # -- In-pod XSD validator sidecar (stateless Go + libxml2). Injected into the api
@@ -364,17 +366,20 @@ flowker:
     # -- AWS region for the Schema Registry S3 store. Empty = resolved by the AWS SDK chain.
     SCHEMA_REGISTRY_S3_REGION: ""
 
-    # Shared OAuth2 token cache
-    TOKEN_CACHE_MAX_TTL_SEC: "3600"
-    TOKEN_CACHE_JANITOR_INTERVAL_SEC: "300"
-    TOKEN_CACHE_REFRESH_BUFFER_SEC: "60"
-    TOKEN_CACHE_TENANT_SCOPED_DISABLED: "false"
+    # Shared OAuth2 token cache (optional tuning). templates/configmap.yaml supplies
+    # these defaults; the values below are shown for reference — uncomment to override.
+    # TOKEN_CACHE_MAX_TTL_SEC: "3600"
+    # TOKEN_CACHE_JANITOR_INTERVAL_SEC: "300"
+    # TOKEN_CACHE_REFRESH_BUFFER_SEC: "60"
+    # TOKEN_CACHE_TENANT_SCOPED_DISABLED: "false"
 
-    # Secrets backend. Empty = disabled (boots fine); "tenant-manager" = AWS Secrets
-    # Manager reader. FLOWKER_SECRETS_APPLICATION_NAME must match WORKOS_TM_SERVICE_NAME.
-    FLOWKER_SECRETS_BACKEND: ""
-    FLOWKER_SECRETS_CACHE_TTL_SEC: ""
-    FLOWKER_SECRETS_APPLICATION_NAME: ""
+    # Secrets backend selector (optional). Empty = disabled (boots fine);
+    # "tenant-manager" = AWS Secrets Manager reader. FLOWKER_SECRETS_APPLICATION_NAME
+    # must match WORKOS_TM_SERVICE_NAME. templates/configmap.yaml defaults these to ""
+    # — uncomment to override.
+    # FLOWKER_SECRETS_BACKEND: ""
+    # FLOWKER_SECRETS_CACHE_TTL_SEC: ""
+    # FLOWKER_SECRETS_APPLICATION_NAME: ""
 
     # XSD validator (app-side knobs). Leave EMPTY to auto-derive from the in-pod
     # sidecar (flowker.xsdValidator.enabled): URL -> http://localhost:<port> and
@@ -396,7 +401,9 @@ flowker:
     SCHEDULER_CONCURRENCY: "10"
 
     # WorkOS Tenant Manager token mint (#300). Emitted only when flowker.workosTmEnabled=true.
-    WORKOS_TM_TOKEN_URL: ""
+    # WORKOS_TM_TOKEN_URL is the OAuth2 token endpoint (required when workosTmEnabled=true);
+    # set it via your override values.
+    # WORKOS_TM_TOKEN_URL: ""
     WORKOS_TM_CLIENT_ID: ""
     # -- Optional space-delimited scope (e.g. backoffice:tm:m2m:write).
     WORKOS_TM_SCOPE: ""
@@ -450,8 +457,9 @@ flowker:
 worker:
   # -- Enable or disable the worker Deployment
   enabled: true
-  # -- Number of replicas (fixed; the worker is not leader-gated — do NOT add an HPA)
-  replicaCount: 1
+  # Replicas are fixed at 1 in the template (the worker is not leader-gated, so a
+  # second replica would double-process). This is intentionally not configurable —
+  # do NOT add an HPA.
   # -- Number of old ReplicaSets to retain
   revisionHistoryLimit: 10
 
@@ -548,7 +556,9 @@ aws:
     sidecar:
       image:
         repository: public.ecr.aws/rolesanywhere/credential-helper
-        tag: "latest-amd64"
+        # Immutable, multi-arch (amd64+arm64) tag. Avoid the mutable `latest-amd64`
+        # so redeploys/rollbacks are reproducible and arm64 nodes are covered.
+        tag: "1.8.4-2026.06.09.14.59"
         pullPolicy: IfNotPresent
       port: 9911
       resources:


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Flowker

## Summary

Brings the Flowker Helm chart into alignment with the app's runtime surface and ships it as a coherent `3.1.0` multi-component release. Five atomic commits:

1. **Scheduler worker Deployment + full env surface** — a second Deployment running the `/worker` binary from the same flowker image (queue consume server + background jobs; single replica, `Recreate`, no HPA). Full ConfigMap/Secret env surface (Schema Registry S3, secrets backend, token cache, internal provider URLs, `SCHEDULER_*`, CORS/body caps, XSD knobs) with an all-or-none WorkOS Tenant Manager gate. Shared `waitForMongoInit`/`otelHostEnv` helpers.
2. **In-pod XSD validator sidecar** (default on) — injected into the api + worker pods (port 8081, hardened securityContext). `XSD_VALIDATOR_URL` auto-wires to loopback; the cleartext ack is scoped to the in-pod hop only (off-pod overrides default secure).
3. **valkey subchart** (default off) backing the scheduler queue — `SCHEDULER_REDIS_HOST` auto-derives to the subchart Service (`<release>-valkey`) when enabled; explicit override / external Redis honored; isolated from the tenant Pub/Sub Redis.
4. **AWS IRSA + IAM Roles Anywhere** — IRSA via the api/worker ServiceAccount annotations; optional hardened `aws-signing-helper` sidecar (default off) for non-EKS clusters, serving credentials over a loopback IMDS endpoint with the client cert mounted read-only. RA wiring factored into shared helpers reused by both Deployments.
5. **3.1.0 release prep** — version `3.0.0` → `3.1.0`, appVersion + `flowker.image.tag` → `1.2.0-beta.82` (first image bundling `/worker` + published xsd sidecar), chart-type → `multi-component`, typed `values.schema.json`, `values-template.yaml` toggles, README + CHANGELOG.

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

- `helm lint` clean; full toggle matrix (worker/valkey/xsd/rolesAnywhere/workosTm/multi-tenant on/off) renders valid manifests with disjoint selectors; no secret material lands in any ConfigMap; all flowker images resolve to `1.2.0-beta.82`.
- All new components are opt-out/opt-in via toggles. **Migration:** the worker + XSD sidecar default on and require an app image `>= 1.2.0-beta.82`; pin `flowker.image.tag` accordingly or set `worker.enabled=false` / `flowker.xsdValidator.enabled=false`. To run the scheduler, set `valkey.enabled=true` or point `SCHEDULER_REDIS_HOST` at an external Redis.
- `Chart.lock` regenerated (mongodb + valkey); vendored `charts/*.tgz` are gitignored and rebuilt by CI via `helm dependency build`.
