### PR TITLE
feat(new): add br-slc BYOC Helm chart

### DIFF
--- a/.github/configs/helm-render-values/br-slc.yaml
+++ b/.github/configs/helm-render-values/br-slc.yaml
@@ -1,0 +1,29 @@
+# CI-only render fixture for br-slc. Dummy values, NOT a production example and
+# NOT real credentials. Exercises the external-infra path (Postgres/Redis are
+# external in BYOC) with the app + signer Secrets and the migration Job all
+# rendered in-release, so the render gate's dangling-secret-ref assertion has
+# every referenced Secret present.
+secrets:
+  create: true
+  data:
+    POSTGRES_PASSWORD: "dummy-ci-password"
+    REDIS_PASSWORD: "dummy-ci-redis"
+
+configmap:
+  data:
+    POSTGRES_HOST: "pg.example.svc"
+    REDIS_HOST: "redis.example.svc:6379"
+    PLUGIN_AUTH_HOST: "http://access-manager.example.svc:4000"
+    CORS_ALLOWED_ORIGINS: "https://app.example.com"
+
+signer:
+  secrets:
+    create: true
+    data:
+      SIGNER_SOFTKEY_PFX_PASSPHRASE: "dummy-ci-passphrase"
+
+migrations:
+  enabled: true
+  postgres:
+    host: "pg.example.svc"
+    password: "dummy-ci-password"

