### PR TITLE
feat(flowker): add optional WORKOS_TM_CLIENT_SECRET secret (v3.0.1)

### DIFF
--- a/charts/flowker/CHANGELOG.md
+++ b/charts/flowker/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.0.1] — Unreleased
+
+### Added
+
+- Optional `WORKOS_TM_CLIENT_SECRET` secret passthrough (the WorkOS M2M
+  client secret for the outbound token flowker mints to call the Tenant
+  Manager). Emitted in the Secret only when set. Non-secret WorkOS/
+  SecretsProvider env vars are delivered via the chart's generic
+  `extraEnvVars` passthrough, not the ConfigMap allowlist.
+
 ## [2.1.0-beta.5] — Unreleased
 
 ### Changed

--- a/charts/flowker/Chart.yaml
+++ b/charts/flowker/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
-version: 3.0.0
+version: 3.0.1
 appVersion: "1.0.0"
 keywords:
   - flowker

--- a/charts/flowker/templates/secrets.yaml
+++ b/charts/flowker/templates/secrets.yaml
@@ -23,6 +23,11 @@ stringData:
   MONGO_TLS_CA_CERT: {{ .Values.flowker.secrets.MONGO_TLS_CA_CERT | quote }}
   {{- end }}
 
+  # WorkOS M2M client secret (outbound token flowker mints to call the Tenant Manager)
+  {{- if .Values.flowker.secrets.WORKOS_TM_CLIENT_SECRET }}
+  WORKOS_TM_CLIENT_SECRET: {{ .Values.flowker.secrets.WORKOS_TM_CLIENT_SECRET | quote }}
+  {{- end }}
+
   # API key (when API_KEY_ENABLED=true)
   {{- if .Values.flowker.secrets.API_KEY }}
   API_KEY: {{ .Values.flowker.secrets.API_KEY | quote }}

--- a/charts/flowker/values.yaml
+++ b/charts/flowker/values.yaml
@@ -299,6 +299,9 @@ flowker:
     MULTI_TENANT_SERVICE_API_KEY: ""
     # -- Redis password for tenant Pub/Sub (optional)
     MULTI_TENANT_REDIS_PASSWORD: ""
+    # -- WorkOS M2M client secret for the outbound token flowker mints to call
+    # the Tenant Manager (emitted only when set)
+    WORKOS_TM_CLIENT_SECRET: ""
 
   # -- Use an existing secret instead of creating one
   useExistingSecret: false


### PR DESCRIPTION
## What
Adds a conditional `WORKOS_TM_CLIENT_SECRET` key to the flowker chart's `Secret` template (`stringData`). This is the flowker outbound M2M client secret used to mint a token to call the Tenant Manager (recreate + associations). Chart `3.0.0` → `3.0.1`.

## Why
The non-secret `WORKOS_TM_*` config (token URL, client id, scope, service name) is delivered via the existing generic `extraEnvVars` passthrough (same pattern as `AWS_REGION`), so the ConfigMap allowlist is unchanged. Only the actual credential needs a chart change, and it must flow through the `Secret` (never a plaintext ConfigMap).

## Changes
- `templates/secrets.yaml`: conditional `WORKOS_TM_CLIENT_SECRET`
- `values.yaml`: `flowker.secrets.WORKOS_TM_CLIENT_SECRET: ""`
- `Chart.yaml`: `3.0.0` → `3.0.1`
- `CHANGELOG.md`: `[3.0.1]` entry

## Validation
- `helm lint charts/flowker` — 0 failures
- `helm template` with benedita stg-mt values renders `WORKOS_TM_CLIENT_SECRET` in the Secret; `configmap.yaml` byte-identical to `main`

## Consumers
- benedita stg-mt gitops bumps its flowker release to `3.0.1` (separate PR in the gitops repo). Requires the `flowker-helm` `3.0.1` OCI to be published before that helmfile resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)