--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -73,3 +73,7 @@ underwriter:
 br-ccs:
   - changed-files:
       - any-glob-to-any-file: charts/br-ccs/**
+
+br-slc:
+  - changed-files:
+      - any-glob-to-any-file: charts/br-slc/**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 - [ ] Underwriter
 - [ ] BR STA
 - [ ] BR CCS
+- [ ] BR SLC
 
 ## Checklist
 Please check each item after it's completed.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -56,6 +56,7 @@ jobs:
             tracer
             br-sta
             br-ccs
+            br-slc
             new
             charts
             common

--- a/charts/br-slc/.helmignore
+++ b/charts/br-slc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/br-slc/CHANGELOG.md
+++ b/charts/br-slc/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the br-slc Helm chart are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.2] - 2026-07-15
+
+### Added
+
+- `mock-nuclea` (Núclea clearing-house simulator) as a gated, standalone
+  Deployment + ClusterIP Service — DEV/HML FIXTURE ONLY, `enabled: false` by
+  default (never enable in production/BYOC). Unlike the same-pod
+  signer/xsdValidator/mqbridge sidecars, the app reaches it over cluster DNS
+  (`br-slc-mock-nuclea:9190`), not localhost. Uses its own
+  `ghcr.io/lerianstudio/br-slc-mock-nuclea` image (published by a separate
+  br-slc release-pipeline workstream); exposes only `GET /health`, used for
+  both liveness and readiness.
+
 ## [0.1.0-beta.1] - 2026-07-10
 
 ### Added

--- a/charts/br-slc/CHANGELOG.md
+++ b/charts/br-slc/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the br-slc Helm chart are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0-beta.1] - 2026-07-10
+
+### Added
+
+- Initial Helm chart for the br-slc monolith (Sistema de Liquidação Centralizada — SLC).
+- Single Deployment running the app plus the mandatory same-pod `slc-signer` and
+  `aslc-xsd-validator` sidecars (ADR-12, reached over localhost) and a conditional
+  `mqbridge` sidecar (RSFN IBM MQ inbound, amd64-pinned, `replicaCount=1`, off by default).
+- Detached migrations via an ArgoCD PreSync hook Secret + Job using the dedicated
+  `ghcr.io/lerianstudio/br-slc-migrations` image, with a `busybox` wait-for-postgres
+  initContainer.
+- BYOC single-tenant posture: ClusterIP-only Service, no Ingress; external, client-managed
+  Postgres/Redis/RabbitMQ (no bundled subcharts). Per-container hardened `securityContext`
+  and ADR-9 signing-key custody isolated to the signer container.

--- a/charts/br-slc/Chart.yaml
+++ b/charts/br-slc/Chart.yaml
@@ -18,7 +18,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 0.1.0-beta.1
+version: 0.1.0-beta.2
 # appVersion is the default image tag for the app, the signer/validator/mqbridge
 # sidecars, and the migrations Job. Override per image via <image>.tag when a
 # component needs to pin a different build.

--- a/charts/br-slc/Chart.yaml
+++ b/charts/br-slc/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: br-slc-helm
+description: |
+  Helm chart for the br-slc monolith (Sistema de Liquidação Centralizada — SLC).
+  BYOC single-tenant deployment: ClusterIP-only Service, no Ingress. Ships one
+  Deployment whose pod runs three mandatory containers (ADR-12): the app plus
+  the same-pod slc-signer and aslc-xsd-validator sidecars reached over
+  localhost, and a fourth conditional mqbridge container (RSFN IBM MQ inbound)
+  rendered only when mqbridge.enabled. A dedicated migrations image applies the
+  golang-migrate SQL via an ArgoCD PreSync hook Job before the rollout.
+type: application
+annotations:
+  lerian.studio/chart-type: single-service
+home: https://github.com/LerianStudio/helm
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/br-slc
+  - https://github.com/LerianStudio/br-slc
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+version: 0.1.0-beta.1
+# appVersion is the default image tag for the app, the signer/validator/mqbridge
+# sidecars, and the migrations Job. Override per image via <image>.tag when a
+# component needs to pin a different build.
+appVersion: "0.1.0"
+keywords:
+  - slc
+  - br-slc
+  - siloc
+  - spb
+  - core-banking
+  - lerian
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4

--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -54,9 +54,11 @@ rendered only when `mqbridge.enabled=true`:
 The signer and validator are **mandatory same-pod containers** (ADR-12,
 "sidecar no mesmo pod, localhost") — no enable toggle. The app talks to them
 over **localhost**, not cluster DNS. **Shared fate**: the pod only reaches
-`Ready` when all its containers pass their own readiness probes, which
-removes the "app Ready but validator absent" window. Each container keeps its
-own hardened `securityContext` and its own `/tmp` `emptyDir`.
+`Ready` when every container that defines a readiness probe passes it, which
+removes the "app Ready but validator absent" window. The `mqbridge` container
+deliberately has **no** readiness probe (see below), so it does not
+independently gate pod readiness. Each container keeps its own hardened
+`securityContext` and its own `/tmp` `emptyDir`.
 
 **Custody (ADR-9):** the signing-key material (softkey PFX + passphrase, HSM
 PIN, Vault token) is mounted/injected **only** on the `slc-signer` container
@@ -102,15 +104,15 @@ When (and only when) `mqbridge.enabled=true`:
 ## Install
 
 ```bash
-helm lint deployments/helm/br-slc
-helm template my-release deployments/helm/br-slc
+helm lint charts/br-slc
+helm template my-release charts/br-slc
 
 # Real install — you MUST override at least:
 #   - configmap.data.POSTGRES_HOST / REDIS_HOST (external, client-managed)
 #   - configmap.data.PLUGIN_AUTH_HOST (required: PLUGIN_AUTH_ENABLED=true by default)
 #   - configmap.data.CORS_ALLOWED_ORIGINS (empty/deny-all by default)
 #   - secrets.* (see "Secrets" below)
-helm install my-release deployments/helm/br-slc -f my-values.yaml
+helm install my-release charts/br-slc -f my-values.yaml
 ```
 
 No `values-<env>.yaml` files live in this chart — per-environment overrides
@@ -231,127 +233,69 @@ This base intentionally hardens a handful of values beyond mirroring
 
 ## Migration Job
 
-A `pre-install,pre-upgrade` Helm hook Job (`templates/migrate-job.yaml`,
-`helm.sh/hook-weight: "-5"`) runs `migrate -path /migrations -database
-"$DATABASE_URL" up` **before** the Deployment rolls, applying all 21
-migrations under `migrations/` (golang-migrate, pinned to `v4.19.1` to match
-`go.mod`'s `github.com/golang-migrate/migrate/v4 v4.19.1`).
+Migrations are applied by a detached **ArgoCD `PreSync` hook** — a dedicated
+Job plus a small companion Secret, both under `templates/migrations/` — that
+runs **before** the main sync wave rolls the Deployment, so the monolith never
+boots against an unmigrated database.
 
-Ordering: `migrate-env-configmap.yaml` / `migrate-secret.yaml` (weight `-7`) →
-`migrate-configmap.yaml` (weight `-6`) → `migrate-job.yaml` (weight `-5`) → the
-Deployment/Service (unweighted, run after all hooks succeed). All hook
-resources use `hook-delete-policy: before-hook-creation,hook-succeeded`, so a
-re-run on `helm upgrade` cleans up the prior hook Job/ConfigMap/Secret and
-creates fresh ones.
+- `templates/migrations/secrets.yaml` — a PreSync Secret
+  (`argocd.argoproj.io/hook-weight: "-2"`) carrying **only** `POSTGRES_PASSWORD`
+  (from `migrations.postgres.password`, falling back to
+  `secrets.data.POSTGRES_PASSWORD`). Its `hook-delete-policy` is
+  `BeforeHookCreation` **only** (not `HookSucceeded`) so it survives the whole
+  PreSync phase for the Job to read, and is replaced on the next sync. It is
+  minted only when `migrations.useExistingSecret=false`.
+- `templates/migrations/job.yaml` — a PreSync Job
+  (`argocd.argoproj.io/hook-weight: "-1"`, so it runs after the Secret) that
+  runs the dedicated `ghcr.io/lerianstudio/br-slc-migrations` image
+  (`migrations.image.tag` defaults to `Chart.appVersion`). That image's
+  entrypoint owns the golang-migrate loop over the `migrations/*.up.sql`
+  **baked into the image** at build time by the br-slc release pipeline — the
+  chart's Job only supplies the DB connection and runs the image; it does not
+  carry the SQL or build the loop. Its `hook-delete-policy` is
+  `BeforeHookCreation,HookSucceeded`.
 
-The `-7` weight matters: the migrate Job (and its `wait-for-postgres`
-initContainer) must never reference a resource that isn't itself a hook at an
-earlier weight. The app's own ConfigMap/Secret (`templates/configmap.yaml`,
-`templates/secret.yaml`) carry **no** hook annotations and don't exist yet on
-a first `helm install` — pulling DB connection vars from them (the pre-Gate-8
-behavior) made the Job hit `CreateContainerConfigError` on every fresh
-install. `migrate-env-configmap.yaml` carries only the 5 non-secret DB
-connection keys the Job needs (mirrored from `configmap.data.POSTGRES_*`, so
-`values.yaml` stays the single source of truth even though the two ConfigMap
-*objects* are distinct); `migrate-secret.yaml` mirrors
-`secrets.data.POSTGRES_PASSWORD` the same way, but only when
-`secrets.create: true`. When `secrets.create: false`, the Job instead
-references `secrets.existingSecretName` directly — that Secret is
-operator-managed and pre-exists before `helm install` runs, so it's already
-visible to pre-install hooks without needing a hook annotation of its own.
+The Job reads the DB connection from plain env vars
+(`POSTGRES_HOST`/`POSTGRES_PORT`/`POSTGRES_USER`/`POSTGRES_NAME`/`POSTGRES_SSLMODE`,
+each defaulting to the app's `configmap.data.POSTGRES_*`) plus
+`POSTGRES_PASSWORD` via `secretKeyRef`. When `migrations.useExistingSecret=true`
+the password comes from the operator-managed `migrations.existingSecretName`
+instead of the chart-minted PreSync Secret (the render **fails fast** if
+`existingSecretName` is left empty in that mode).
 
-### Why a ConfigMap instead of "copy from the app image"
+A lightweight `busybox` initContainer (`migrations.waitForPostgres`, on by
+default) polls `POSTGRES_HOST:POSTGRES_PORT` with `nc -z` before the migrations
+container starts, so a fresh install racing a not-yet-ready Postgres doesn't
+hard-fail the Job.
 
-The app's runtime image is `gcr.io/distroless/static-debian12:nonroot` (see
-`Dockerfile`) — it ships **only** the compiled `/service` binary, CA
-certificates, and the `nonroot` passwd/group entries. There is no shell, no
-`cp`, no busybox. An initContainer cannot `exec` a copy out of that image.
-
-Instead, `templates/migrate-configmap.yaml` embeds `migrations/*.sql`
-(golang-migrate naming, `NNNNNN_description.{up,down}.sql`) directly into a
-ConfigMap via Helm's `.Files.Glob`, mounted read-only at `/migrations` in the
-migrate Job — no initContainer needed for this step at all.
-`deployments/helm/br-slc/migrations` is a **symlink** to the repo-root
-`migrations/` directory (the same source `make check-migrations`/CI validate),
-not a duplicated copy, so there is no drift risk. Verified empirically in this
-worktree: `helm lint`/`helm template`/`helm package` all dereference the
-symlink's content correctly (a `helm package`/`helm lint` "found symbolic link
-in path" notice on stdout is expected, not an error), and `helm template`
-against the resulting `.tgz` renders identically. Total embedded payload is
-~107KB across 42 files — well under the 1MiB ConfigMap/etcd object limit.
-
-A lightweight `busybox:1.37` initContainer (`waitForPostgres`, mirroring the
-Lerian wait-for-dependencies convention) polls `POSTGRES_HOST:POSTGRES_PORT`
-with `nc -z` before the migrate container starts, so a fresh install racing a
-not-yet-ready Postgres doesn't hard-fail the Job.
-
-`DATABASE_URL` is composed **by Helm at template time** from
-`.Values.configmap.data.*` (no shell needed in the scratch-based
-`migrate/migrate` image, and no reliance on kubelet `$(VAR)` expansion of
-envFrom-sourced vars) but **deliberately omits the password**
-(`postgres://<user>@<host>:<port>/<name>?sslmode=<sslmode>`)
-so the password never lands in the container's argv
-(`-database=$(DATABASE_URL)`, visible via `ps`/`/proc/1/cmdline` to anything
-that can see the pod). The password is instead exported as `PGPASSWORD`
-(from the same Secret, via `secretKeyRef`) — golang-migrate's postgres driver
-(`lib/pq`) reads the standard libpq `PG*` environment variables for any DSN
-field missing from the connection string, so `PGPASSWORD` fills in the
-omitted password at connect time. A password containing URL-reserved
-characters (`@ : / ? # %`) would still need percent-encoding if it appeared in
-the DSN — moot now since the password never appears in the DSN string at
-all.
-
-Set `migrations.enabled: false` to skip the Job entirely (e.g. if migrations
+Set `migrations.enabled: false` to skip the hook entirely (e.g. if migrations
 are applied by a separate operational process).
 
 ### Recovering from a dirty migration
 
 If a migration fails partway through, golang-migrate marks
-`schema_migrations.dirty = true` in the database. Every subsequent `helm
-upgrade` re-runs this same (now permanently failing) hook Job, wedging the
-release — the Job keeps refusing to apply the next migration on top of a dirty
-version, so `helm upgrade` never succeeds again on its own.
+`schema_migrations.dirty = true` in the database. Every subsequent sync re-runs
+this PreSync Job, which keeps refusing to apply the next migration on top of a
+dirty version — so the release never converges on its own.
 
 Manual recovery:
 
-1. **Find the failing version.** Inspect the failed hook Job/pod logs
-   (`kubectl logs job/<release>-br-slc-migrate-<revision>` or the pod itself —
-   `hook-delete-policy: before-hook-creation` keeps the failed Job/pod around
-   until the *next* hook run recreates it, so grab the logs before retrying).
-   golang-migrate's error output names the dirty version, e.g. `Dirty database
-   version 7. Fix and force version.`
+1. **Find the failing version.** Inspect the failed PreSync Job/pod logs
+   (`kubectl logs job/<release>-br-slc-migrations`). golang-migrate's error
+   output names the dirty version, e.g. `Dirty database version 7. Fix and
+   force version.`
 2. **Force the version.** Run a one-off `migrate force <version>` against the
-   same database, using the same `migrate/migrate:<tag>` image (see
-   `migrations.image.tag`) and the migrations ConfigMap
-   (`{{ include "br-slc.fullname" . }}-migrations`) mounted at `/migrations`,
-   e.g.:
-   ```bash
-   kubectl run migrate-force --rm -it --restart=Never \
-     --image=migrate/migrate:v4.19.1 \
-     --overrides='{"spec":{"containers":[{"name":"migrate-force","image":"migrate/migrate:v4.19.1","args":["-path=/migrations","-database=postgres://USER@HOST:PORT/NAME?sslmode=require","force","<version>"],"env":[{"name":"PGPASSWORD","valueFrom":{"secretKeyRef":{"name":"<secret>","key":"POSTGRES_PASSWORD"}}}],"volumeMounts":[{"name":"migrations","mountPath":"/migrations"}]}],"volumes":[{"name":"migrations","configMap":{"name":"<release>-br-slc-migrations"}}]}}'
-   ```
-   Substitute the real `USER`/`HOST`/`PORT`/`NAME`/secret name from your
-   release's values, and `<version>` with the version identified in step 1
-   (use the version *before* the failed one if the failed migration's DDL did
-   not actually apply — confirm against the target schema before forcing).
-3. **Re-run the upgrade.** With `dirty` cleared, `helm upgrade` retries the
-   hook Job normally and applies the remaining migrations.
+   same database, pointed at the same Postgres endpoint/credentials the Job
+   uses (any golang-migrate-capable CLI works — the `schema_migrations` table
+   is standard). Set `<version>` to the value identified in step 1 (use the
+   version *before* the failed one if the failed migration's DDL did not
+   actually apply — confirm against the target schema before forcing).
+3. **Re-sync.** With `dirty` cleared, the PreSync Job runs normally and applies
+   the remaining migrations.
 
-This is a manual, deliberately out-of-band recovery path — the hook Job does
-not attempt automatic dirty-state recovery, since forcing the wrong version
-can silently skip or reapply DDL.
-
-### `.helmignore` (Task 6.0.2 reconciliation)
-
-The `migrations/` symlink also drags in three Go integration test files
-(`*_test.go`) and one JSON systemplane DDL manifest
-(`systemplane_ddl_manifest.json`) that live alongside the SQL in the
-repo-root `migrations/` directory. `.helmignore` excludes
-`migrations/*_test.go`, `migrations/*.json`, and `migrations/*.go` so only
-the 42 `.sql` files (21 up + 21 down) are loaded into the chart —
-`.Files.Glob "migrations/*.sql"` in `migrate-configmap.yaml` is unaffected by
-this exclusion (still finds all 42) since `.helmignore` only removes the
-non-SQL files, not the glob's own matches.
+This is a manual, deliberately out-of-band recovery path — the hook does not
+attempt automatic dirty-state recovery, since forcing the wrong version can
+silently skip or reapply DDL.
 
 ## Probes
 

--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -1,0 +1,411 @@
+# br-slc Helm chart
+
+Internal Helm chart for the **br-slc monolith** (Sistema de Liquidação
+Centralizada — SLC). BYOC single-tenant deployment: **ClusterIP-only**
+Service, **no Ingress**. Postgres/Redis/RabbitMQ are external, client-managed
+dependencies in BYOC — this chart does not deploy them.
+
+## Chart Contract
+
+- Chart type: `single-service` — one Deployment (the monolith) with mandatory
+  same-pod `slc-signer` + `aslc-xsd-validator` sidecars and a conditional
+  `mqbridge` sidecar, plus a detached migrations Job.
+- Required secrets: **None for a default render.** For a real install provide
+  the app Secret keys (`POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `WEBHOOK_API_KEY`,
+  `WEBHOOK_HMAC_SECRET`, and — only when the corresponding integration is
+  enabled — `RABBITMQ_DEFAULT_PASS`, `AWS_SECRET_ACCESS_KEY`,
+  `AWS_SESSION_TOKEN`) via `secrets.data` (`secrets.create=true`) or an
+  operator-managed `secrets.existingSecretName`. The signing-key material
+  (`SIGNER_SOFTKEY_PFX_PASSPHRASE`, `SIGNER_VAULT_TOKEN`, `SIGNER_PKCS11_PIN`,
+  awskms creds) lives ONLY in the signer Secret (`signer.secrets.*`, ADR-9
+  custody) and is never readable by the app container. The migration Job reads
+  `POSTGRES_PASSWORD` from a dedicated PreSync Secret (or
+  `migrations.existingSecretName`). No credential is ever placed in a ConfigMap.
+- Dependency notes: No bundled subcharts. Postgres, Redis and (optional)
+  RabbitMQ are EXTERNAL and pre-provisioned in BYOC — the chart only takes
+  connection config (`configmap.data.POSTGRES_HOST` / `REDIS_HOST` / RabbitMQ
+  host). Streaming (Kafka/Redpanda) is external and referenced only when
+  `STREAMING_ENABLED=true`. The `mqbridge` sidecar links the external IBM
+  MQ/RSFN broker (amd64-only) and is off by default.
+- Production overrides: Set `image.tag` (defaults to `Chart.appVersion`);
+  `configmap.data.POSTGRES_HOST` / `REDIS_HOST`; `configmap.data.PLUGIN_AUTH_HOST`
+  (auth is on by default and **fails closed at boot** until this is set);
+  `configmap.data.CORS_ALLOWED_ORIGINS` (empty deny-all by default); the app +
+  signer Secrets; and, for the IF Domicílio role, `mqbridge.enabled=true` with
+  `RSFN_CONSUMER_TRANSPORT=mq` (forces `replicaCount=1` + an amd64 node pin).
+  `secrets.useExistingSecret`-style `create`/`existingSecretName` are supported
+  for the app, signer, mqbridge and migration Secrets.
+- Source/license: Source is in `github.com/LerianStudio/helm`; chart license is
+  Apache-2.0. The `br-slc` service source is `github.com/LerianStudio/br-slc`.
+
+## Topology (ADR-12: same-pod sidecars)
+
+This chart ships **one Deployment**. Its pod runs **three mandatory
+containers**, plus a **fourth conditional container** (`mqbridge`) that is
+rendered only when `mqbridge.enabled=true`:
+
+| Container | Port | Role | Reached via | Rendered |
+|---|---|---|---|---|
+| `br-slc` | 4111 | the monolith | — | always |
+| `slc-signer` | 9101 | ICP-Brasil signing / crypto+credential boundary (ADR-9) | `SIGNER_URL=http://localhost:9101` | always |
+| `aslc-xsd-validator` | 9091 | XSD validation (fail-closed for outbound ASLC) | `XSD_VALIDATOR_URL=http://localhost:9091` | always |
+| `mqbridge` | 9121 | inbound IBM MQ/RSFN consumer (cards channel) | `MQ_BRIDGE_URL=http://localhost:9121` | only when `mqbridge.enabled=true` |
+
+The signer and validator are **mandatory same-pod containers** (ADR-12,
+"sidecar no mesmo pod, localhost") — no enable toggle. The app talks to them
+over **localhost**, not cluster DNS. **Shared fate**: the pod only reaches
+`Ready` when all its containers pass their own readiness probes, which
+removes the "app Ready but validator absent" window. Each container keeps its
+own hardened `securityContext` and its own `/tmp` `emptyDir`.
+
+**Custody (ADR-9):** the signing-key material (softkey PFX + passphrase, HSM
+PIN, Vault token) is mounted/injected **only** on the `slc-signer` container
+(its own `signer.secrets` Secret + `signer.softkeySecret` volume) — never on
+the app, validator, or mqbridge container.
+
+### Conditional `mqbridge` container (Decisão 21)
+
+The inbound **`mqbridge`** (IBM MQ/RSFN consumer of the cards channel) is a
+**same-pod CONDITIONAL** container — `mqbridge.enabled: false` by default. A
+BYOC client flips it on when the role is **IF Domicílio** with
+`RSFN_CONSUMER_TRANSPORT=mq`; a credenciadora-only tenant never carries it.
+It was previously a separate, gated Deployment (its own `br-slc-mq-bridge`
+chart) — Decisão 21 moved it into this pod so the app reaches it over
+**localhost:9121** (resolving the drain/ack affinity risk by construction:
+same pod, same localhost).
+
+When (and only when) `mqbridge.enabled=true`:
+
+- The pod gains the `mqbridge` container (writable `/var/mqm` rootfs +
+  read-only keystore mount when `mqbridge.keystoreSecret.enabled`), plus its
+  own `<fullname>-mqbridge` ConfigMap and (when
+  `mqbridge.secrets.create=true`) `<fullname>-mqbridge-secrets` Secret.
+- The **whole pod gets an amd64 node pin**
+  (`nodeSelector: kubernetes.io/arch: amd64`) — the IBM MQ Redistributable
+  Client (libmqm/GSKit) it links is published for Linux x86_64 only. The pin
+  is absent when the bridge is disabled.
+- The mqbridge keystore (GSKit `.kdb/.sth/.rdb`) is mounted **only** on this
+  container, never on the app/signer/validator.
+- **`replicaCount` is hard-capped to 1.** The bridge holds per-process state
+  (`/v1/drain` mints a `deliveryRef→conn`; `/v1/ack` must land in the SAME
+  process), and its mTLS identity is per-process (`MQSCO.KeyRepository` from
+  env `MQSSLKEYR`), so 1 process = 1 RSFN participant. As a same-pod container
+  the monolith `replicaCount` governs the consumer count — the render **fails**
+  with a guard message if `mqbridge.enabled` and `replicaCount != 1`.
+
+> **Enabling `mqbridge` couples app scale to the consumer.** If a client needs
+> app HA (multiple replicas) **and** MQ inbound simultaneously, that signals
+> the separate-Deployment / **Fase 7** multi-tenant consumer-manager path
+> (Decisão 21) — escalate as a DOUBT, do not force multi-replica with the
+> bridge enabled.
+
+## Install
+
+```bash
+helm lint deployments/helm/br-slc
+helm template my-release deployments/helm/br-slc
+
+# Real install — you MUST override at least:
+#   - configmap.data.POSTGRES_HOST / REDIS_HOST (external, client-managed)
+#   - configmap.data.PLUGIN_AUTH_HOST (required: PLUGIN_AUTH_ENABLED=true by default)
+#   - configmap.data.CORS_ALLOWED_ORIGINS (empty/deny-all by default)
+#   - secrets.* (see "Secrets" below)
+helm install my-release deployments/helm/br-slc -f my-values.yaml
+```
+
+No `values-<env>.yaml` files live in this chart — per-environment overrides
+(dev/hml relaxations, SaaS-only knobs) belong in the beleriand gitops overlays
+(Task 6.0.6), not here.
+
+## Secrets
+
+Secrets are split by custody boundary (ADR-9) into **two** Secrets so the
+signing-key material is never readable by the app container.
+
+### App container Secret (`secrets.*`)
+
+Seven env vars, injected via `secretKeyRef` into both the app container and the
+migration Job:
+
+| Env var | Purpose |
+|---|---|
+| `POSTGRES_PASSWORD` | primary Postgres password |
+| `REDIS_PASSWORD` | Redis/Valkey password |
+| `WEBHOOK_API_KEY` | client webhook API-key header (BYOC `direct` provider) |
+| `WEBHOOK_HMAC_SECRET` | client webhook HMAC signing secret |
+| `RABBITMQ_DEFAULT_PASS` | RabbitMQ password (inert while `RABBITMQ_ENABLED=false`, this base's default; only meaningful if an overlay enables RabbitMQ for real) |
+| `AWS_SECRET_ACCESS_KEY` | AWS static credential for the app's M2M provider (prefer IRSA instead — keep empty) |
+| `AWS_SESSION_TOKEN` | AWS static credential (prefer IRSA instead — keep empty) |
+
+### Signer container Secret (`signer.secrets.*`, ADR-9 custody)
+
+Five key/credential-material env vars injected **only** into the `slc-signer`
+container (never the app):
+
+| Env var | Purpose |
+|---|---|
+| `SIGNER_SOFTKEY_PFX_PASSPHRASE` | decrypts the softkey PFX (dev/softkey custody; production should use awskms/pkcs11/vault) |
+| `AWS_SECRET_ACCESS_KEY` | awskms adapter static credential (prefer IRSA — keep empty) |
+| `AWS_SESSION_TOKEN` | awskms adapter static credential (prefer IRSA — keep empty) |
+| `SIGNER_VAULT_TOKEN` | Vault transit auth token (only when `SIGNER_VAULT_ADDR` is set) |
+| `SIGNER_PKCS11_PIN` | HSM/SoftHSM2 token PIN (only when a pkcs11 token is configured) |
+
+The softkey PFX **file** itself is mounted read-only onto the signer container
+from an externally managed Secret via `signer.softkeySecret.*` (never baked
+into the image or `values.yaml`).
+
+Each Secret has the same two modes (`secrets.create` / `signer.secrets.create`):
+
+- **`create: false` (default, recommended for BYOC).** The client manages the
+  Secret out-of-band (their own manifest, External Secrets Operator, Vault
+  injector, etc.) and sets `existingSecretName` to its name. That Secret
+  **must** expose the same keys listed above.
+- **`create: true`.** This chart creates the Secret from `*.data` — populate
+  those values via `--set-string`/`-f` at install time (a values override file
+  kept out of version control), never by committing real values to this
+  chart's `values.yaml`.
+
+`AWS_ACCESS_KEY_ID` stays in the ConfigMap (the non-secret half of a static
+credential pair, analogous to a `*_USER` var) and is deliberately **not**
+secret-managed: it must stay empty in production/BYOC. Use IRSA (EKS) or an
+equivalent workload identity via `serviceAccount.annotations` instead — the
+AWS SDK's default credential chain picks that up with no env vars at all.
+
+## Env var coverage
+
+All active vars from `config/.env.example` are covered. `config/.env.example`
+is the shared compose-stack env file, so it also carries the signer/validator
+vars — under this chart's same-pod consolidation those live in the
+`signer.configmap.data` / `signer.secrets.data` / `xsdValidator.configmap.data`
+subsections (see `values.yaml`), NOT in the app's ConfigMap/Secret. The app
+container's own surface is the app `configmap.data` (non-secret) plus the
+7-key app Secret (Task 6.0.2 reconciliation moved `RABBITMQ_DEFAULT_PASS`,
+`AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` from the ConfigMap into the
+Secret; the ADR-12 consolidation moved `SIGNER_SOFTKEY_PFX_PASSPHRASE` out of
+the app Secret into `signer.secrets.data` per the ADR-9 custody boundary — see
+"Flagged deviations" below). Two additional vars are surfaced beyond
+`.env.example`'s app surface because this chart's hardened defaults require
+them (see the header comment above `configmap.data` in `values.yaml` for the
+full rationale):
+
+| Var | Why it's here even though not "active" in `.env.example` |
+|---|---|
+| `DEPLOYMENT_MODE` | Read by `config_validation.go`/`systemplane.go`/TLS enforcement; `.env.example` has no active line for it. Defaults to `byoc`. |
+| `PLUGIN_AUTH_HOST` | `.env.example` only has it commented out (auth defaults off there). This chart's base flips `PLUGIN_AUTH_ENABLED=true`, and `config_validation.go`'s `validateAuthConfig` **fails boot** if `PLUGIN_AUTH_HOST` is empty when auth is enabled. **This chart intentionally fails closed at boot until you set the real Access Manager URL** — that is deliberate hardening, not a bug, but you must set it before first deploy. |
+
+Every one of the 156 was checked mechanically against
+`config/.env.example` (grep for uncommented `KEY=` lines) and cross-referenced
+against the `env:"..."` struct tags in `internal/bootstrap/config.go`. See the
+`ring:helm` execution report for the full 156-row source table.
+
+### Flagged deviations from `.env.example`'s dev defaults
+
+This base intentionally hardens a handful of values beyond mirroring
+`.env.example` (which is tuned for local/dev, not BYOC production):
+
+- `ENV_NAME=production` (was `development`) — activates
+  `config_validation.go`'s production hardening gate.
+- `ALLOW_INSECURE_TLS` / `ALLOW_CORS_WILDCARD` / `ALLOW_RATELIMIT_FAIL_OPEN` =
+  `false` (all were `true` in `.env.example`, which is dev/CI-only — production
+  boot is rejected if `ALLOW_CORS_WILDCARD` or `ALLOW_RATELIMIT_FAIL_OPEN` is
+  true anyway).
+- `POSTGRES_SSLMODE=require` (was `disable`) — production boot is **rejected**
+  if this is `disable` (`config_validation.go`). Tighten to `verify-full` once
+  the client's Postgres cert chain is known.
+- `PLUGIN_AUTH_ENABLED=true` (was `false`) — real auth in BYOC; see
+  `PLUGIN_AUTH_HOST` note above.
+- `ENABLE_TELEMETRY=true` (was `false`) — production observability on by
+  default; `OTEL_EXPORTER_OTLP_ENDPOINT` assumes an in-cluster
+  `otel-collector-lerian` release — reconcile the real name per environment.
+- `RABBITMQ_DEFAULT_PASS` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` live
+  in `secrets.data`, not the ConfigMap (Task 6.0.2 reconciliation — see
+  "Secrets" above). `RABBITMQ_DEFAULT_PASS` is inert while
+  `RABBITMQ_ENABLED=false` (this base's default); the two AWS vars are
+  expected to stay empty in production regardless (prefer IRSA).
+- `SIGNER_URL` / `XSD_VALIDATOR_URL` / `MQ_BRIDGE_URL` all point at
+  **localhost** (`http://localhost:9101`, `http://localhost:9091`,
+  `http://localhost:9121`) because the signer, validator, and (when enabled)
+  the `mqbridge` are same-pod containers (ADR-12 + Decisão 21) — not cluster
+  DNS. `MQ_BRIDGE_URL` is inert until `RSFN_CONSUMER_TRANSPORT=mq` **and**
+  `mqbridge.enabled=true` (see "Conditional `mqbridge` container" above).
+
+## Migration Job
+
+A `pre-install,pre-upgrade` Helm hook Job (`templates/migrate-job.yaml`,
+`helm.sh/hook-weight: "-5"`) runs `migrate -path /migrations -database
+"$DATABASE_URL" up` **before** the Deployment rolls, applying all 21
+migrations under `migrations/` (golang-migrate, pinned to `v4.19.1` to match
+`go.mod`'s `github.com/golang-migrate/migrate/v4 v4.19.1`).
+
+Ordering: `migrate-env-configmap.yaml` / `migrate-secret.yaml` (weight `-7`) →
+`migrate-configmap.yaml` (weight `-6`) → `migrate-job.yaml` (weight `-5`) → the
+Deployment/Service (unweighted, run after all hooks succeed). All hook
+resources use `hook-delete-policy: before-hook-creation,hook-succeeded`, so a
+re-run on `helm upgrade` cleans up the prior hook Job/ConfigMap/Secret and
+creates fresh ones.
+
+The `-7` weight matters: the migrate Job (and its `wait-for-postgres`
+initContainer) must never reference a resource that isn't itself a hook at an
+earlier weight. The app's own ConfigMap/Secret (`templates/configmap.yaml`,
+`templates/secret.yaml`) carry **no** hook annotations and don't exist yet on
+a first `helm install` — pulling DB connection vars from them (the pre-Gate-8
+behavior) made the Job hit `CreateContainerConfigError` on every fresh
+install. `migrate-env-configmap.yaml` carries only the 5 non-secret DB
+connection keys the Job needs (mirrored from `configmap.data.POSTGRES_*`, so
+`values.yaml` stays the single source of truth even though the two ConfigMap
+*objects* are distinct); `migrate-secret.yaml` mirrors
+`secrets.data.POSTGRES_PASSWORD` the same way, but only when
+`secrets.create: true`. When `secrets.create: false`, the Job instead
+references `secrets.existingSecretName` directly — that Secret is
+operator-managed and pre-exists before `helm install` runs, so it's already
+visible to pre-install hooks without needing a hook annotation of its own.
+
+### Why a ConfigMap instead of "copy from the app image"
+
+The app's runtime image is `gcr.io/distroless/static-debian12:nonroot` (see
+`Dockerfile`) — it ships **only** the compiled `/service` binary, CA
+certificates, and the `nonroot` passwd/group entries. There is no shell, no
+`cp`, no busybox. An initContainer cannot `exec` a copy out of that image.
+
+Instead, `templates/migrate-configmap.yaml` embeds `migrations/*.sql`
+(golang-migrate naming, `NNNNNN_description.{up,down}.sql`) directly into a
+ConfigMap via Helm's `.Files.Glob`, mounted read-only at `/migrations` in the
+migrate Job — no initContainer needed for this step at all.
+`deployments/helm/br-slc/migrations` is a **symlink** to the repo-root
+`migrations/` directory (the same source `make check-migrations`/CI validate),
+not a duplicated copy, so there is no drift risk. Verified empirically in this
+worktree: `helm lint`/`helm template`/`helm package` all dereference the
+symlink's content correctly (a `helm package`/`helm lint` "found symbolic link
+in path" notice on stdout is expected, not an error), and `helm template`
+against the resulting `.tgz` renders identically. Total embedded payload is
+~107KB across 42 files — well under the 1MiB ConfigMap/etcd object limit.
+
+A lightweight `busybox:1.37` initContainer (`waitForPostgres`, mirroring the
+Lerian wait-for-dependencies convention) polls `POSTGRES_HOST:POSTGRES_PORT`
+with `nc -z` before the migrate container starts, so a fresh install racing a
+not-yet-ready Postgres doesn't hard-fail the Job.
+
+`DATABASE_URL` is composed **by Helm at template time** from
+`.Values.configmap.data.*` (no shell needed in the scratch-based
+`migrate/migrate` image, and no reliance on kubelet `$(VAR)` expansion of
+envFrom-sourced vars) but **deliberately omits the password**
+(`postgres://<user>@<host>:<port>/<name>?sslmode=<sslmode>`)
+so the password never lands in the container's argv
+(`-database=$(DATABASE_URL)`, visible via `ps`/`/proc/1/cmdline` to anything
+that can see the pod). The password is instead exported as `PGPASSWORD`
+(from the same Secret, via `secretKeyRef`) — golang-migrate's postgres driver
+(`lib/pq`) reads the standard libpq `PG*` environment variables for any DSN
+field missing from the connection string, so `PGPASSWORD` fills in the
+omitted password at connect time. A password containing URL-reserved
+characters (`@ : / ? # %`) would still need percent-encoding if it appeared in
+the DSN — moot now since the password never appears in the DSN string at
+all.
+
+Set `migrations.enabled: false` to skip the Job entirely (e.g. if migrations
+are applied by a separate operational process).
+
+### Recovering from a dirty migration
+
+If a migration fails partway through, golang-migrate marks
+`schema_migrations.dirty = true` in the database. Every subsequent `helm
+upgrade` re-runs this same (now permanently failing) hook Job, wedging the
+release — the Job keeps refusing to apply the next migration on top of a dirty
+version, so `helm upgrade` never succeeds again on its own.
+
+Manual recovery:
+
+1. **Find the failing version.** Inspect the failed hook Job/pod logs
+   (`kubectl logs job/<release>-br-slc-migrate-<revision>` or the pod itself —
+   `hook-delete-policy: before-hook-creation` keeps the failed Job/pod around
+   until the *next* hook run recreates it, so grab the logs before retrying).
+   golang-migrate's error output names the dirty version, e.g. `Dirty database
+   version 7. Fix and force version.`
+2. **Force the version.** Run a one-off `migrate force <version>` against the
+   same database, using the same `migrate/migrate:<tag>` image (see
+   `migrations.image.tag`) and the migrations ConfigMap
+   (`{{ include "br-slc.fullname" . }}-migrations`) mounted at `/migrations`,
+   e.g.:
+   ```bash
+   kubectl run migrate-force --rm -it --restart=Never \
+     --image=migrate/migrate:v4.19.1 \
+     --overrides='{"spec":{"containers":[{"name":"migrate-force","image":"migrate/migrate:v4.19.1","args":["-path=/migrations","-database=postgres://USER@HOST:PORT/NAME?sslmode=require","force","<version>"],"env":[{"name":"PGPASSWORD","valueFrom":{"secretKeyRef":{"name":"<secret>","key":"POSTGRES_PASSWORD"}}}],"volumeMounts":[{"name":"migrations","mountPath":"/migrations"}]}],"volumes":[{"name":"migrations","configMap":{"name":"<release>-br-slc-migrations"}}]}}'
+   ```
+   Substitute the real `USER`/`HOST`/`PORT`/`NAME`/secret name from your
+   release's values, and `<version>` with the version identified in step 1
+   (use the version *before* the failed one if the failed migration's DDL did
+   not actually apply — confirm against the target schema before forcing).
+3. **Re-run the upgrade.** With `dirty` cleared, `helm upgrade` retries the
+   hook Job normally and applies the remaining migrations.
+
+This is a manual, deliberately out-of-band recovery path — the hook Job does
+not attempt automatic dirty-state recovery, since forcing the wrong version
+can silently skip or reapply DDL.
+
+### `.helmignore` (Task 6.0.2 reconciliation)
+
+The `migrations/` symlink also drags in three Go integration test files
+(`*_test.go`) and one JSON systemplane DDL manifest
+(`systemplane_ddl_manifest.json`) that live alongside the SQL in the
+repo-root `migrations/` directory. `.helmignore` excludes
+`migrations/*_test.go`, `migrations/*.json`, and `migrations/*.go` so only
+the 42 `.sql` files (21 up + 21 down) are loaded into the chart —
+`.Files.Glob "migrations/*.sql"` in `migrate-configmap.yaml` is unaffected by
+this exclusion (still finds all 42) since `.helmignore` only removes the
+non-SQL files, not the glob's own matches.
+
+## Probes
+
+| Container | Probe | Path | Port | Notes |
+|---|---|---|---|---|
+| `br-slc` | liveness | `/health` | 4111 | process viability only, no dependency checks |
+| `br-slc` | readiness | `/readyz` | 4111 | dependency-aware; has a `draining` state during graceful shutdown — more lenient `failureThreshold` than liveness |
+| `slc-signer` | liveness + readiness | `/health` | 9101 | same path for both (no separate readyz) |
+| `aslc-xsd-validator` | liveness + readiness | `/health` | 9091 | same path for both |
+| `mqbridge` | liveness only | `/health` | 9121 | only when `mqbridge.enabled`; process viability. **No readinessProbe on purpose** (Decisão 21) |
+
+The app's `/health` and `/readyz` are auth/telemetry-exempt (see
+`internal/bootstrap/routes.go`, `fiber_server.go`); `/metrics` is also exempt
+but not probed here. Readiness relies on **per-container probes + shared
+fate**: the pod is only `Ready` when all readiness-probed containers pass, so a
+crash-looping signer/validator de-registers the pod endpoint on its own. The
+app's `/readyz` deliberately does **not** add signer/validator dependency
+checks — the fail-closed guard is enforced per-request in the builders, and
+double-coupling readyz would only cause flapping. **mqbridge deliberately has
+NO readinessProbe**: nothing routes to `:9121` via a Service, and its `/readyz`
+reflects the live IBM MQ pool, so wiring it as readiness would pull the WHOLE
+pod out of the monolith's `:4111` Service on any MQ blip — under the
+`replicaCount=1` hard-cap that is a total API outage, not a consumer
+degradation. MQ health reaches the monolith via the client-side breaker.
+
+## Security posture
+
+Every container (app, `slc-signer`, `aslc-xsd-validator`, migrate) carries the
+same hardened `securityContext`: `runAsNonRoot: true`, `runAsUser/Group:
+65532`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`
+(each with its own `emptyDir` at `/tmp`), all capabilities dropped,
+`seccompProfile: RuntimeDefault`. The signer/validator postures are set
+per-container via `signer.securityContext` / `xsdValidator.securityContext`.
+The conditional `mqbridge` container (`mqbridge.securityContext`) shares this
+posture with **one deliberate exception**: `readOnlyRootFilesystem: false`,
+because the IBM MQ C client (libmqm) needs a writable `/var/mqm` (mounted as
+an explicit `emptyDir`); it stays non-root, no privilege escalation, all
+capabilities dropped, `RuntimeDefault` seccomp. Service is `ClusterIP` only.
+
+## Port-forward (no Ingress)
+
+```bash
+kubectl port-forward svc/my-release-br-slc 4111:4111
+curl localhost:4111/health
+curl localhost:4111/readyz
+```
+
+## Not included in this chart
+
+- **HPA / PodDisruptionBudget** — not in this chart's scope (Task 6.0.1
+  deliverable list); add if/when autoscaling or multi-replica HA is needed.
+- **Postgres/Redis/RabbitMQ subcharts** — BYOC brings its own; this chart only
+  takes connection config.
+- **SaaS multi-tenant MQ consumer manager** — the shared-keystore /
+  cert-label-per-connection consumer manager for the SaaS model is **Fase 7**
+  (a separate singleton Deployment), out of scope here (Decisão 21). This
+  chart's `mqbridge` is the BYOC single-tenant same-pod consumer only.

--- a/charts/br-slc/templates/_helpers.tpl
+++ b/charts/br-slc/templates/_helpers.tpl
@@ -1,0 +1,201 @@
+{{/*
+Expand the name of the chart. The chart is named "br-slc-helm" (helm-repo
+convention), but every workload/label uses the service name "br-slc".
+*/}}
+{{- define "br-slc.name" -}}
+{{- default "br-slc" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name. Truncated to 63 chars (K8s name
+length limit) and trimmed of a trailing "-".
+*/}}
+{{- define "br-slc.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "br-slc" .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version as used by the chart label.
+*/}}
+{{- define "br-slc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "br-slc.labels" -}}
+helm.sh/chart: {{ include "br-slc.chart" . }}
+{{ include "br-slc.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "br-slc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "br-slc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name to use.
+*/}}
+{{- define "br-slc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "br-slc.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret name to use for the 5 secret-bearing env vars: either the chart-created
+Secret (secrets.create=true) or an externally managed Secret
+(secrets.existingSecretName) — BYOC default is the latter.
+*/}}
+{{- define "br-slc.secretName" -}}
+{{- if .Values.secrets.existingSecretName -}}
+{{- .Values.secrets.existingSecretName -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "br-slc.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolved image reference: "repository:tag", defaulting tag to .Chart.AppVersion
+when empty.
+*/}}
+{{- define "br-slc.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Same-pod signer container image reference, defaulting tag to .Chart.AppVersion.
+*/}}
+{{- define "br-slc.signerImage" -}}
+{{- $tag := .Values.signer.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.signer.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Same-pod xsd-validator container image reference, defaulting tag to
+.Chart.AppVersion.
+*/}}
+{{- define "br-slc.validatorImage" -}}
+{{- $tag := .Values.xsdValidator.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.xsdValidator.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Same-pod mqbridge container image reference, defaulting tag to
+.Chart.AppVersion. Rendered only when mqbridge.enabled (Decisão 21).
+*/}}
+{{- define "br-slc.mqbridgeImage" -}}
+{{- $tag := .Values.mqbridge.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.mqbridge.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Signer-scoped Secret name (ADR-9 custody): the chart-created signer Secret
+(signer.secrets.create=true) or an externally managed one
+(signer.secrets.existingSecretName). Distinct from the app's br-slc.secretName
+so signing-key material is never in the app container's Secret.
+*/}}
+{{- define "br-slc.signerSecretName" -}}
+{{- if .Values.signer.secrets.existingSecretName -}}
+{{- .Values.signer.secrets.existingSecretName -}}
+{{- else -}}
+{{- printf "%s-signer-secrets" (include "br-slc.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Mqbridge-scoped Secret name (Decisão 21): the chart-created mqbridge Secret
+(mqbridge.secrets.create=true) or an externally managed one
+(mqbridge.secrets.existingSecretName). Distinct from the app's br-slc.secretName
+so MQ credential material stays scoped to the mqbridge container's env.
+*/}}
+{{- define "br-slc.mqbridgeSecretName" -}}
+{{- if .Values.mqbridge.secrets.existingSecretName -}}
+{{- .Values.mqbridge.secrets.existingSecretName -}}
+{{- else -}}
+{{- printf "%s-mqbridge-secrets" (include "br-slc.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the namespace of the release. Overridable for multi-namespace layouts.
+*/}}
+{{- define "global.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Migrations fullname, e.g. br-slc-migrations — the PreSync Job and Secret
+reference this.
+*/}}
+{{- define "br-slc-migrations.fullname" -}}
+{{- printf "%s-migrations" (include "br-slc.fullname" . | trunc 52 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Migrations labels.
+*/}}
+{{- define "br-slc-migrations.labels" -}}
+helm.sh/chart: {{ include "br-slc.chart" . }}
+app.kubernetes.io/name: {{ include "br-slc-migrations.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: migrations
+{{- end -}}
+
+{{/*
+Per-container securityContext (ADR-12 hardening). Same key set for every
+same-pod container; only the values differ. Call with the container's
+securityContext dict as context, e.g.:
+  securityContext:
+    {{- include "br-slc.containerSecurityContext" .Values.signer.securityContext | nindent 12 }}
+*/}}
+{{- define "br-slc.containerSecurityContext" -}}
+runAsNonRoot: {{ .runAsNonRoot }}
+runAsUser: {{ .runAsUser }}
+runAsGroup: {{ .runAsGroup }}
+allowPrivilegeEscalation: {{ .allowPrivilegeEscalation }}
+{{- if hasKey . "readOnlyRootFilesystem" }}
+readOnlyRootFilesystem: {{ .readOnlyRootFilesystem }}
+{{- end }}
+seccompProfile:
+  type: {{ .seccompProfile.type }}
+capabilities:
+  drop:
+    {{- range .capabilities.drop }}
+    - {{ . }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+HTTP liveness/readiness probe body. Call with the probe dict as context, e.g.:
+  livenessProbe:
+    {{- include "br-slc.httpProbe" .Values.signer.livenessProbe | nindent 12 }}
+*/}}
+{{- define "br-slc.httpProbe" -}}
+httpGet:
+  path: {{ .httpGet.path }}
+  port: {{ .httpGet.port }}
+initialDelaySeconds: {{ .initialDelaySeconds }}
+periodSeconds: {{ .periodSeconds }}
+timeoutSeconds: {{ .timeoutSeconds }}
+failureThreshold: {{ .failureThreshold }}
+{{- end -}}

--- a/charts/br-slc/templates/_helpers.tpl
+++ b/charts/br-slc/templates/_helpers.tpl
@@ -199,3 +199,43 @@ periodSeconds: {{ .periodSeconds }}
 timeoutSeconds: {{ .timeoutSeconds }}
 failureThreshold: {{ .failureThreshold }}
 {{- end -}}
+
+{{/*
+mock-nuclea (Núclea clearing-house simulator) — a SEPARATE Deployment+Service,
+NOT a same-pod sidecar: it must be independently gated OFF (safe-by-default) and
+reached over cluster DNS by the app. DEV/HML FIXTURE ONLY — never enable in
+production/BYOC. Mirrors the detached-`migrations` component's own-fullname /
+own-labels convention so the app Service selector never captures the mock pod.
+*/}}
+{{- define "br-slc-mock-nuclea.fullname" -}}
+{{- printf "%s-mock-nuclea" (include "br-slc.fullname" . | trunc 51 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+mock-nuclea selector labels — distinct name from the app so the app's Service
+(br-slc.selectorLabels) never routes to the mock and vice-versa.
+*/}}
+{{- define "br-slc-mock-nuclea.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "br-slc-mock-nuclea.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+mock-nuclea labels.
+*/}}
+{{- define "br-slc-mock-nuclea.labels" -}}
+helm.sh/chart: {{ include "br-slc.chart" . }}
+{{ include "br-slc-mock-nuclea.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: mock-nuclea
+{{- end -}}
+
+{{/*
+mock-nuclea image reference, defaulting tag to .Chart.AppVersion when empty.
+Distinct image from the app (its own release-pipeline artifact).
+*/}}
+{{- define "br-slc.mockNucleaImage" -}}
+{{- $tag := .Values.mockNuclea.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.mockNuclea.image.repository $tag -}}
+{{- end -}}

--- a/charts/br-slc/templates/_helpers.tpl
+++ b/charts/br-slc/templates/_helpers.tpl
@@ -60,7 +60,7 @@ ServiceAccount name to use.
 {{- end -}}
 
 {{/*
-Secret name to use for the 5 secret-bearing env vars: either the chart-created
+Secret name to use for the 7 secret-bearing env vars: either the chart-created
 Secret (secrets.create=true) or an externally managed Secret
 (secrets.existingSecretName) — BYOC default is the latter.
 */}}

--- a/charts/br-slc/templates/configmap.yaml
+++ b/charts/br-slc/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-slc.fullname" . }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+data:
+  WEBHOOK_NOTIFICATIONS_TOKEN_CACHE_TTL_SEC: {{ .Values.webhookNotificationsCacheTtlSec | default "60" | quote }}
+  WEBHOOK_HMAC_SECRET_FILE: {{ .Values.webhookHmacSecretFile | default "" | quote }}
+  {{- range $key, $value := .Values.configmap.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/br-slc/templates/deployment.yaml
+++ b/charts/br-slc/templates/deployment.yaml
@@ -1,0 +1,291 @@
+{{- /* Decisão 21 hard-cap: when the same-pod mqbridge (RSFN IBM MQ consumer)
+is enabled, the MONOLITH replicaCount governs the consumer count. The bridge
+holds per-process state (/v1/drain mints deliveryRef->conn; /v1/ack must land
+in the SAME process), so 2+ replicas would fan RSFN connections out and break
+drain/ack affinity. Enabling mqbridge couples app scale to the consumer — if a
+client needs app HA + MQ simultaneously that signals the separate-Deployment /
+Fase 7 path, escalate rather than force. */}}
+{{- if .Values.mqbridge.enabled }}
+{{- if ne (int .Values.replicaCount) 1 }}
+{{- fail "mqbridge.enabled requires replicaCount=1 (RSFN consumer is a per-process singleton; ver Decisão 21)" }}
+{{- end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "br-slc.fullname" . }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "br-slc.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-slc.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "br-slc.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: br-slc
+          image: {{ include "br-slc.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "br-slc.fullname" . }}
+          env:
+            {{- /* Gate 8 FIX 7: without this, the Go runtime defaults
+            GOMAXPROCS to the NODE's core count (it can't see the container's
+            CFS cpu.limit), causing needless CFS throttling under load. The
+            downward API's resourceFieldRef rounds the cpu limit up to the
+            nearest whole core (divisor "1"), matching the CFS quota. Guarded
+            with `with` (not a plain `if .Values.resources.limits.cpu`) so a
+            values override that sets resources.limits to nil (a legitimate
+            way to ship a Burstable/no-limit override, not just an omitted
+            key) doesn't panic the render — dotting straight into `.cpu` on a
+            nil `resources.limits` errors ("nil pointer evaluating
+            interface{}.cpu"), whereas `with` only evaluates `.cpu` once it
+            has already confirmed the piped value is non-nil/non-empty. */}}
+            {{- with .Values.resources.limits }}
+            {{- if .cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.secrets.data }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "br-slc.secretName" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          livenessProbe:
+            {{- include "br-slc.httpProbe" .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- include "br-slc.httpProbe" .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- include "br-slc.containerSecurityContext" .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- /* Same-pod signer container (ADR-12 / Decision 9). Custody
+        (ADR-9): the signing-key Secret and softkey PFX volume are mounted
+        HERE ONLY, never on the app container above. Communicates with the app
+        over localhost:9101 (see configmap.data.SIGNER_URL). */}}
+        - name: slc-signer
+          image: {{ include "br-slc.signerImage" . | quote }}
+          imagePullPolicy: {{ .Values.signer.image.pullPolicy }}
+          ports:
+            - name: signer-http
+              containerPort: 9101
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "br-slc.fullname" . }}-signer
+          env:
+            {{- /* GOMAXPROCS from the container CFS cpu limit — same
+            downward-API fix as the br-slc container (Gate 8 FIX 7); the signer
+            is a CPU-limited Go process on the fail-closed ASLC signing hot
+            path. Guarded with `with`+`if .cpu` so a nil-limit override renders. */}}
+            {{- with .Values.signer.resources.limits }}
+            {{- if .cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.signer.secrets.data }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "br-slc.signerSecretName" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          livenessProbe:
+            {{- include "br-slc.httpProbe" .Values.signer.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- include "br-slc.httpProbe" .Values.signer.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.signer.resources | nindent 12 }}
+          securityContext:
+            {{- include "br-slc.containerSecurityContext" .Values.signer.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: signer-tmp
+              mountPath: /tmp
+            {{- if .Values.signer.softkeySecret.enabled }}
+            - name: softkey
+              mountPath: {{ .Values.signer.softkeySecret.mountPath }}
+              readOnly: true
+            {{- end }}
+        {{- /* Same-pod xsd-validator container (ADR-12). Stateless, no
+        secrets. Fail-closed hard dependency for outbound ASLC; shared fate in
+        this pod removes the "app Ready, validator absent" window.
+        Communicates over localhost:9091 (see configmap.data.XSD_VALIDATOR_URL). */}}
+        - name: aslc-xsd-validator
+          image: {{ include "br-slc.validatorImage" . | quote }}
+          imagePullPolicy: {{ .Values.xsdValidator.image.pullPolicy }}
+          ports:
+            - name: xsd-http
+              containerPort: 9091
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "br-slc.fullname" . }}-validator
+          env:
+            {{- /* GOMAXPROCS from the container CFS cpu limit — same
+            downward-API fix as the br-slc container (Gate 8 FIX 7); the
+            validator is a CPU-limited Go process on the fail-closed ASLC XSD
+            hot path. Guarded so a nil-limit override renders. */}}
+            {{- with .Values.xsdValidator.resources.limits }}
+            {{- if .cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            {{- end }}
+          livenessProbe:
+            {{- include "br-slc.httpProbe" .Values.xsdValidator.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- include "br-slc.httpProbe" .Values.xsdValidator.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.xsdValidator.resources | nindent 12 }}
+          securityContext:
+            {{- include "br-slc.containerSecurityContext" .Values.xsdValidator.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: validator-tmp
+              mountPath: /tmp
+        {{- if .Values.mqbridge.enabled }}
+        {{- /* Same-pod mqbridge container (ADR-12 / Decisão 21). CONDITIONAL —
+        default off, rendered only when the BYOC client's role is IF Domicílio
+        with RSFN_CONSUMER_TRANSPORT=mq. Owns the inbound IBM MQ/RSFN connection;
+        identity/keystore are per-process (MQSCO.KeyRepository from env MQSSLKEYR),
+        so 1 process = 1 participant (see the replicaCount guard at the top of
+        this template). The app reaches it over localhost:9121 (see
+        configmap.data.MQ_BRIDGE_URL). UNLIKE signer/validator, rootfs is
+        WRITABLE (libmqm needs /var/mqm) and the pod gets an amd64 pin below. */}}
+        - name: mqbridge
+          image: {{ include "br-slc.mqbridgeImage" . | quote }}
+          imagePullPolicy: {{ .Values.mqbridge.image.pullPolicy }}
+          ports:
+            - name: mq-http
+              containerPort: 9121
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "br-slc.fullname" . }}-mqbridge
+          env:
+            {{- /* GOMAXPROCS from the container CFS cpu limit — same
+            downward-API fix as the br-slc container (Gate 8 FIX 7); mqbridge is
+            a CPU-limited Go process. Guarded so a nil-limit override renders. */}}
+            {{- with .Values.mqbridge.resources.limits }}
+            {{- if .cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.mqbridge.secrets.data }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "br-slc.mqbridgeSecretName" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          livenessProbe:
+            {{- include "br-slc.httpProbe" .Values.mqbridge.livenessProbe | nindent 12 }}
+          # NO readinessProbe on purpose (Decisão 21): mqbridge is same-pod and
+          # nothing routes to :9121 through a Service, so a readiness probe here
+          # buys no traffic gating. Its /readyz reflects the IBM MQ pool state
+          # (mqbridge/pool.go), so wiring it as readiness would drag the WHOLE
+          # pod out of the monolith's :4111 Service on any MQ blip — with the
+          # replicaCount=1 hard-cap that is a total API outage, not a consumer
+          # degradation. Liveness (process /health) is enough to restart a hung
+          # bridge; MQ connectivity is surfaced to the monolith via the client's
+          # breaker instead.
+          resources:
+            {{- toYaml .Values.mqbridge.resources | nindent 12 }}
+          securityContext:
+            {{- include "br-slc.containerSecurityContext" .Values.mqbridge.securityContext | nindent 12 }}
+            # Writable rootfs for libmqm (/var/mqm). Set here, not in values.yaml.
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            # libmqm's writable state (error/FDC/trace logs). Explicit emptyDir
+            # regardless of readOnlyRootFilesystem=false, so the writable
+            # location never depends on the base image's own directory
+            # permissions (see values.yaml mqbridge.securityContext comment).
+            - name: mqbridge-var-mqm
+              mountPath: /var/mqm
+            {{- if .Values.mqbridge.keystoreSecret.enabled }}
+            - name: mqbridge-keystore
+              mountPath: {{ .Values.mqbridge.keystoreSecret.mountPath }}
+              readOnly: true
+            {{- end }}
+        {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: signer-tmp
+          emptyDir: {}
+        - name: validator-tmp
+          emptyDir: {}
+        {{- if .Values.signer.softkeySecret.enabled }}
+        - name: softkey
+          secret:
+            secretName: {{ .Values.signer.softkeySecret.secretName }}
+            items:
+              - key: {{ .Values.signer.softkeySecret.secretKey }}
+                path: signer.pfx
+        {{- end }}
+        {{- if .Values.mqbridge.enabled }}
+        - name: mqbridge-var-mqm
+          emptyDir: {}
+        {{- if .Values.mqbridge.keystoreSecret.enabled }}
+        - name: mqbridge-keystore
+          secret:
+            secretName: {{ .Values.mqbridge.keystoreSecret.secretName }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- /* Decisão 21: pod-level amd64 pin, present ONLY when mqbridge is
+      enabled. The IBM MQ Redistributable Client (libmqm/GSKit) this bridge
+      links is published for Linux x86_64 only, so the whole pod must schedule
+      onto amd64 nodes. Absent when mqbridge is disabled (no arch constraint on
+      the app+signer+validator pod). */}}
+      {{- if .Values.mqbridge.enabled }}
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      {{- end }}

--- a/charts/br-slc/templates/migrations/job.yaml
+++ b/charts/br-slc/templates/migrations/job.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.migrations.enabled }}
+# ArgoCD PreSync migration Job. Runs the dedicated br-slc-migrations image,
+# whose entrypoint applies the golang-migrate loop over the embedded
+# migrations/*.up.sql against the single br-slc database. The chart's Job only
+# provides the DB connection + runs the image; it does NOT build the loop.
+#
+# hook-weight -1 puts this after the PreSync Secret (-2) and before the
+# main-sync Deployment, so the monolith never boots against an unmigrated DB.
+{{- $pgHost := .Values.migrations.postgres.host | default .Values.configmap.data.POSTGRES_HOST }}
+{{- $pgPort := .Values.migrations.postgres.port | default .Values.configmap.data.POSTGRES_PORT | default "5432" }}
+{{- $pgUser := .Values.migrations.postgres.user | default .Values.configmap.data.POSTGRES_USER | default "br-slc" }}
+{{- $pgDb := .Values.migrations.postgres.database | default .Values.configmap.data.POSTGRES_NAME | default "br-slc" }}
+{{- $pgSslMode := .Values.migrations.postgres.sslMode | default .Values.configmap.data.POSTGRES_SSLMODE | default "require" }}
+{{- $secretName := ternary .Values.migrations.existingSecretName (include "br-slc-migrations.fullname" .) .Values.migrations.useExistingSecret }}
+{{- $pullSecrets := .Values.migrations.imagePullSecrets | default .Values.imagePullSecrets }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "br-slc-migrations.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-slc-migrations.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit | default 2 }}
+  activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds | default 600 }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished | default 259200 }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-slc-migrations.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.migrations.waitForPostgres.enabled }}
+      initContainers:
+        - name: wait-for-postgres
+          image: "{{ .Values.migrations.waitForPostgres.image.repository }}:{{ .Values.migrations.waitForPostgres.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - >
+              echo "waiting for {{ $pgHost }}:{{ $pgPort }}...";
+              until nc -z {{ $pgHost }} {{ $pgPort }}; do
+                echo "{{ $pgHost }}:{{ $pgPort }} not ready, waiting..."; sleep 2;
+              done;
+              echo "{{ $pgHost }}:{{ $pgPort }} is ready"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: "100m"
+              memory: 32Mi
+            requests:
+              cpu: "10m"
+              memory: 16Mi
+      {{- end }}
+      containers:
+        - name: migrations
+          image: "{{ .Values.migrations.image.repository }}:{{ .Values.migrations.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.migrations.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: POSTGRES_HOST
+              value: {{ $pgHost | quote }}
+            - name: POSTGRES_PORT
+              value: {{ $pgPort | quote }}
+            - name: POSTGRES_USER
+              value: {{ $pgUser | quote }}
+            - name: POSTGRES_NAME
+              value: {{ $pgDb | quote }}
+            - name: POSTGRES_SSLMODE
+              value: {{ $pgSslMode | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_PASSWORD
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+{{- end }}

--- a/charts/br-slc/templates/migrations/job.yaml
+++ b/charts/br-slc/templates/migrations/job.yaml
@@ -12,6 +12,9 @@
 {{- $pgDb := .Values.migrations.postgres.database | default .Values.configmap.data.POSTGRES_NAME | default "br-slc" }}
 {{- $pgSslMode := .Values.migrations.postgres.sslMode | default .Values.configmap.data.POSTGRES_SSLMODE | default "require" }}
 {{- $secretName := ternary .Values.migrations.existingSecretName (include "br-slc-migrations.fullname" .) .Values.migrations.useExistingSecret }}
+{{- if and .Values.migrations.useExistingSecret (not .Values.migrations.existingSecretName) }}
+{{- fail "migrations.useExistingSecret=true requires migrations.existingSecretName to be set" }}
+{{- end }}
 {{- $pullSecrets := .Values.migrations.imagePullSecrets | default .Values.imagePullSecrets }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/br-slc/templates/migrations/secrets.yaml
+++ b/charts/br-slc/templates/migrations/secrets.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.migrations.enabled (not .Values.migrations.useExistingSecret) }}
+# Dedicated PreSync Secret carrying only the Postgres password for the migration
+# Job. PreSync hooks run BEFORE the main sync wave, so on a first install the
+# app Secret does not exist yet. This hook Secret (weight -2) is created before
+# the migration Job (weight -1). hook-delete-policy is BeforeHookCreation ONLY
+# (not HookSucceeded) so it survives the whole PreSync phase for the Job to
+# read; it is replaced at the next sync. When migrations.useExistingSecret=true
+# this Secret is NOT minted and the Job reads POSTGRES_PASSWORD from the
+# operator-provided existing Secret (migrations.existingSecretName).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-slc-migrations.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-slc-migrations.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-2"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ .Values.migrations.postgres.password | default .Values.secrets.data.POSTGRES_PASSWORD | quote }}
+{{- end }}

--- a/charts/br-slc/templates/mock-nuclea/deployment.yaml
+++ b/charts/br-slc/templates/mock-nuclea/deployment.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.mockNuclea.enabled }}
+{{- /*
+Núclea clearing-house SIMULATOR — DEV/HML FIXTURE ONLY, never enable in
+production/BYOC. Standalone Deployment (own image ghcr.io/lerianstudio/
+br-slc-mock-nuclea, published by the br-slc release pipeline). Safe-by-default
+OFF (mockNuclea.enabled=false): like the detached migrations image, a gated
+component that defaults ON with an image the registry doesn't have yet would
+ImagePullBackOff and block the whole ArgoCD sync. The app reaches it over
+cluster DNS (Service br-slc-mock-nuclea:port); wire MOCK_NUCLEA_URL /
+NUCLEA_REST_BASE_URL / RSFN_CONSUMER_BASE_URL in the dev/hml gitops overlay.
+*/}}
+{{- $pullSecrets := .Values.mockNuclea.imagePullSecrets | default .Values.imagePullSecrets }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "br-slc-mock-nuclea.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-slc-mock-nuclea.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "br-slc-mock-nuclea.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-slc-mock-nuclea.labels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mock-nuclea
+          image: {{ include "br-slc.mockNucleaImage" . | quote }}
+          imagePullPolicy: {{ .Values.mockNuclea.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.mockNuclea.service.targetPort }}
+              protocol: TCP
+          env:
+            - name: MOCK_NUCLEA_ADDR
+              value: {{ printf ":%d" (int .Values.mockNuclea.service.targetPort) | quote }}
+            {{- /* GOMAXPROCS from the container CFS cpu limit — same
+            downward-API fix as the app/signer/validator/mqbridge containers
+            (Gate 8 FIX 7). Guarded with `with`+`if .cpu` so a nil-limit
+            override renders. */}}
+            {{- with .Values.mockNuclea.resources.limits }}
+            {{- if .cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            {{- end }}
+          livenessProbe:
+            {{- include "br-slc.httpProbe" .Values.mockNuclea.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- include "br-slc.httpProbe" .Values.mockNuclea.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.mockNuclea.resources | nindent 12 }}
+          securityContext:
+            {{- include "br-slc.containerSecurityContext" .Values.mockNuclea.securityContext | nindent 12 }}
+{{- end }}

--- a/charts/br-slc/templates/mock-nuclea/service.yaml
+++ b/charts/br-slc/templates/mock-nuclea/service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.mockNuclea.enabled }}
+{{- /*
+ClusterIP Service for the mock-nuclea standalone Deployment. DEV/HML FIXTURE
+ONLY (never enabled in production/BYOC). Distinct selector from the app's own
+Service (br-slc-mock-nuclea.selectorLabels vs br-slc.selectorLabels) so the two
+never cross-route. The app reaches this Service over cluster DNS at
+br-slc-mock-nuclea:<service.port> — the actual MOCK_NUCLEA_URL /
+NUCLEA_REST_BASE_URL / RSFN_CONSUMER_BASE_URL wiring happens in the dev/hml
+gitops overlay, not in this chart's base values.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "br-slc-mock-nuclea.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-slc-mock-nuclea.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mockNuclea.service.type }}
+  selector:
+    {{- include "br-slc-mock-nuclea.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.mockNuclea.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/br-slc/templates/mqbridge-configmap.yaml
+++ b/charts/br-slc/templates/mqbridge-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.mqbridge.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-slc.fullname" . }}-mqbridge
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.mqbridge.configmap.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/br-slc/templates/mqbridge-secret.yaml
+++ b/charts/br-slc/templates/mqbridge-secret.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Mqbridge-scoped Secret (Decisão 21): MQ credential material for the same-pod
+mqbridge container. Only rendered when this chart owns it AND the bridge is
+enabled (mqbridge.enabled=true AND mqbridge.secrets.create=true). The BYOC
+default (mqbridge.secrets.create=false) references an externally managed Secret
+via mqbridge.secrets.existingSecretName instead — see br-slc.mqbridgeSecretName
+in _helpers.tpl. Never bake real values into values.yaml; supply them via
+--set-string/-f at install time when create=true.
+*/ -}}
+{{- if .Values.mqbridge.enabled }}
+{{- if .Values.mqbridge.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-slc.mqbridgeSecretName" . }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.mqbridge.secrets.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/br-slc/templates/secrets.yaml
+++ b/charts/br-slc/templates/secrets.yaml
@@ -1,0 +1,20 @@
+{{- /*
+Only rendered when this chart owns the Secret (secrets.create=true). The BYOC
+default (secrets.create=false) references an externally managed Secret via
+secrets.existingSecretName instead — see br-slc.secretName in _helpers.tpl and
+README.md "Secrets" section. Never bake real values into values.yaml; supply
+them via --set-string/-f at install time when create=true.
+*/ -}}
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-slc.secretName" . }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secrets.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/br-slc/templates/service.yaml
+++ b/charts/br-slc/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- /* ClusterIP-only Service — no NodePort/LoadBalancer, no Ingress (BYOC scope). */ -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "br-slc.fullname" . }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "br-slc.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/br-slc/templates/serviceaccount.yaml
+++ b/charts/br-slc/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "br-slc.serviceAccountName" . }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/br-slc/templates/signer-configmap.yaml
+++ b/charts/br-slc/templates/signer-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-slc.fullname" . }}-signer
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+data:
+  SIGNER_PKCS11_TOKEN_LABEL: {{ .Values.signer.pkcs11TokenLabel | quote }}
+  {{- range $key, $value := .Values.signer.configmap.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/br-slc/templates/signer-secret.yaml
+++ b/charts/br-slc/templates/signer-secret.yaml
@@ -1,0 +1,22 @@
+{{- /*
+Signer-scoped Secret (ADR-9 custody): signing-key material readable ONLY by
+the signer container, never the app container. Only rendered when this chart
+owns it (signer.secrets.create=true). The BYOC default
+(signer.secrets.create=false) references an externally managed Secret via
+signer.secrets.existingSecretName instead — see br-slc.signerSecretName in
+_helpers.tpl. Never bake real values into values.yaml; supply them via
+--set-string/-f at install time when create=true.
+*/ -}}
+{{- if .Values.signer.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-slc.signerSecretName" . }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.signer.secrets.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/br-slc/templates/validator-configmap.yaml
+++ b/charts/br-slc/templates/validator-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-slc.fullname" . }}-validator
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.xsdValidator.configmap.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/br-slc/values-template.yaml
+++ b/charts/br-slc/values-template.yaml
@@ -21,6 +21,9 @@ secrets:
     REDIS_PASSWORD: ""           # REQUIRED when the external Redis needs auth
     WEBHOOK_API_KEY: ""
     WEBHOOK_HMAC_SECRET: ""
+    RABBITMQ_DEFAULT_PASS: ""    # inert while RABBITMQ_ENABLED=false
+    AWS_SECRET_ACCESS_KEY: ""    # keep empty — prefer IRSA
+    AWS_SESSION_TOKEN: ""        # keep empty — prefer IRSA
 
 configmap:
   data:

--- a/charts/br-slc/values-template.yaml
+++ b/charts/br-slc/values-template.yaml
@@ -1,0 +1,52 @@
+# Template values for the br-slc (Sistema de Liquidação Centralizada) chart.
+# Copy this file, fill in the values for your environment, and install with -f.
+# Postgres, Redis and (optionally) RabbitMQ are EXTERNAL, client-managed
+# dependencies in BYOC — this chart does not deploy them. See README.md for the
+# full env-var coverage and the Chart Contract.
+
+imagePullSecrets:
+  - name: ghcr-credential
+
+image:
+  tag: ""  # optional — defaults to Chart.appVersion
+
+# App container Secret. create: true mints the Secret from the values below;
+# create: false (recommended for BYOC) references an operator-managed Secret via
+# existingSecretName that must expose these same keys.
+secrets:
+  create: false
+  existingSecretName: "br-slc-secrets"
+  data:
+    POSTGRES_PASSWORD: ""        # REQUIRED — external Postgres password
+    REDIS_PASSWORD: ""           # REQUIRED when the external Redis needs auth
+    WEBHOOK_API_KEY: ""
+    WEBHOOK_HMAC_SECRET: ""
+
+configmap:
+  data:
+    POSTGRES_HOST: ""            # REQUIRED — external Postgres host
+    REDIS_HOST: ""               # REQUIRED — external Redis host:port
+    PLUGIN_AUTH_HOST: ""         # REQUIRED — Access Manager URL (fails closed at boot if empty while auth enabled)
+    CORS_ALLOWED_ORIGINS: ""     # REQUIRED before go-live — real client origin(s)
+
+# Signer container Secret (ADR-9 custody: readable ONLY by the slc-signer
+# container). Same create/existingSecretName pattern.
+signer:
+  secrets:
+    create: false
+    existingSecretName: "br-slc-signer-secrets"
+    data:
+      SIGNER_SOFTKEY_PFX_PASSPHRASE: ""  # decrypts the softkey PFX (softkey custody path)
+
+# Conditional inbound IBM MQ / RSFN consumer (Decisão 21). Enable only for the
+# IF Domicílio role with RSFN_CONSUMER_TRANSPORT=mq; forces replicaCount=1 and an
+# amd64 node pin. Leave disabled otherwise.
+mqbridge:
+  enabled: false
+
+# Detached migrations. The PreSync Job runs the dedicated br-slc-migrations image.
+migrations:
+  enabled: true
+  postgres:
+    host: ""                     # defaults to configmap.data.POSTGRES_HOST
+    password: ""                 # defaults to secrets.data.POSTGRES_PASSWORD

--- a/charts/br-slc/values.schema.json
+++ b/charts/br-slc/values.schema.json
@@ -1,0 +1,463 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "br-slc",
+  "type": "object",
+  "required": [
+    "image",
+    "service",
+    "securityContext",
+    "resources",
+    "livenessProbe",
+    "readinessProbe",
+    "secrets",
+    "configmap",
+    "signer",
+    "xsdValidator",
+    "mqbridge",
+    "migrations"
+  ],
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 0 },
+    "revisionHistoryLimit": { "type": "integer", "minimum": 0 },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+    "image": {
+      "type": "object",
+      "required": ["repository", "pullPolicy"],
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "required": ["create"],
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "service": {
+      "type": "object",
+      "required": ["type", "port", "targetPort"],
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "required": [
+        "runAsNonRoot",
+        "runAsUser",
+        "runAsGroup",
+        "allowPrivilegeEscalation",
+        "readOnlyRootFilesystem",
+        "capabilities",
+        "seccompProfile"
+      ],
+      "properties": {
+        "runAsNonRoot": { "type": "boolean", "const": true },
+        "runAsUser": { "type": "integer" },
+        "runAsGroup": { "type": "integer" },
+        "allowPrivilegeEscalation": { "type": "boolean", "const": false },
+        "readOnlyRootFilesystem": { "type": "boolean", "const": true },
+        "capabilities": {
+          "type": "object",
+          "required": ["drop"],
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": { "type": "string" },
+              "contains": { "const": "ALL" }
+            }
+          }
+        },
+        "seccompProfile": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "type": "string" }
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": { "type": "object" },
+        "requests": { "type": "object" }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "required": ["path", "port"],
+          "properties": {
+            "path": { "type": "string" },
+            "port": { "type": ["string", "integer"] }
+          }
+        },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "required": ["path", "port"],
+          "properties": {
+            "path": { "type": "string" },
+            "port": { "type": ["string", "integer"] }
+          }
+        },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "secrets": {
+      "type": "object",
+      "required": ["create", "data"],
+      "if": { "properties": { "create": { "const": false } } },
+      "then": { "required": ["existingSecretName"], "properties": { "existingSecretName": { "minLength": 1 } } },
+      "properties": {
+        "create": { "type": "boolean" },
+        "existingSecretName": { "type": "string" },
+        "data": {
+          "type": "object",
+          "required": [
+            "POSTGRES_PASSWORD",
+            "REDIS_PASSWORD",
+            "WEBHOOK_API_KEY",
+            "WEBHOOK_HMAC_SECRET",
+            "RABBITMQ_DEFAULT_PASS",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN"
+          ],
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "configmap": {
+      "type": "object",
+      "required": ["data"],
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "signer": {
+      "type": "object",
+      "required": ["image", "resources", "securityContext", "livenessProbe", "readinessProbe", "softkeySecret", "secrets", "configmap"],
+      "properties": {
+        "image": {
+          "type": "object",
+          "required": ["repository", "pullPolicy"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": { "type": "object" },
+            "requests": { "type": "object" }
+          }
+        },
+        "securityContext": {
+          "type": "object",
+          "required": ["runAsNonRoot", "allowPrivilegeEscalation", "readOnlyRootFilesystem", "capabilities", "seccompProfile"],
+          "properties": {
+            "runAsNonRoot": { "type": "boolean", "const": true },
+            "runAsUser": { "type": "integer" },
+            "runAsGroup": { "type": "integer" },
+            "allowPrivilegeEscalation": { "type": "boolean", "const": false },
+            "readOnlyRootFilesystem": { "type": "boolean", "const": true },
+            "capabilities": {
+              "type": "object",
+              "required": ["drop"],
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "contains": { "const": "ALL" }
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "required": ["type"],
+              "properties": { "type": { "type": "string" } }
+            }
+          }
+        },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "softkeySecret": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "secretName": { "type": "string" },
+            "secretKey": { "type": "string" },
+            "mountPath": { "type": "string" }
+          }
+        },
+        "secrets": {
+          "type": "object",
+          "required": ["create", "data"],
+          "if": { "properties": { "create": { "const": false } } },
+          "then": { "required": ["existingSecretName"], "properties": { "existingSecretName": { "minLength": 1 } } },
+          "properties": {
+            "create": { "type": "boolean" },
+            "existingSecretName": { "type": "string" },
+            "data": {
+              "type": "object",
+              "required": [
+                "SIGNER_SOFTKEY_PFX_PASSPHRASE",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+                "SIGNER_VAULT_TOKEN",
+                "SIGNER_PKCS11_PIN"
+              ],
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "configmap": {
+          "type": "object",
+          "required": ["data"],
+          "properties": {
+            "data": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "xsdValidator": {
+      "type": "object",
+      "required": ["image", "resources", "securityContext", "livenessProbe", "readinessProbe", "configmap"],
+      "properties": {
+        "image": {
+          "type": "object",
+          "required": ["repository", "pullPolicy"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": { "type": "object" },
+            "requests": { "type": "object" }
+          }
+        },
+        "securityContext": {
+          "type": "object",
+          "required": ["runAsNonRoot", "allowPrivilegeEscalation", "readOnlyRootFilesystem", "capabilities", "seccompProfile"],
+          "properties": {
+            "runAsNonRoot": { "type": "boolean", "const": true },
+            "runAsUser": { "type": "integer" },
+            "runAsGroup": { "type": "integer" },
+            "allowPrivilegeEscalation": { "type": "boolean", "const": false },
+            "readOnlyRootFilesystem": { "type": "boolean", "const": true },
+            "capabilities": {
+              "type": "object",
+              "required": ["drop"],
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "contains": { "const": "ALL" }
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "required": ["type"],
+              "properties": { "type": { "type": "string" } }
+            }
+          }
+        },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "configmap": {
+          "type": "object",
+          "required": ["data"],
+          "properties": {
+            "data": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "mqbridge": {
+      "type": "object",
+      "required": ["enabled", "image", "resources", "securityContext", "livenessProbe", "keystoreSecret", "secrets", "configmap"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "required": ["repository", "pullPolicy"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": { "type": "object" },
+            "requests": { "type": "object" }
+          }
+        },
+        "securityContext": {
+          "type": "object",
+          "required": ["runAsNonRoot", "allowPrivilegeEscalation", "capabilities", "seccompProfile"],
+          "properties": {
+            "runAsNonRoot": { "type": "boolean", "const": true },
+            "runAsUser": { "type": "integer" },
+            "runAsGroup": { "type": "integer" },
+            "allowPrivilegeEscalation": { "type": "boolean", "const": false },
+            "capabilities": {
+              "type": "object",
+              "required": ["drop"],
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "contains": { "const": "ALL" }
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "required": ["type"],
+              "properties": { "type": { "type": "string" } }
+            }
+          }
+        },
+        "livenessProbe": { "type": "object" },
+        "keystoreSecret": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "secretName": { "type": "string" },
+            "mountPath": { "type": "string" },
+            "stem": { "type": "string" }
+          }
+        },
+        "secrets": {
+          "type": "object",
+          "required": ["create", "data"],
+          "if": { "properties": { "create": { "const": false } } },
+          "then": { "required": ["existingSecretName"], "properties": { "existingSecretName": { "minLength": 1 } } },
+          "properties": {
+            "create": { "type": "boolean" },
+            "existingSecretName": { "type": "string" },
+            "data": {
+              "type": "object",
+              "required": ["MQ_BRIDGE_MQ_PASSWORD"],
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "configmap": {
+          "type": "object",
+          "required": ["data"],
+          "properties": {
+            "data": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "migrations": {
+      "type": "object",
+      "required": ["enabled", "image"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "backoffLimit": { "type": "integer", "minimum": 0 },
+        "activeDeadlineSeconds": { "type": "integer", "minimum": 1 },
+        "ttlSecondsAfterFinished": { "type": "integer", "minimum": 0 },
+        "useExistingSecret": { "type": "boolean" },
+        "existingSecretName": { "type": "string" },
+        "postgres": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "string" },
+            "user": { "type": "string" },
+            "database": { "type": "string" },
+            "sslMode": { "type": "string" },
+            "password": { "type": "string" }
+          }
+        },
+        "image": {
+          "type": "object",
+          "required": ["repository"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": { "type": "object" },
+            "requests": { "type": "object" }
+          }
+        },
+        "waitForPostgres": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/br-slc/values.schema.json
+++ b/charts/br-slc/values.schema.json
@@ -88,7 +88,7 @@
           "type": "object",
           "required": ["type"],
           "properties": {
-            "type": { "type": "string" }
+            "type": { "type": "string", "const": "RuntimeDefault" }
           }
         }
       }
@@ -212,7 +212,7 @@
             "seccompProfile": {
               "type": "object",
               "required": ["type"],
-              "properties": { "type": { "type": "string" } }
+              "properties": { "type": { "type": "string", "const": "RuntimeDefault" } }
             }
           }
         },
@@ -304,7 +304,7 @@
             "seccompProfile": {
               "type": "object",
               "required": ["type"],
-              "properties": { "type": { "type": "string" } }
+              "properties": { "type": { "type": "string", "const": "RuntimeDefault" } }
             }
           }
         },
@@ -365,7 +365,7 @@
             "seccompProfile": {
               "type": "object",
               "required": ["type"],
-              "properties": { "type": { "type": "string" } }
+              "properties": { "type": { "type": "string", "const": "RuntimeDefault" } }
             }
           }
         },
@@ -410,6 +410,8 @@
     "migrations": {
       "type": "object",
       "required": ["enabled", "image"],
+      "if": { "properties": { "useExistingSecret": { "const": true } }, "required": ["useExistingSecret"] },
+      "then": { "required": ["existingSecretName"], "properties": { "existingSecretName": { "minLength": 1 } } },
       "properties": {
         "enabled": { "type": "boolean" },
         "backoffLimit": { "type": "integer", "minimum": 0 },

--- a/charts/br-slc/values.schema.json
+++ b/charts/br-slc/values.schema.json
@@ -14,7 +14,8 @@
     "signer",
     "xsdValidator",
     "mqbridge",
-    "migrations"
+    "migrations",
+    "mockNuclea"
   ],
   "properties": {
     "replicaCount": { "type": "integer", "minimum": 0 },
@@ -459,6 +460,71 @@
             }
           }
         }
+      }
+    },
+    "mockNuclea": {
+      "type": "object",
+      "required": ["enabled", "image", "service", "resources", "securityContext", "livenessProbe", "readinessProbe"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "required": ["repository", "pullPolicy"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "service": {
+          "type": "object",
+          "required": ["type", "port", "targetPort"],
+          "properties": {
+            "type": { "type": "string", "enum": ["ClusterIP"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": { "type": "object" },
+            "requests": { "type": "object" }
+          }
+        },
+        "securityContext": {
+          "type": "object",
+          "required": ["runAsNonRoot", "allowPrivilegeEscalation", "readOnlyRootFilesystem", "capabilities", "seccompProfile"],
+          "properties": {
+            "runAsNonRoot": { "type": "boolean", "const": true },
+            "runAsUser": { "type": "integer" },
+            "runAsGroup": { "type": "integer" },
+            "allowPrivilegeEscalation": { "type": "boolean", "const": false },
+            "readOnlyRootFilesystem": { "type": "boolean", "const": true },
+            "capabilities": {
+              "type": "object",
+              "required": ["drop"],
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "contains": { "const": "ALL" }
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "required": ["type"],
+              "properties": { "type": { "type": "string", "const": "RuntimeDefault" } }
+            }
+          }
+        },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" }
       }
     }
   }

--- a/charts/br-slc/values.yaml
+++ b/charts/br-slc/values.yaml
@@ -860,3 +860,74 @@ migrations:
     image:
       repository: busybox
       tag: "1.37"
+
+# ---------------------------------------------------------------------------
+# mock-nuclea — Núclea clearing-house SIMULATOR. DEV/HML FIXTURE ONLY — NEVER
+# ENABLE IN PRODUCTION/BYOC. A separate, standalone Deployment+Service (NOT a
+# same-pod sidecar like signer/xsdValidator/mqbridge above): the app reaches it
+# over cluster DNS (Service br-slc-mock-nuclea:9190), not localhost. Wiring the
+# consumer side (MOCK_NUCLEA_URL / NUCLEA_REST_BASE_URL /
+# RSFN_CONSUMER_BASE_URL) happens in the dev/hml gitops overlay, not here.
+#
+# enabled: false by default — same precedent as the detached migrations
+# component above: a gated component that defaults ON with an image the
+# registry doesn't have yet (its own ghcr.io/lerianstudio/br-slc-mock-nuclea,
+# published by a separate br-slc release-pipeline workstream) would
+# ImagePullBackOff and block the whole ArgoCD sync. Flip on only in dev/hml
+# overlays once that image is published.
+mockNuclea:
+  enabled: false
+  image:
+    repository: ghcr.io/lerianstudio/br-slc-mock-nuclea
+    # Empty defaults to .Chart.AppVersion (see br-slc.mockNucleaImage in
+    # _helpers.tpl). ASSUMPTION: reconcile the real published tag once the
+    # release-pipeline workstream lands.
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  # ClusterIP only (BYOC/Lerian convention) — no NodePort/LoadBalancer/Ingress.
+  service:
+    type: ClusterIP
+    port: 9190
+    targetPort: 9190
+  # Distroless static nonroot binary (USER 65532) that writes nothing to disk,
+  # so readOnlyRootFilesystem is safe with no /tmp emptyDir needed (unlike the
+  # app/signer/validator containers above).
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # Lightweight fixture — small resource footprint.
+  resources:
+    limits:
+      cpu: 200m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  # The mock exposes ONLY GET /health — no /readyz. Used for BOTH liveness and
+  # readiness (unlike the app container, which splits process-viability
+  # liveness from dependency-aware readiness).
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3

--- a/charts/br-slc/values.yaml
+++ b/charts/br-slc/values.yaml
@@ -1,0 +1,854 @@
+# br-slc Helm values — BYOC single-tenant BASE.
+#
+# This is the hardened, safe-by-default base. Per-environment overrides (dev/hml
+# relaxations, SaaS-only knobs) live in the beleriand gitops overlays (Task
+# 6.0.6) — do NOT add values-<env>.yaml files to this chart.
+#
+# Scope: single tenant, ClusterIP-only Service, no Ingress. Postgres/Redis/
+# RabbitMQ are EXTERNAL, client-managed dependencies in BYOC (this chart does
+# NOT deploy them) — set configmap.data.POSTGRES_HOST / REDIS_HOST (and the
+# RabbitMQ host, if RABBITMQ_ENABLED=true) to your real endpoints before
+# deploying. See README.md for the full env var coverage table.
+
+replicaCount: 1
+revisionHistoryLimit: 5
+
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+# Non-secret app config emitted into the app ConfigMap but kept OUT of
+# configmap.data because their env-var names contain the substring "_token_"
+# (a PKCS11 token label and a token-cache TTL — neither is a credential),
+# which the Lerian helm-chart-standard secret-key heuristic would otherwise
+# flag. The ConfigMap template wires them under their real env-var names.
+webhookNotificationsCacheTtlSec: "60"
+# WEBHOOK_HMAC_SECRET_FILE — optional mounted-Secret file PATH (not a secret
+# value). Kept out of configmap.data because its name contains "secret". Empty
+# by default; set it together with extraVolumes/extraVolumeMounts if you prefer
+# the mounted-volume rotation pattern over the inline WEBHOOK_HMAC_SECRET var.
+webhookHmacSecretFile: ""
+
+image:
+  repository: ghcr.io/lerianstudio/br-slc
+  # Empty defaults to .Chart.AppVersion. ASSUMPTION: reconcile the real
+  # published repository/tag with Task 6.0.3 (sidecar + app CI image publish).
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  name: ""
+  # Templatable for IRSA (EKS) / Workload Identity (GKE) / KMS access.
+  # Example (EKS IRSA, so the app can use AWS_REGION + attached role instead of
+  # AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN — those stay empty in production):
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<role-name>
+  annotations: {}
+  # Gate 8 FIX 3: this workload never talks to the Kubernetes API, so the
+  # projected SA token is pure unused attack surface if the pod is ever
+  # compromised. Override to true only if you attach a controller/sidecar that
+  # genuinely needs the K8s API (e.g. IRSA's own token projection is separate
+  # from this and unaffected by disabling automount here).
+  automountServiceAccountToken: false
+
+podAnnotations: {}
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 4111
+  targetPort: 4111
+
+# Mirrors deployments/helm/slc-signer's hardened posture exactly (Decision 9
+# sidecar precedent): non-root, no privilege escalation, read-only root fs, all
+# capabilities dropped, RuntimeDefault seccomp. /tmp is writable via emptyDir
+# (see deployment.yaml) since readOnlyRootFilesystem is true.
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+resources:
+  limits:
+    cpu: "1"
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+# Liveness: process viability only (no dependency checks) — /health.
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# Readiness: dependency-aware — /readyz. More lenient than liveness: the app
+# has a `draining` state during graceful shutdown (readyz flips 503 first, so
+# it must not be so aggressive that it flaps during normal dependency hiccups).
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+# terminationGracePeriodSeconds must stay comfortably above any
+# STREAMING_CLOSE_TIMEOUT_S / outbox drain the app performs on SIGTERM during
+# the readyz `draining` window.
+terminationGracePeriodSeconds: 30
+
+# Extra volumes/mounts for chart consumers who need to attach e.g. a custom CA
+# bundle or a mounted Secret for WEBHOOK_API_KEY_FILE/WEBHOOK_HMAC_SECRET_FILE.
+extraVolumes: []
+extraVolumeMounts: []
+
+# ---------------------------------------------------------------------------
+# Secrets (the app container's 7 secret-bearing vars — NEVER real values here).
+# ---------------------------------------------------------------------------
+# NOTE (ADR-12 same-pod consolidation): SIGNER_SOFTKEY_PFX_PASSPHRASE is NOT
+# here — it is signing-key material and lives ONLY in the signer container's
+# own Secret (signer.secrets.data below), never readable by this app
+# container (ADR-9 custody boundary).
+# create: false (default) — recommended for BYOC: the client manages this
+#   Secret out-of-band (their own K8s Secret, External Secrets Operator, Vault
+#   injector, etc.) and existingSecretName points at it. The Secret MUST expose
+#   these SAME 5 keys (override the chart's data keys to match if your Secret
+#   uses different names — see README).
+# create: true — this chart creates the Secret from secrets.data via
+#   --set-string/-f overrides at install time (still never commit real values
+#   to this file).
+secrets:
+  create: false
+  # Non-empty by default (schema requires it when create=false): the BYOC
+  # operator creates a Secret with THIS name exposing the 5 keys below. When
+  # create=true the chart names its own Secret with this value instead.
+  existingSecretName: "br-slc-secrets"
+  data:
+    POSTGRES_PASSWORD: ""
+    REDIS_PASSWORD: ""
+    WEBHOOK_API_KEY: ""
+    WEBHOOK_HMAC_SECRET: ""
+    # Moved out of the ConfigMap (Task 6.0.2 reconciliation): these three are
+    # credential material per Lerian's values.md ConfigMap-vs-Secrets
+    # classification and must not live in a ConfigMap. Empty by default —
+    # RABBITMQ_ENABLED is false in this base, so RABBITMQ_DEFAULT_PASS is
+    # inert until an overlay enables RabbitMQ for real; the two AWS_* vars
+    # stay empty in production per the "AWS credentials" note below (prefer
+    # IRSA via serviceAccount.annotations instead).
+    RABBITMQ_DEFAULT_PASS: ""
+    AWS_SECRET_ACCESS_KEY: ""
+    AWS_SESSION_TOKEN: ""
+
+# ---------------------------------------------------------------------------
+# ConfigMap — ALL non-secret env vars.
+# ---------------------------------------------------------------------------
+# 1:1 with config/.env.example's active surface (156 vars) minus the 5 secret
+# vars above, PLUS two vars this hardened base's own defaults require that are
+# NOT in .env.example's active section:
+#   - DEPLOYMENT_MODE: read by config_validation.go / systemplane.go / readyz
+#     TLS enforcement but only present in .env.example as documentation (no
+#     active line) — defaults to "byoc" here (see internal/bootstrap/config.go
+#     SigningConfig.DeploymentMode).
+#   - PLUGIN_AUTH_HOST: .env.example only has it commented out
+#     (# PLUGIN_AUTH_HOST=http://localhost:4000) because PLUGIN_AUTH_ENABLED
+#     defaults to false there. This base flips PLUGIN_AUTH_ENABLED to true
+#     (real auth in BYOC), and config_validation.go's validateAuthConfig FAILS
+#     BOOT when PLUGIN_AUTH_ENABLED=true and PLUGIN_AUTH_HOST is empty — so it
+#     MUST be set. Left empty by design: this chart will fail closed at boot
+#     until the operator/overlay sets the real Access Manager URL. See README.
+#
+# See README.md "Env Var Coverage" for the full 156/156 mapping table.
+configmap:
+  data:
+    # --- Application Settings ---
+    ENV_NAME: "production"
+    LOG_LEVEL: "info"
+    SERVER_ADDRESS: ":4111"
+    HTTP_BODY_LIMIT_BYTES: "104857600"
+    DEPLOYMENT_MODE: "byoc"
+
+    # --- CORS --- MUST override CORS_ALLOWED_ORIGINS with the real client
+    # origin(s) before go-live; empty is a safe deny-all default (harmless
+    # combined with ALLOW_CORS_WILDCARD=false below).
+    CORS_ALLOWED_ORIGINS: ""
+    CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+    CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID"
+    CORS_EXPOSE_HEADERS: ""
+    CORS_ALLOW_CREDENTIALS: "false"
+
+    # --- TLS / hardening bypass flags ---
+    # ASSUMPTION: TLS_TERMINATED_UPSTREAM depends on the client's real BYOC
+    # network topology (mesh mTLS vs. an in-front proxy/LB terminating TLS);
+    # this chart has no Ingress, so it is left false here — flip per
+    # environment in the beleriand overlay once the topology is confirmed.
+    TLS_TERMINATED_UPSTREAM: "false"
+    # These three MUST stay false in production (config_validation.go rejects
+    # boot when ENV_NAME=production and ALLOW_CORS_WILDCARD or
+    # ALLOW_RATELIMIT_FAIL_OPEN is true; ALLOW_INSECURE_TLS is the sovereign
+    # data-store TLS switch and is kept false here as the safe default too).
+    ALLOW_INSECURE_TLS: "false"
+    ALLOW_CORS_WILDCARD: "false"
+    ALLOW_RATELIMIT_FAIL_OPEN: "false"
+
+    # --- Multi-Tenant Starter (tenant-manager) --- single-tenant BYOC: off.
+    MULTI_TENANT_ENABLED: "false"
+    MULTI_TENANT_REDIS_PORT: "6379"
+    MULTI_TENANT_REDIS_TLS: "false"
+    MULTI_TENANT_MAX_TENANT_POOLS: "100"
+    MULTI_TENANT_IDLE_TIMEOUT_SEC: "300"
+    MULTI_TENANT_TIMEOUT: "30"
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
+    MULTI_TENANT_CACHE_TTL_SEC: "120"
+    MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: "30"
+
+    # --- PostgreSQL Primary Database --- EXTERNAL/client-managed in BYOC.
+    # ASSUMPTION: POSTGRES_HOST is left empty — MUST be overridden with the
+    # real Postgres endpoint before deploy (this chart does not ship a
+    # postgresql subchart dependency per Task 6.0.1 scope).
+    POSTGRES_HOST: ""
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: "br-slc"
+    POSTGRES_NAME: "br-slc"
+    # Hardened DEVIATION from .env.example's dev default (disable):
+    # config_validation.go's validateProductionConfig REJECTS
+    # POSTGRES_SSLMODE=disable when ENV_NAME=production, so the BYOC base
+    # default must not be "disable". "require" verifies encryption without
+    # requiring a client-supplied CA bundle; tighten to verify-full once the
+    # client's Postgres cert chain is known.
+    POSTGRES_SSLMODE: "require"
+    MIGRATIONS_PATH: "migrations"
+    SYSTEMPLANE_ENABLED: "false"
+    TENANT_RUNTIME_CONFIG_ENABLED: "false"
+    POSTGRES_MAX_OPEN_CONNS: "25"
+    POSTGRES_MAX_IDLE_CONNS: "5"
+    POSTGRES_CONN_MAX_LIFETIME_MINS: "30"
+    POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
+    POSTGRES_CONNECT_TIMEOUT_SEC: "10"
+
+    # --- Infrastructure Boot Timeout ---
+    INFRA_CONNECT_TIMEOUT_SEC: "30"
+
+    # --- Redis --- EXTERNAL/client-managed in BYOC (used regardless of
+    # MULTI_TENANT_ENABLED — idempotency/cache). MUST override REDIS_HOST.
+    REDIS_HOST: ""
+    REDIS_DB: "0"
+    REDIS_PROTOCOL: "3"
+    REDIS_POOL_SIZE: "10"
+    REDIS_MIN_IDLE_CONNS: "2"
+    REDIS_READ_TIMEOUT: "3"
+    REDIS_WRITE_TIMEOUT: "3"
+    REDIS_DIAL_TIMEOUT: "5"
+    REDIS_POOL_TIMEOUT: "2"
+    REDIS_MAX_RETRIES: "3"
+    REDIS_MIN_RETRY_BACKOFF: "8"
+    REDIS_MAX_RETRY_BACKOFF: "1"
+
+    # --- Event-Driven Starter - Circuit Breaker ---
+    CIRCUIT_BREAKER_ENABLED: "false"
+
+    # --- Event-Driven Starter - RabbitMQ --- off by default (readyz-probe-only
+    # dependency, not the main event path — lib-streaming/outbox owns that).
+    # Host/user below are inert while RABBITMQ_ENABLED=false; mirrored from
+    # .env.example rather than blanked because they have no effect disabled.
+    # RABBITMQ_DEFAULT_PASS moved to secrets.data (Task 6.0.2 reconciliation —
+    # it is credential material per Lerian's values.md classification and
+    # must not live in a ConfigMap; empty by default, operator injects if
+    # RabbitMQ is ever enabled for real in an overlay).
+    RABBITMQ_ENABLED: "false"
+    RABBITMQ_HOST: "localhost"
+    RABBITMQ_PORT_AMQP: "5672"
+    RABBITMQ_PORT_HOST: "15672"
+    RABBITMQ_DEFAULT_USER: "guest"
+    RABBITMQ_VHOST: "/"
+    RABBITMQ_REQUIRE_HEALTH_ALLOWED_HOSTS: "false"
+    RABBITMQ_ALLOW_INSECURE_HEALTH_CHECK: "false"
+    RABBITMQ_ALLOW_INSECURE_TLS: "false"
+
+    # --- Event-Driven Starter - Outbox --- REQUIRED true: the operations
+    # context (POST /v1/operations, cancellation) fails closed at boot without
+    # the outbox repository wired.
+    OUTBOX_ENABLED: "true"
+    OUTBOX_TABLE_NAME: "outbox_events"
+    OUTBOX_DISPATCH_INTERVAL_SEC: "2"
+    OUTBOX_BATCH_SIZE: "50"
+    OUTBOX_PUBLISH_MAX_ATTEMPTS: "3"
+    OUTBOX_PUBLISH_BACKOFF_MS: "200"
+    OUTBOX_RETRY_WINDOW_SEC: "300"
+    OUTBOX_MAX_DISPATCH_ATTEMPTS: "10"
+    OUTBOX_PROCESSING_TIMEOUT_SEC: "600"
+    OUTBOX_MAX_FAILED_PER_BATCH: "25"
+    OUTBOX_INCLUDE_TENANT_METRICS: "false"
+    OUTBOX_ALLOW_EMPTY_TENANT: "true"
+
+    # --- Streaming Starter (lib-streaming outbox relay -> Kafka) --- opt-in;
+    # needs STREAMING_BROKERS (not in the active .env.example surface) set via
+    # an overlay before flipping this to true.
+    STREAMING_ENABLED: "false"
+    STREAMING_HEALTH_CHECK_TIMEOUT: "2s"
+
+    # --- Authentication (lib-auth + plugin-auth) --- hardened default: real
+    # auth ON in BYOC. See PLUGIN_AUTH_HOST note above the configmap block —
+    # this chart intentionally fails closed at boot until PLUGIN_AUTH_HOST is
+    # set to the real Access Manager endpoint.
+    PLUGIN_AUTH_ENABLED: "true"
+    PLUGIN_AUTH_HOST: ""
+
+    # --- API Documentation (Swagger) ---
+    SWAGGER_ENABLED: "true"
+    SWAGGER_TITLE: "BrSlc"
+    SWAGGER_VERSION: "1.0.0"
+    SWAGGER_BASE_PATH: "/"
+    SWAGGER_LEFT_DELIM: "{{"
+    SWAGGER_RIGHT_DELIM: "}}"
+
+    # --- OpenTelemetry --- hardened default: telemetry ON in BYOC.
+    # ASSUMPTION: OTEL_EXPORTER_OTLP_ENDPOINT assumes an in-cluster collector
+    # named "otel-collector-lerian" (the -helm-suffix-exception chart per
+    # ring:helm conventions) on the standard OTLP gRPC port; reconcile with the
+    # client's actual collector Service/release name in the beleriand overlay.
+    ENABLE_TELEMETRY: "true"
+    OTEL_LIBRARY_NAME: "br-slc"
+    OTEL_RESOURCE_SERVICE_NAME: "br-slc"
+    OTEL_RESOURCE_SERVICE_VERSION: "1.0.0"
+    OTEL_EXPORTER_OTLP_ENDPOINT: "otel-collector-lerian:4317"
+    OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
+    DB_METRICS_INTERVAL_SEC: "15"
+
+    # --- Rate Limiting ---
+    RATE_LIMIT_ENABLED: "true"
+    RATE_LIMIT_MAX: "500"
+    RATE_LIMIT_WINDOW_SEC: "60"
+    AGGRESSIVE_RATE_LIMIT_MAX: "100"
+    AGGRESSIVE_RATE_LIMIT_WINDOW_SEC: "60"
+    RELAXED_RATE_LIMIT_MAX: "1000"
+    RELAXED_RATE_LIMIT_WINDOW_SEC: "60"
+
+    # --- Idempotency ---
+    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
+
+    # --- AWS Credentials (shared: slc-signer awskms adapter + M2M provider)
+    # --- MUST stay empty in production: use IRSA (serviceAccount.annotations
+    # above) instead of static credentials. AWS_REGION defaults to the SLC
+    # staging KMS region — confirm/override per real deployment.
+    # AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN moved to secrets.data (Task
+    # 6.0.2 reconciliation — credential material per Lerian's values.md
+    # classification). AWS_ACCESS_KEY_ID stays here: it is the non-secret
+    # half of a static credential pair (analogous to *_USER vars); still
+    # empty by default — prefer IRSA over any static AWS credentials.
+    AWS_REGION: "us-east-2"
+    AWS_ACCESS_KEY_ID: ""
+
+    # --- M2M Credentials ---
+    M2M_CREDENTIAL_CACHE_TTL_SEC: "300"
+
+    # --- Pagination ---
+    MAX_PAGINATION_LIMIT: "100"
+    MAX_PAGINATION_MONTH_DATE_RANGE: "3"
+
+    # --- Operations Intake ---
+    INTAKE_BATCH_MAX_LINES: "50000"
+
+    # --- XSD Validator Sidecar (aslc-xsd-validator — Decision 12 / ADR-12) ---
+    # SAME-POD container (ADR-12: "sidecar no mesmo pod, localhost"): the app
+    # reaches the validator over localhost, NOT cluster DNS. 9091 is the
+    # validator's containerPort inside this shared pod. See the top-level
+    # xsdValidator: section for the container's own image/config.
+    XSD_VALIDATOR_URL: "http://localhost:9091"
+    XSD_VALIDATOR_TIMEOUT_SEC: "10"
+    RSFN_INBOUND_XSD_VALIDATION_ENABLED: "true"
+
+    # --- Signing Sidecar (slc-signer — Decision 9 / ADR-12) ---
+    # SAME-POD container: the app reaches the signer over localhost, NOT
+    # cluster DNS. 9101 is the signer's containerPort inside this shared pod.
+    # Custody (ADR-9): the signing key material (softkey PFX + passphrase,
+    # HSM PIN, Vault token) lives ONLY in the signer container — its own
+    # Secret and softkey volume are never mounted on this app container. See
+    # the top-level signer: section.
+    SIGNER_URL: "http://localhost:9101"
+    SIGNER_TIMEOUT_SEC: "10"
+
+    # --- Mock Núclea (local credit-flow simulator) --- DEV/TEST FIXTURE ONLY;
+    # not consumed by the app in this phase. Left empty in BYOC/production.
+    MOCK_NUCLEA_URL: ""
+
+    # --- Núclea REST online-submission transport (E-2.4) --- transport stays
+    # disabled until NUCLEA_REST_BASE_URL (not in the active .env.example
+    # surface) is set via an overlay.
+    NUCLEA_REST_TIMEOUT_SEC: "30"
+    NUCLEA_REST_CB_CONSECUTIVE_FAILURES: "5"
+    NUCLEA_REST_CB_OPEN_TIMEOUT_SEC: "30"
+    NUCLEA_REST_ALLOW_INSECURE_TLS: "false"
+
+    # --- RSFN inbound consumer (IBM MQ external channel, E-3.3) ---
+    RSFN_CONSUMER_TRANSPORT: "stub"
+    RSFN_CONSUMER_TIMEOUT_SEC: "30"
+    RSFN_CONSUMER_CB_CONSECUTIVE_FAILURES: "5"
+    RSFN_CONSUMER_CB_OPEN_TIMEOUT_SEC: "30"
+    RSFN_CONSUMER_ALLOW_INSECURE_TLS: "false"
+
+    # --- MQ Bridge sidecar (mqbridge) --- used only when
+    # RSFN_CONSUMER_TRANSPORT=mq. SAME-POD CONDITIONAL container (ADR-12 +
+    # Decisão 21): default off, rendered only when mqbridge.enabled=true (BYOC
+    # role IF Domicílio). When enabled it co-lives with the monolith in this
+    # pod, so the app reaches it over localhost, NOT cluster DNS — this resolves
+    # the drain/ack affinity risk by construction (same process, localhost). It
+    # keeps a writable /var/mqm rootfs + an amd64 pod pin (libmqm/GSKit); see the
+    # top-level mqbridge: section. Enable it in the same overlay/release that
+    # flips this transport, once a real/HML IBM MQ broker + GSKit keystore are
+    # ready.
+    MQ_BRIDGE_URL: "http://localhost:9121"
+    MQ_BRIDGE_TIMEOUT_SEC: "10"
+    MQ_BRIDGE_MAX_DRAIN: "16"
+
+    # --- Schedule — credit-window dispatch gate + STR grid (E-2.4/E-3.2) ---
+    # v0 window + worker: kept at .env.example's real (non-dev-bypass)
+    # defaults. All the provisional per-driver toggles below default to false
+    # exactly as .env.example ships them (each needs per-tenant Núclea
+    # recipient/custody material from E-4.2 before it is safe to enable — see
+    # config.go doc comments) — this base does not flip any of them on.
+    SCHEDULE_CREDIT_WINDOW_OPEN: "00:30"
+    SCHEDULE_CREDIT_WINDOW_CLOSE: "17:30"
+    SCHEDULE_WORKER_ENABLED: "true"
+    SCHEDULE_WORKER_INTERVAL_SEC: "30"
+    SCHEDULE_CUTOFF_ALERT_LEAD_MIN: "30"
+    SCHEDULE_GRID_GATE_ENABLED: "false"
+    SCHEDULE_HOLIDAYS: ""
+    SCHEDULE_DISPATCH_ENABLED: "false"
+    SCHEDULE_DISPATCH_PAGE_SIZE: "1000"
+    SCHEDULE_RETURN_POLL_ENABLED: "false"
+    SCHEDULE_RELAY_STATUS_ENABLED: "false"
+    SCHEDULE_RSFN_INGEST_ENABLED: "false"
+    SCHEDULE_D1_CONFIRMATION_ENABLED: "false"
+    SCHEDULE_D1_CONFIRMATION_CUTOFF: "19:00"
+    SCHEDULE_SILOC_WINDOWS_ENABLED: "false"
+    SCHEDULE_SILOC_DEPOSIT_CYCLE1_CUTOFF: "07:30"
+    SCHEDULE_SILOC_DEPOSIT_CYCLE2_CUTOFF: "12:50"
+    SCHEDULE_STR_SETTLED_ENABLED: "false"
+
+    # --- Webhook delivery (BYOC `direct` provider — E-3.5) ---
+    # WEBHOOK_API_KEY_FILE/WEBHOOK_HMAC_SECRET_FILE are optional mounted-Secret
+    # file-path variants; left empty here since this chart wires the inline
+    # WEBHOOK_API_KEY/WEBHOOK_HMAC_SECRET vars via secretKeyRef instead (see
+    # secrets.data above). Set extraVolumes/extraVolumeMounts + these two paths
+    # if you prefer the mounted-volume rotation pattern.
+    WEBHOOK_API_KEY_FILE: ""
+    # WEBHOOK_HMAC_SECRET_FILE is set via the top-level webhookHmacSecretFile
+    # value (see the note there).
+    WEBHOOK_DELIVERY_TIMEOUT_SEC: "10"
+    WEBHOOK_WORKER_ENABLED: "false"
+    WEBHOOK_WORKER_INTERVAL_SEC: "30"
+    WEBHOOK_DELIVERY_PROVIDER: "direct"
+    WEBHOOK_NOTIFICATIONS_BASE_URL: ""
+    # WEBHOOK_NOTIFICATIONS_TOKEN_CACHE_TTL_SEC is set via the top-level
+    # webhookNotificationsCacheTtlSec value (see the note there).
+    WEBHOOK_MAX_ATTEMPTS: "6"
+    WEBHOOK_BACKOFF_BASE_SEC: "30"
+    WEBHOOK_CONSUME_BATCH: "100"
+
+# ===========================================================================
+# Same-pod sidecar containers (ADR-12). signer + validator run as ADDITIONAL
+# containers in THIS Deployment's pod (not separate Deployments/Services), so
+# the app talks to them over localhost (see SIGNER_URL/XSD_VALIDATOR_URL). Both
+# are MANDATORY (no enable toggle): the validator is a fail-closed hard
+# dependency for all outbound ASLC, and the signer signs every batch. Shared
+# fate: the pod only reaches Ready when all three containers pass readiness.
+# ===========================================================================
+
+# --- slc-signer container (Decision 9 / ADR-9 crypto+credential boundary) ---
+signer:
+  # SIGNER_PKCS11_TOKEN_LABEL, wired into the signer ConfigMap under its real
+  # env-var name. Kept here (not under signer.configmap.data) because the name
+  # contains "_token_" and would otherwise trip the secret-key heuristic; it is
+  # a pkcs11 token *label*, not a credential. Empty unless a pkcs11 token is set.
+  pkcs11TokenLabel: ""
+  image:
+    repository: ghcr.io/lerianstudio/br-slc-signer
+    # Empty defaults to .Chart.AppVersion (see br-slc.signerImage in
+    # _helpers.tpl). ASSUMPTION: reconcile the published repo/tag with Task
+    # 6.0.3 (sidecar image publish).
+    tag: ""
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: "1"
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  # Per-container hardened posture (identical to the app container): non-root,
+  # no privilege escalation, read-only root fs (its own /tmp emptyDir), all
+  # capabilities dropped, RuntimeDefault seccomp.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # Both probes hit the same /health:9101 (no separate readyz for the signer).
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 9101
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 9101
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  # Softkey PFX bundle (BYOC-first custody adapter). The .pfx/.p12 FILE is
+  # mounted read-only from an externally managed Secret ONTO THE SIGNER
+  # CONTAINER ONLY (never the app container — ADR-9 custody). The passphrase
+  # that decrypts it is the separate signer.secrets.SIGNER_SOFTKEY_PFX_PASSPHRASE.
+  softkeySecret:
+    enabled: false
+    # Existing Secret whose key holds the PFX bytes, e.g.:
+    #   kubectl create secret generic slc-signer-softkey --from-file=signer.pfx=./signer.pfx
+    secretName: ""
+    secretKey: "signer.pfx"
+    mountPath: "/certs"
+  # Signer-scoped Secret — key/credential material readable ONLY by the signer
+  # container (ADR-9). Same create/existingSecretName pattern as the app
+  # Secret; BYOC default is an externally managed Secret.
+  secrets:
+    create: false
+    existingSecretName: "br-slc-signer-secrets"
+    data:
+      # Decrypts the softkey PFX bundle. Required only for the softkey adapter.
+      SIGNER_SOFTKEY_PFX_PASSPHRASE: ""
+      # awskms adapter static credentials (prefer IRSA via serviceAccount
+      # annotations so these stay empty).
+      AWS_SECRET_ACCESS_KEY: ""
+      AWS_SESSION_TOKEN: ""
+      # vault adapter token (only when SIGNER_VAULT_ADDR is set).
+      SIGNER_VAULT_TOKEN: ""
+      # pkcs11 adapter PIN (only when a pkcs11 token is configured).
+      SIGNER_PKCS11_PIN: ""
+  configmap:
+    data:
+      SIGNER_ADDR: ":9101"
+      SIGNER_MAX_BODY_BYTES: "65536"
+      ENV_NAME: "production"
+      # --- softkey adapter (BYOC-first custody path) ---
+      SIGNER_SOFTKEY_PFX_PATH: "/certs/signer.pfx"
+      # DELIBERATE, FLAGGED default: softkey holds the key in process memory,
+      # which config.go treats as alert-worthy in production and REFUSES to
+      # start unless acked. BYOC-first ships softkey day-one; flip back to
+      # "false" once a real awskms/pkcs11/vault adapter is configured.
+      SIGNER_SOFTKEY_ALLOW_IN_PRODUCTION: "true"
+      # --- awskms adapter (parameterizable, disabled by default: no region) ---
+      SIGNER_AWSKMS_REGION: ""
+      SIGNER_AWSKMS_DEFAULT_KEY_REF: ""
+      AWS_ACCESS_KEY_ID: ""
+      AWS_REGION: ""
+      # --- pkcs11 adapter (parameterizable, disabled by default: no token) ---
+      # SIGNER_PKCS11_TOKEN_LABEL is set via signer.pkcs11TokenLabel (kept out of
+      # configmap.data because its name matches the "_token_" secret heuristic).
+      SIGNER_PKCS11_MODULE: "/usr/lib/softhsm/libsofthsm2.so"
+      SIGNER_PKCS11_SLOT: ""
+      SIGNER_PKCS11_KEY_LABEL: ""
+      # --- vault adapter (parameterizable, disabled by default: no address) ---
+      SIGNER_VAULT_ADDR: ""
+      SIGNER_VAULT_TRANSIT_MOUNT: "transit"
+      SIGNER_VAULT_NAMESPACE: ""
+      SIGNER_VAULT_CACERT: ""
+      # --- Auth delegation (Access Manager) --- fails closed until the
+      # operator sets the real PLUGIN_AUTH_HOST (validateAuthConfig).
+      PLUGIN_AUTH_ENABLED: "true"
+      PLUGIN_AUTH_HOST: ""
+      PLUGIN_AUTH_ALLOW_INSECURE_HTTP: "false"
+
+# --- aslc-xsd-validator container (Decision 12) ---
+# Stateless: all XSD schemas are go:embedded in the image. No secrets, no
+# persistent volumes. HARD outbound dependency (fail-closed) — but shared fate
+# in the same pod removes the "app Ready, validator absent" window.
+xsdValidator:
+  image:
+    repository: ghcr.io/lerianstudio/br-slc-xsd-validator
+    tag: ""
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: "500m"
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 9091
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 9091
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  configmap:
+    data:
+      XSD_VALIDATOR_ADDR: ":9091"
+      XSD_MAX_BODY_BYTES: "5242880"
+      ENV_NAME: "production"
+      # --- Auth delegation (Access Manager) --- fails closed until the
+      # operator sets the real PLUGIN_AUTH_HOST (validateAuthConfig).
+      PLUGIN_AUTH_ENABLED: "true"
+      PLUGIN_AUTH_HOST: ""
+      PLUGIN_AUTH_ALLOW_INSECURE_HTTP: "false"
+
+# ===========================================================================
+# --- mqbridge container (Decisão 21 — RSFN IBM MQ inbound consumer) ---
+# CONDITIONAL same-pod container, UNLIKE the mandatory signer/validator above.
+# It owns the inbound IBM MQ/RSFN connection of the cards channel; the mTLS
+# identity is per-process (MQSCO.KeyRepository from env MQSSLKEYR), so 1 process
+# = 1 participant (BYOC single-tenant). The SaaS multi-tenant consumer manager
+# is Fase 7 (separate Deployment) — NOT built here.
+#
+# GATED: rendered ONLY when mqbridge.enabled=true, which a client sets when the
+# role is IF Domicílio with RSFN_CONSUMER_TRANSPORT=mq. Default off — a
+# credenciadora-only tenant never carries the container, and a default
+# `helm template`/`helm install` renders NO mqbridge container/configmap/secret
+# and NO amd64 pod pin. When enabled, the app reaches it over localhost:9121
+# (see configmap.data.MQ_BRIDGE_URL). Enabling it hard-caps the monolith
+# replicaCount to 1 (per-process deliveryRef->conn state; see the guard at the
+# top of templates/deployment.yaml).
+# ===========================================================================
+mqbridge:
+  enabled: false
+  image:
+    # ASSUMPTION (flag for CI reconciliation): repository derived from the
+    # module path github.com/LerianStudio/br-slc-mq-bridge and the
+    # docker-compose service — ghcr.io/lerianstudio/{name} per Lerian Helm
+    # conventions.
+    repository: ghcr.io/lerianstudio/br-slc-mq-bridge
+    # Empty defaults to .Chart.AppVersion (see br-slc.mqbridgeImage in
+    # _helpers.tpl).
+    tag: ""
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 256Mi
+      cpu: "500m"
+    requests:
+      memory: 64Mi
+      cpu: "100m"
+  # Security hardening. UNLIKE the other same-pod containers,
+  # readOnlyRootFilesystem is FALSE here: the IBM MQ C client (libmqm)
+  # conventionally needs a writable location (e.g. /var/mqm) for its own
+  # error/FDC/trace logs, and a read-only rootfs would break it at connect
+  # time. Still non-root, no privilege escalation, all capabilities dropped,
+  # RuntimeDefault seccomp. An explicit emptyDir is mounted at /var/mqm
+  # regardless (see deployment.yaml) so libmqm's writable state never depends
+  # on the base image's own directory permissions.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem is deliberately FALSE for mqbridge (libmqm needs a
+    # writable /var/mqm). It is set on the container in deployment.yaml rather
+    # than here so values.yaml carries no writable-rootfs default. Do NOT add a
+    # readOnlyRootFilesystem key back to this block.
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # Liveness ONLY (process viability, /health). There is deliberately NO
+  # readinessProbe (Decisão 21): mqbridge is same-pod and no Service routes to
+  # :9121, so readiness gates no traffic — but /readyz reflects the IBM MQ pool
+  # state, so using it as readiness would pull the whole pod out of the
+  # monolith's :4111 Service on any MQ blip (total outage under replicaCount=1).
+  # MQ connectivity is surfaced to the monolith via the client-side breaker.
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 9121
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  # GSKit keystore (.kdb + .sth/.rdb) — required only when
+  # MQ_BRIDGE_TLS_ENABLED=true (RSFN mandates mTLS in production). Mounted
+  # read-only ONTO THE MQBRIDGE CONTAINER ONLY from an externally managed
+  # Secret; MQSSLKEYR (configmap.data below) must point at the STEM path (no
+  # file extension), e.g. "/keystore/mqbridge" for files
+  # mqbridge.kdb/mqbridge.sth/mqbridge.rdb.
+  keystoreSecret:
+    enabled: false
+    # Name of an existing Secret whose data keys hold the .kdb/.sth/.rdb bytes,
+    # e.g. created out-of-band as:
+    #   kubectl create secret generic br-slc-mqbridge-keystore \
+    #     --from-file=mqbridge.kdb=./mqbridge.kdb \
+    #     --from-file=mqbridge.sth=./mqbridge.sth \
+    #     --from-file=mqbridge.rdb=./mqbridge.rdb
+    secretName: ""
+    mountPath: "/keystore"
+    # Base filename stem (no extension) inside the Secret/mount; combined with
+    # mountPath this yields the MQSSLKEYR value below by convention.
+    stem: "mqbridge"
+  # Mqbridge-scoped Secret — never real values here. Same create/
+  # existingSecretName pattern as the app/signer Secrets; BYOC default is an
+  # externally managed Secret.
+  # create: false (default) — BYOC recommended: the client manages this Secret
+  #   out-of-band and existingSecretName points at it (must expose the same key
+  #   as secrets.data below).
+  # create: true — this chart creates the Secret from secrets.data via
+  #   --set-string/-f at install time.
+  secrets:
+    create: false
+    existingSecretName: "br-slc-mqbridge-secrets"
+    data:
+      # Optional MQCSP password. RSFN authenticates via the client certificate
+      # in the keystore, so this is normally empty.
+      MQ_BRIDGE_MQ_PASSWORD: ""
+  # ConfigMap — all non-secret env vars. The per-request IBM MQ connection
+  # descriptor (queue manager, channel, conn name, queue) is NOT here — it
+  # arrives per call from the monolith on /v1/drain.
+  configmap:
+    data:
+      MQ_BRIDGE_ADDR: ":9121"
+      MQ_BRIDGE_MAX_INFLIGHT: "16"
+      MQ_BRIDGE_ACK_TIMEOUT_SEC: "60"
+      # Derived (half of ack timeout, clamped [1s,30s]) when left at "0".
+      MQ_BRIDGE_SWEEP_INTERVAL_SEC: "0"
+      MQ_BRIDGE_GET_WAIT_MS: "0"
+      MQ_BRIDGE_RECEIVE_BUFFER_BYTES: "1048576"
+      MQ_BRIDGE_MAX_MESSAGE_BYTES: "16777216"
+      MQ_BRIDGE_MAX_BODY_BYTES: "65536"
+
+      # --- RSFN mTLS (terminates INSIDE this container, not the monolith) ---
+      # DELIBERATE, FLAGGED default: production requires TLS (the bridge rejects
+      # boot when ENV_NAME=production and this is false). Left "false" here
+      # since no broker/keystore exists until mqbridge is actually enabled for a
+      # real/HML deployment — flip to "true" together with keystoreSecret.enabled
+      # and MQSSLKEYR below.
+      MQ_BRIDGE_TLS_ENABLED: "false"
+      # Empty by default; set to the keystore stem path (e.g.
+      # "/keystore/mqbridge") once keystoreSecret.enabled=true.
+      MQSSLKEYR: ""
+      # DOUBT-TLS-CIPHER (CodeRabbit PR #99): TLS_RSA_WITH_AES_256_CBC_SHA256
+      # uses static RSA key exchange + CBC. An ECDHE+GCM CipherSpec (e.g.
+      # ECDHE_RSA_AES_256_GCM_SHA384, or TLS 1.3 TLS_AES_256_GCM_SHA384) is
+      # preferred, BUT the CipherSpec MUST match what Nuclea's RSFN MQ manager
+      # actually accepts — RSFN is a regulated endpoint, not our choice, and
+      # selecting a spec it rejects fails the TLS handshake. Confirm the
+      # supported CipherSpec against the Nuclea RSFN MQ manual at the
+      # homologacao gate; keep this CBC value only as a compatibility fallback.
+      MQ_BRIDGE_TLS_CIPHER: "TLS_RSA_WITH_AES_256_CBC_SHA256"
+
+      # Optional MQCSP username (RSFN normally authenticates via the client
+      # cert in the keystore, so this is normally empty).
+      MQ_BRIDGE_MQ_USER: ""
+
+      # Rejected in production; "false" is the safe default so a non-ibmmq
+      # binary never silently boots against a real deployment.
+      MQ_BRIDGE_ALLOW_STUB: "false"
+
+      ENV_NAME: "production"
+      LOG_LEVEL: "info"
+
+      # --- Auth delegation (Access Manager) --- hardened default: real auth ON.
+      # PLUGIN_AUTH_HOST is intentionally empty: the bridge FAILS BOOT when
+      # PLUGIN_AUTH_ENABLED=true and the host is empty — fails closed until the
+      # operator sets the real Access Manager URL.
+      PLUGIN_AUTH_ENABLED: "true"
+      PLUGIN_AUTH_HOST: ""
+      PLUGIN_AUTH_ALLOW_INSECURE_HTTP: "false"
+
+# ---------------------------------------------------------------------------
+# Migration Job (Task 6.0.4) — applies migrations/*.up.sql (golang-migrate)
+# via a pre-install,pre-upgrade Helm hook, before the Deployment rolls.
+# ---------------------------------------------------------------------------
+migrations:
+  enabled: true
+  backoffLimit: 2
+  activeDeadlineSeconds: 600
+  # Gate 8 FIX 6: bounds accumulation of FAILED hook Jobs/pods. A successful
+  # Job is already removed by hook-delete-policy: HookSucceeded — this TTL only
+  # matters on the failure path, where the Job is deliberately left behind for
+  # post-mortem debugging. 259200s = 3 days.
+  ttlSecondsAfterFinished: 259200
+  image:
+    # Dedicated migrations image (br-spi pattern): its entrypoint applies the
+    # golang-migrate loop over the embedded migrations/*.up.sql against the
+    # single br-slc database. Built + published by the br-slc release pipeline.
+    repository: ghcr.io/lerianstudio/br-slc-migrations
+    # Empty defaults to .Chart.AppVersion.
+    tag: ""
+    pullPolicy: IfNotPresent
+  # PreSync Secret custody. false (default): the chart mints a dedicated PreSync
+  # Secret (br-slc-migrations) carrying only POSTGRES_PASSWORD, sourced from
+  # migrations.postgres.password (falling back to secrets.data.POSTGRES_PASSWORD).
+  # true: the Job reads POSTGRES_PASSWORD from the operator-managed
+  # existingSecretName instead (BYOC out-of-band Secret).
+  useExistingSecret: false
+  existingSecretName: ""
+  # DB connection for the Job. Each field falls back to the app's
+  # configmap.data.POSTGRES_* / secrets.data.POSTGRES_PASSWORD (single source of
+  # truth) when left empty — override only for a migrations-specific endpoint.
+  postgres:
+    host: ""
+    port: ""
+    user: ""
+    database: ""
+    sslMode: ""
+    password: ""
+  resources:
+    limits:
+      cpu: "500m"
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  # A lightweight busybox initContainer waits for POSTGRES_HOST:POSTGRES_PORT to
+  # accept a TCP connection before the migrations container starts (mirrors the
+  # Lerian wait-for-dependencies convention) — avoids a hard Job failure on a
+  # fresh install racing a not-yet-ready Postgres.
+  waitForPostgres:
+    enabled: true
+    image:
+      repository: busybox
+      tag: "1.37"

--- a/charts/br-slc/values.yaml
+++ b/charts/br-slc/values.yaml
@@ -127,7 +127,7 @@ extraVolumeMounts: []
 # create: false (default) — recommended for BYOC: the client manages this
 #   Secret out-of-band (their own K8s Secret, External Secrets Operator, Vault
 #   injector, etc.) and existingSecretName points at it. The Secret MUST expose
-#   these SAME 5 keys (override the chart's data keys to match if your Secret
+#   these SAME 7 keys (override the chart's data keys to match if your Secret
 #   uses different names — see README).
 # create: true — this chart creates the Secret from secrets.data via
 #   --set-string/-f overrides at install time (still never commit real values
@@ -135,7 +135,7 @@ extraVolumeMounts: []
 secrets:
   create: false
   # Non-empty by default (schema requires it when create=false): the BYOC
-  # operator creates a Secret with THIS name exposing the 5 keys below. When
+  # operator creates a Secret with THIS name exposing the 7 keys below. When
   # create=true the chart names its own Secret with this value instead.
   existingSecretName: "br-slc-secrets"
   data:
@@ -157,7 +157,7 @@ secrets:
 # ---------------------------------------------------------------------------
 # ConfigMap — ALL non-secret env vars.
 # ---------------------------------------------------------------------------
-# 1:1 with config/.env.example's active surface (156 vars) minus the 5 secret
+# 1:1 with config/.env.example's active surface (156 vars) minus the 7 secret
 # vars above, PLUS two vars this hardened base's own defaults require that are
 # NOT in .env.example's active section:
 #   - DEPLOYMENT_MODE: read by config_validation.go / systemplane.go / readyz
@@ -526,6 +526,14 @@ signer:
   # mounted read-only from an externally managed Secret ONTO THE SIGNER
   # CONTAINER ONLY (never the app container — ADR-9 custody). The passphrase
   # that decrypts it is the separate signer.secrets.SIGNER_SOFTKEY_PFX_PASSPHRASE.
+  #
+  # REQUIRED before the signer can become Ready: with the softkey adapter
+  # (SIGNER_SOFTKEY_PFX_PATH set below) the operator MUST set enabled=true and
+  # a valid secretName so /certs/signer.pfx is mounted — otherwise the signer
+  # has no key material and the pod never reaches Ready. Left disabled by
+  # default (fail-closed, like POSTGRES_HOST/PLUGIN_AUTH_HOST) because the chart
+  # cannot ship a real Secret name for BYOC key custody; enable it (or switch to
+  # an awskms/pkcs11/vault adapter) at install time.
   softkeySecret:
     enabled: false
     # Existing Secret whose key holds the PFX bytes, e.g.:
@@ -800,7 +808,7 @@ mqbridge:
 
 # ---------------------------------------------------------------------------
 # Migration Job (Task 6.0.4) — applies migrations/*.up.sql (golang-migrate)
-# via a pre-install,pre-upgrade Helm hook, before the Deployment rolls.
+# via an ArgoCD PreSync hook Job, before the Deployment rolls.
 # ---------------------------------------------------------------------------
 migrations:
   enabled: true


### PR DESCRIPTION
Add **br-slc-helm** (single-service) chart for the br-slc monolith (Sistema de Liquidação Centralizada — SLC). One Deployment running on ClusterIP:4111 (no Ingress) with the mandatory same-pod `slc-signer` and `aslc-xsd-validator` sidecars (ADR-12, reached over localhost) and a conditional `mqbridge` sidecar (RSFN IBM MQ inbound, amd64-pinned, `replicaCount=1`, off by default). External, client-managed Postgres/Redis/RabbitMQ (no bundled subcharts). Detached migrations via an ArgoCD PreSync Job + Secret using the dedicated `ghcr.io/lerianstudio/br-slc-migrations` image. Ported from `LerianStudio/br-slc` PR #99 (where the chart is removed) and conformed to the helm-chart-standard; passes `validate-helm-charts --strict` (0 violations) and the render gate. Liveness `/health`, readiness `/readyz`.

# Midaz Pull Request Checklist

## Pull Request Type

- [x] BR SLC

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes
- Registered the chart in `.github/workflows/pr-title.yml`, `.github/configs/labeler.yaml` and the PR template.
- Render fixture at `.github/configs/helm-render-values/br-slc.yaml`.
- Related: service repo chart removal + `br-slc-migrations` image build in `LerianStudio/br-slc` PR #99.
