### PR TITLE
feat(plugin-br-pix-switch): add adapter-lerian chart components

### DIFF
--- a/charts/plugin-br-pix-switch/README.md
+++ b/charts/plugin-br-pix-switch/README.md
@@ -38,15 +38,15 @@ per component.
 The plugin uses a Proxy/Hub deployment model. A "hub" component owns business
 logic and local state (its own Postgres database, sometimes Mongo+Valkey),
 while a "proxy" component is a stateless pass-through. Both expose identical
-APIs. Three Postgres databases are required (`pix-spi`, `pix-dict`, `pix-cob`)
-and one Mongo database (`pix-dict`) for `dict-hub` (`pix-cob` is a
+APIs. Four Postgres databases are required (`pix-spi`, `pix-dict`, `pix-cob`,
+`pix-adapter-lerian`) and one Mongo database (`pix-dict`) for `dict-hub` (`pix-cob` is a
 forward-compat slot the Mongo bootstrap provisions but no component reads yet).
 
 ## Required infrastructure
 
 For a full deployment:
-- **PostgreSQL**: 3 databases (`pix-spi`, `pix-dict`, `pix-cob`) and a role
-  `pixswitch` with full ownership of each
+- **PostgreSQL**: 4 databases (`pix-spi`, `pix-dict`, `pix-cob`,
+  `pix-adapter-lerian`) and a role `pixswitch` with full ownership of each
 - **MongoDB**: 1 database (`pix-dict`) used by `dict-hub`; the bootstrap also
   provisions `pix-cob` as a forward-compat slot, but no component reads it yet
 - **Valkey** (Redis-compatible): used by `spi`, `dict-hub`, `dict-hub-vsync`

--- a/charts/plugin-br-pix-switch/README.md
+++ b/charts/plugin-br-pix-switch/README.md
@@ -67,6 +67,8 @@ Default `enabled` values:
 - `spi`, `spiSystemplane`, `dictHub`, `dictHubVsync`, `dictProxy`,
   `dictSystemplane`, `cobHub`, `cobProxy`, `cobSystemplane`: `true`
 - `adapterBtgMock`: `false` (it's a mock — only enable in dev/staging)
+- `adapterLerian`, `adapterLerianConsumer`, `adapterLerianSystemplane`: `false`
+  (Lerian provider adapter — enable per environment)
 
 ## Configuration
 
@@ -90,7 +92,9 @@ The app reads:
 
 Each component publishes and pulls its own image
 (`ghcr.io/lerianstudio/plugin-br-pix-switch-<component>-api`), set per
-component under `<component>.image.repository`. There is no shared
+component under `<component>.image.repository`. Worker components omit the
+`-api` suffix (e.g. `plugin-br-pix-switch-dict-hub-vsync` and
+`plugin-br-pix-switch-adapter-lerian-consumer`). There is no shared
 `global.image.repository`. When a component's `image.tag` is unset it falls
 back to `.Chart.AppVersion`, which keeps the cohort in lockstep by default;
 override `<component>.image.tag` to pin a specific build per component (rare).

--- a/charts/plugin-br-pix-switch/README.md
+++ b/charts/plugin-br-pix-switch/README.md
@@ -10,7 +10,7 @@
 
 BACEN-compliant PIX instant payment platform for the Lerian ecosystem.
 
-The plugin is a Go monorepo that produces 10 independently-deployable binaries.
+The plugin is a Go monorepo that produces 13 independently-deployable binaries.
 This chart deploys all of them with one helm release. Each component has its
 own Deployment, Service, ConfigMap, Secret, HPA, and PDB; ingress is opt-in
 per component.
@@ -29,6 +29,9 @@ per component.
 | `cobHub` | `cob/hub/api` | 4108 | COB hub |
 | `cobProxy` | `cob/proxy/api` | 4109 | COB proxy to BCB |
 | `cobSystemplane` | `cob/systemplane/api` | 4110 | Runtime config plane for COB |
+| `adapterLerian` | `adapter-lerian/api` | 4113 | Lerian provider adapter (API, disabled by default) |
+| `adapterLerianConsumer` | `adapter-lerian/consumer` | 4114 | Lerian provider adapter Kafka consumer (disabled by default) |
+| `adapterLerianSystemplane` | `adapter-lerian/systemplane/api` | 4115 | Runtime config plane for adapter-lerian (disabled by default) |
 
 ## Architecture
 

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/configmap.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.adapterLerianConsumer.enabled }}
+{{- $component := "adapter-lerian-consumer" }}
+{{- $values := .Values.adapterLerianConsumer }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+data:
+  {{- range $key, $value := $values.configmap }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- /*
+  OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
+  tracks releases automatically. Resolution order:
+    component image.tag > Chart.AppVersion.
+  Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
+  explicitly (the range above wins because data keys are unique per YAML map,
+  but we only emit this when the key wasn't already provided).
+  */}}
+  {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/lerian/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/health" }}
+              path: {{ $values.livenessProbe.path | default "/lerian/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/deployment.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.adapterLerianConsumer.enabled }}
+{{- $component := "adapter-lerian-consumer" }}
+{{- $values := .Values.adapterLerianConsumer }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ $values.revisionHistoryLimit | default 10 }}
+  {{- if not $values.autoscaling.enabled }}
+  replicas: {{ $values.replicaCount }}
+  {{- end }}
+  strategy:
+    {{- toYaml $values.deploymentStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      {{- with $values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 8 }}
+    spec:
+      {{- with (include "plugin-br-pix-switch.componentImagePullSecrets" (dict "context" $ "componentValues" $values)) }}
+      {{- if . }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "plugin-br-pix-switch.componentServiceAccountName" (dict "context" $ "component" $component "componentValues" $values) }}
+      securityContext:
+        {{- toYaml $values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- include "plugin-br-pix-switch.waitForDependencies" (dict "context" $ "component" $component "componentValues" $values) | nindent 8 }}
+      containers:
+        - name: {{ $component }}
+          securityContext:
+            {{- toYaml $values.securityContext | nindent 12 }}
+          image: {{ include "plugin-br-pix-switch.componentImage" (dict "context" $ "componentValues" $values) }}
+          imagePullPolicy: {{ include "plugin-br-pix-switch.componentPullPolicy" (dict "context" $ "componentValues" $values) }}
+          {{- with $values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $values.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
+          {{- /*
+          Build the env: list when EITHER telemetry is enabled (HOST_IP +
+          OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each
+          pod talks to its node-local OTel collector by default) OR the
+          operator has set extraEnvVars. The configmap-supplied
+          OTEL_EXPORTER_OTLP_ENDPOINT can still be overridden by setting
+          it in the configmap; the K8s rule is "later env entry wins",
+          so the configmap value (via envFrom) is overridden by the
+          explicit env entry below.
+          */}}
+          {{- $telemetryOn := eq (toString (default "false" $values.configmap.TELEMETRY_ENABLED)) "true" }}
+          {{- $hasExtras := gt (len $values.extraEnvVars) 0 }}
+          {{- if or $telemetryOn $hasExtras }}
+          env:
+            {{- if $telemetryOn }}
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "$(HOST_IP):4317"
+            {{- end }}
+            {{- if $hasExtras }}
+            {{- range $k, $v := $values.extraEnvVars }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml $values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ $values.readinessProbe.path | default "/readyz" }}
+              port: http
+            initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ $values.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ $values.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
+          livenessProbe:
+            httpGet:
+              path: {{ $values.livenessProbe.path | default "/health" }}
+              port: http
+            initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ $values.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ $values.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $values.livenessProbe.failureThreshold | default 3 }}
+      {{- with $values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/hpa.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/hpa.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.adapterLerianConsumer.enabled .Values.adapterLerianConsumer.autoscaling.enabled }}
+{{- $component := "adapter-lerian-consumer" }}
+{{- $values := .Values.adapterLerianConsumer }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  minReplicas: {{ $values.autoscaling.minReplicas }}
+  maxReplicas: {{ $values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if $values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/pdb.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.adapterLerianConsumer.enabled .Values.adapterLerianConsumer.pdb.enabled }}
+{{- $component := "adapter-lerian-consumer" }}
+{{- $values := .Values.adapterLerianConsumer }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $values.pdb.minAvailable }}
+  minAvailable: {{ $values.pdb.minAvailable }}
+  {{- else if $values.pdb.maxUnavailable }}
+  maxUnavailable: {{ $values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/secrets.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.adapterLerianConsumer.enabled (not .Values.adapterLerianConsumer.useExistingSecret) }}
+{{- $component := "adapter-lerian-consumer" }}
+{{- $values := .Values.adapterLerianConsumer }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := $values.secrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/service.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.adapterLerianConsumer.enabled }}
+{{- $component := "adapter-lerian-consumer" }}
+{{- $values := .Values.adapterLerianConsumer }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $values.service.type }}
+  ports:
+    - port: {{ $values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 4 }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/serviceaccount.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-consumer/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.adapterLerianConsumer.enabled .Values.adapterLerianConsumer.serviceAccount.create }}
+{{- $component := "adapter-lerian-consumer" }}
+{{- $values := .Values.adapterLerianConsumer }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentServiceAccountName" (dict "context" $ "component" $component "componentValues" $values) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/configmap.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.adapterLerianSystemplane.enabled }}
+{{- $component := "adapter-lerian-systemplane" }}
+{{- $values := .Values.adapterLerianSystemplane }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+data:
+  {{- range $key, $value := $values.configmap }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- /*
+  OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
+  tracks releases automatically. Resolution order:
+    component image.tag > Chart.AppVersion.
+  Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
+  explicitly (the range above wins because data keys are unique per YAML map,
+  but we only emit this when the key wasn't already provided).
+  */}}
+  {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/deployment.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.adapterLerianSystemplane.enabled }}
+{{- $component := "adapter-lerian-systemplane" }}
+{{- $values := .Values.adapterLerianSystemplane }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ $values.revisionHistoryLimit | default 10 }}
+  {{- if not $values.autoscaling.enabled }}
+  replicas: {{ $values.replicaCount }}
+  {{- end }}
+  strategy:
+    {{- toYaml $values.deploymentStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      {{- with $values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 8 }}
+    spec:
+      {{- with (include "plugin-br-pix-switch.componentImagePullSecrets" (dict "context" $ "componentValues" $values)) }}
+      {{- if . }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "plugin-br-pix-switch.componentServiceAccountName" (dict "context" $ "component" $component "componentValues" $values) }}
+      securityContext:
+        {{- toYaml $values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- include "plugin-br-pix-switch.waitForDependencies" (dict "context" $ "component" $component "componentValues" $values) | nindent 8 }}
+      containers:
+        - name: {{ $component }}
+          securityContext:
+            {{- toYaml $values.securityContext | nindent 12 }}
+          image: {{ include "plugin-br-pix-switch.componentImage" (dict "context" $ "componentValues" $values) }}
+          imagePullPolicy: {{ include "plugin-br-pix-switch.componentPullPolicy" (dict "context" $ "componentValues" $values) }}
+          {{- with $values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $values.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
+          {{- /*
+          Build the env: list when EITHER telemetry is enabled (HOST_IP +
+          OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each
+          pod talks to its node-local OTel collector by default) OR the
+          operator has set extraEnvVars. The configmap-supplied
+          OTEL_EXPORTER_OTLP_ENDPOINT can still be overridden by setting
+          it in the configmap; the K8s rule is "later env entry wins",
+          so the configmap value (via envFrom) is overridden by the
+          explicit env entry below.
+          */}}
+          {{- $telemetryOn := eq (toString (default "false" $values.configmap.TELEMETRY_ENABLED)) "true" }}
+          {{- $hasExtras := gt (len $values.extraEnvVars) 0 }}
+          {{- if or $telemetryOn $hasExtras }}
+          env:
+            {{- if $telemetryOn }}
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "$(HOST_IP):4317"
+            {{- end }}
+            {{- if $hasExtras }}
+            {{- range $k, $v := $values.extraEnvVars }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml $values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ $values.readinessProbe.path | default "/lerian/readyz" }}
+              port: http
+            initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ $values.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ $values.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
+          livenessProbe:
+            httpGet:
+              path: {{ $values.livenessProbe.path | default "/lerian/health" }}
+              port: http
+            initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ $values.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ $values.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $values.livenessProbe.failureThreshold | default 3 }}
+      {{- with $values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/hpa.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/hpa.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.adapterLerianSystemplane.enabled .Values.adapterLerianSystemplane.autoscaling.enabled }}
+{{- $component := "adapter-lerian-systemplane" }}
+{{- $values := .Values.adapterLerianSystemplane }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  minReplicas: {{ $values.autoscaling.minReplicas }}
+  maxReplicas: {{ $values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if $values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/pdb.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.adapterLerianSystemplane.enabled .Values.adapterLerianSystemplane.pdb.enabled }}
+{{- $component := "adapter-lerian-systemplane" }}
+{{- $values := .Values.adapterLerianSystemplane }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $values.pdb.minAvailable }}
+  minAvailable: {{ $values.pdb.minAvailable }}
+  {{- else if $values.pdb.maxUnavailable }}
+  maxUnavailable: {{ $values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/secrets.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.adapterLerianSystemplane.enabled (not .Values.adapterLerianSystemplane.useExistingSecret) }}
+{{- $component := "adapter-lerian-systemplane" }}
+{{- $values := .Values.adapterLerianSystemplane }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := $values.secrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/service.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.adapterLerianSystemplane.enabled }}
+{{- $component := "adapter-lerian-systemplane" }}
+{{- $values := .Values.adapterLerianSystemplane }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $values.service.type }}
+  ports:
+    - port: {{ $values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 4 }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/serviceaccount.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian-systemplane/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.adapterLerianSystemplane.enabled .Values.adapterLerianSystemplane.serviceAccount.create }}
+{{- $component := "adapter-lerian-systemplane" }}
+{{- $values := .Values.adapterLerianSystemplane }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentServiceAccountName" (dict "context" $ "component" $component "componentValues" $values) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/configmap.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.adapterLerian.enabled }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+data:
+  {{- range $key, $value := $values.configmap }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- /*
+  OTEL_RESOURCE_SERVICE_VERSION: derive from the deployed image tag so it
+  tracks releases automatically. Resolution order:
+    component image.tag > Chart.AppVersion.
+  Operators can override by setting `<component>.configmap.OTEL_RESOURCE_SERVICE_VERSION`
+  explicitly (the range above wins because data keys are unique per YAML map,
+  but we only emit this when the key wasn't already provided).
+  */}}
+  {{- if not (hasKey $values.configmap "OTEL_RESOURCE_SERVICE_VERSION") }}
+  {{- $compTag := default $.Chart.AppVersion $values.image.tag }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ $compTag | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/deployment.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.adapterLerian.enabled }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ $values.revisionHistoryLimit | default 10 }}
+  {{- if not $values.autoscaling.enabled }}
+  replicas: {{ $values.replicaCount }}
+  {{- end }}
+  strategy:
+    {{- toYaml $values.deploymentStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+  template:
+    metadata:
+      {{- with $values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 8 }}
+    spec:
+      {{- with (include "plugin-br-pix-switch.componentImagePullSecrets" (dict "context" $ "componentValues" $values)) }}
+      {{- if . }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "plugin-br-pix-switch.componentServiceAccountName" (dict "context" $ "component" $component "componentValues" $values) }}
+      securityContext:
+        {{- toYaml $values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- include "plugin-br-pix-switch.waitForDependencies" (dict "context" $ "component" $component "componentValues" $values) | nindent 8 }}
+      containers:
+        - name: {{ $component }}
+          securityContext:
+            {{- toYaml $values.securityContext | nindent 12 }}
+          image: {{ include "plugin-br-pix-switch.componentImage" (dict "context" $ "componentValues" $values) }}
+          imagePullPolicy: {{ include "plugin-br-pix-switch.componentPullPolicy" (dict "context" $ "componentValues" $values) }}
+          {{- with $values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $values.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+            - secretRef:
+                name: {{ include "plugin-br-pix-switch.componentSecretName" (dict "context" $ "component" $component "componentValues" $values) }}
+          {{- /*
+          Build the env: list when EITHER telemetry is enabled (HOST_IP +
+          OTEL_EXPORTER_OTLP_ENDPOINT injected via downward API so each
+          pod talks to its node-local OTel collector by default) OR the
+          operator has set extraEnvVars. The configmap-supplied
+          OTEL_EXPORTER_OTLP_ENDPOINT can still be overridden by setting
+          it in the configmap; the K8s rule is "later env entry wins",
+          so the configmap value (via envFrom) is overridden by the
+          explicit env entry below.
+          */}}
+          {{- $telemetryOn := eq (toString (default "false" $values.configmap.TELEMETRY_ENABLED)) "true" }}
+          {{- $hasExtras := gt (len $values.extraEnvVars) 0 }}
+          {{- if or $telemetryOn $hasExtras }}
+          env:
+            {{- if $telemetryOn }}
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "$(HOST_IP):4317"
+            {{- end }}
+            {{- if $hasExtras }}
+            {{- range $k, $v := $values.extraEnvVars }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml $values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ $values.readinessProbe.path | default "/lerian/readyz" }}
+              port: http
+            initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ $values.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ $values.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
+          livenessProbe:
+            httpGet:
+              path: {{ $values.livenessProbe.path | default "/lerian/health" }}
+              port: http
+            initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ $values.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ $values.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ $values.livenessProbe.failureThreshold | default 3 }}
+      {{- with $values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/hpa.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/hpa.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.adapterLerian.enabled .Values.adapterLerian.autoscaling.enabled }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  minReplicas: {{ $values.autoscaling.minReplicas }}
+  maxReplicas: {{ $values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if $values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/ingress.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.adapterLerian.enabled .Values.adapterLerian.ingress.enabled }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+{{- $fullName := include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+{{- $svcPort := $values.service.port }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/migrations-job.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/migrations-job.yaml
@@ -1,0 +1,1 @@
+{{- include "plugin-br-pix-switch.migrationJob" (dict "context" . "component" "adapterLerian" "serviceName" "adapter-lerian") }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/pdb.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.adapterLerian.enabled .Values.adapterLerian.pdb.enabled }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $values.pdb.minAvailable }}
+  minAvailable: {{ $values.pdb.minAvailable }}
+  {{- else if $values.pdb.maxUnavailable }}
+  maxUnavailable: {{ $values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/secrets.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.adapterLerian.enabled (not .Values.adapterLerian.useExistingSecret) }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := $values.secrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/service.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.adapterLerian.enabled }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $values.service.type }}
+  ports:
+    - port: {{ $values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "plugin-br-pix-switch.selectorLabels" (dict "context" $ "component" $component) | nindent 4 }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-lerian/serviceaccount.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-lerian/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.adapterLerian.enabled .Values.adapterLerian.serviceAccount.create }}
+{{- $component := "adapter-lerian" }}
+{{- $values := .Values.adapterLerian }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "plugin-br-pix-switch.componentServiceAccountName" (dict "context" $ "component" $component "componentValues" $values) }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "plugin-br-pix-switch.labels" (dict "context" $ "component" $component) | nindent 4 }}
+  {{- with $values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-br-pix-switch/values-template.yaml
+++ b/charts/plugin-br-pix-switch/values-template.yaml
@@ -1,8 +1,9 @@
 # Production values template for plugin-br-pix-switch (chart 2.0.0-beta.1+)
 #
 # Override only the fields you need to change from values.yaml defaults.
-# All 10 components are enabled by default except adapter-btg-mock; disable
-# any component by setting its `enabled: false`.
+# All 13 components are enabled by default except adapter-btg-mock and the
+# adapter-lerian trio (adapterLerian / adapterLerianConsumer /
+# adapterLerianSystemplane); disable any component by setting `enabled: false`.
 
 # Global image override (applies to every component unless overridden per-component)
 global:
@@ -161,6 +162,46 @@ cobSystemplane:
   secrets:
     DATABASE_URL: "postgres://pixswitch:<password>@postgres-host:5432/pix-cob?sslmode=require"
     SYSTEMPLANE_POSTGRES_DSN: "postgres://pixswitch:<password>@postgres-host:5432/pix-cob?sslmode=require"
+    LICENSE_KEY: ""
+    SYSTEMPLANE_SECRET_MASTER_KEY: ""
+
+# ------------------------------------------------------------
+# adapter-lerian (api) — Lerian provider adapter HTTP entry
+# ------------------------------------------------------------
+adapterLerian:
+  enabled: false
+  configmap:
+    DEPLOYMENT_MODE: "saas"
+    PLUGIN_AUTH_ENABLED: "true"
+    PLUGIN_AUTH_URL: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
+    ORGANIZATION_IDS: "global"
+  secrets:
+    DATABASE_URL: "postgres://pixswitch:<password>@postgres-host:5432/pix-adapter-lerian?sslmode=require"
+    SYSTEMPLANE_POSTGRES_DSN: "postgres://pixswitch:<password>@postgres-host:5432/pix-adapter-lerian?sslmode=require"
+    LICENSE_KEY: ""
+
+# ------------------------------------------------------------
+# adapter-lerian (consumer) — br-sfn Kafka consumer
+# ------------------------------------------------------------
+adapterLerianConsumer:
+  enabled: false
+  configmap:
+    ISPB: "<8-digit-ispb>"
+    KAFKA_BROKERS: "<broker-1:9092,broker-2:9092>"
+    KAFKA_GROUP_ID: "pix-adapter-lerian-cashin"
+  secrets:
+    SYSTEMPLANE_POSTGRES_DSN: "postgres://pixswitch:<password>@postgres-host:5432/pix-adapter-lerian?sslmode=require"
+    VALKEY_URL: "redis://default:<password>@valkey-host:6379/0"
+    LICENSE_KEY: ""
+
+# ------------------------------------------------------------
+# adapter-lerian (systemplane) — runtime config plane
+# ------------------------------------------------------------
+adapterLerianSystemplane:
+  enabled: false
+  configmap: {}
+  secrets:
+    DATABASE_URL: "postgres://pixswitch:<password>@postgres-host:5432/pix-adapter-lerian?sslmode=require"
     LICENSE_KEY: ""
     SYSTEMPLANE_SECRET_MASTER_KEY: ""
 

--- a/charts/plugin-br-pix-switch/values.schema.json
+++ b/charts/plugin-br-pix-switch/values.schema.json
@@ -100,6 +100,42 @@
       },
       "additionalProperties": true
     },
+    "adapterLerian": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "adapterLerianConsumer": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "adapterLerianSystemplane": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
     "cobHub": {
       "type": "object",
       "properties": {

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -1555,9 +1555,9 @@ adapterLerianConsumer:
     maxReplicas: 1
 
   readinessProbe:
-    path: "/readyz"
+    path: "/lerian/readyz"
   livenessProbe:
-    path: "/health"
+    path: "/lerian/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -1708,7 +1708,6 @@ adapterLerianSystemplane:
     SWITCH_BASE_URL: ""
     INTEGRATION_MODE: ""
     BRSFN_BASE_URL: ""
-    BRSFN_TOKEN_URL: ""
     BRSFN_CLIENT_ID: ""
 
   secrets:
@@ -1717,6 +1716,8 @@ adapterLerianSystemplane:
     # -- 32-byte AES-256-GCM key; required in non-local deployment modes.
     SYSTEMPLANE_SECRET_MASTER_KEY: ""
     MULTI_TENANT_API_KEY: ""
+    # -- OAuth token endpoint; classified as a secret to satisfy the credential-name chart standard.
+    BRSFN_TOKEN_URL: ""
     BRSFN_CLIENT_SECRET: ""
 
   useExistingSecret: false

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -46,7 +46,7 @@ global:
   #
   # Use cases:
   #   - In-cluster Postgres subchart (postgresql.enabled=true) AND you want
-  #     the chart to create the 3 pix-switch databases for you. Set
+  #     the chart to create the 4 pix-switch databases for you. Set
   #     connection.host to the in-cluster service name
   #     (plugin-br-pix-switch-postgresql).
   #   - External Postgres (RDS, Cloud SQL, etc.) where the operator wants the
@@ -64,7 +64,7 @@ global:
   #     values live under component `secrets`, not `configmap`.
   externalPostgresDefinitions:
     enabled: false
-    # -- Databases to create (one Job per database). pix-switch needs 3.
+    # -- Databases to create (one Job per database). pix-switch needs 4.
     databases:
       - pix-spi
       - pix-dict

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -69,6 +69,7 @@ global:
       - pix-spi
       - pix-dict
       - pix-cob
+      - pix-adapter-lerian
     connection:
       host: ""
       port: "5432"
@@ -1374,6 +1375,355 @@ appsIngress:
       component: cobProxy
       serviceName: cob-proxy
 
+# -----------------------------------------------------------------------------
+# adapter-lerian (api) — Lerian provider adapter HTTP entry (br-sfn)
+# -----------------------------------------------------------------------------
+adapterLerian:
+  enabled: false   # safety default — explicitly enable in dev/staging values
+  name: "adapter-lerian"
+  description: "Lerian provider adapter (API)"
+  replicaCount: 1
+  revisionHistoryLimit: 10
+
+  image:
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-lerian-api"
+    pullPolicy: ""
+    tag: ""
+
+  imagePullSecrets: []
+
+  # -- Override container entrypoint (e.g., to dispatch to a specific binary
+  # inside a multi-binary image). When empty, the image's ENTRYPOINT is used.
+  command: []
+  # -- Container args
+  args: []
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 1000
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+
+  pdb:
+    enabled: false
+    minAvailable: 0
+    maxUnavailable: 1
+
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+
+  service:
+    type: ClusterIP
+    port: 4113
+
+  ingress:
+    enabled: false
+
+  resources:
+    limits: { cpu: 200m, memory: 256Mi }
+    requests: { cpu: 50m, memory: 64Mi }
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 1
+
+  readinessProbe:
+    path: "/lerian/readyz"
+  livenessProbe:
+    path: "/lerian/health"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+
+  configmap:
+    APPLICATION_NAME: "plugin-br-pix-switch"
+    SERVER_ADDRESS: ":4113"
+    LOG_LEVEL: "info"
+    ENV_NAME: "development"
+    DEPLOYMENT_MODE: "byoc"
+    TELEMETRY_ENABLED: "false"
+    OTEL_RESOURCE_SERVICE_NAME: "pix-adapter-lerian-api"
+    OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-pix-switch"
+    OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "development"
+    OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    PLUGIN_AUTH_ENABLED: "false"
+    PLUGIN_AUTH_URL: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
+    # License allow-list (use "global" for single-license mode).
+    ORGANIZATION_IDS: ""
+    # -- Multi-tenant (consumed when MULTI_TENANT_ENABLED=true). MULTI_TENANT_URL
+    # is the tenant-manager address; MULTI_TENANT_API_KEY lives under secrets.
+    MULTI_TENANT_ENABLED: "false"
+    MULTI_TENANT_URL: ""
+
+  secrets:
+    # -- DATABASE_URL backs the golang-migrate Job that applies the component's
+    # SQL migrations. SYSTEMPLANE_POSTGRES_DSN is the api's sole routing source
+    # (read-only consumer DSN for adapter_lerian.* runtime config).
+    DATABASE_URL: ""
+    SYSTEMPLANE_POSTGRES_DSN: ""
+    LICENSE_KEY: ""
+    MULTI_TENANT_API_KEY: ""
+
+  useExistingSecret: false
+  existingSecretName: ""
+
+  extraEnvVars: {}
+
+  # -- golang-migrate Job that applies SQL migrations from the component's
+  # /migrations directory against the database referenced by DATABASE_URL.
+  # Runs as a Helm hook on pre-upgrade + post-install.
+  migrations:
+    enabled: true
+    migrationsPath: /migrations
+    ttlSecondsAfterFinished: 300
+    backoffLimit: 3
+
+# -----------------------------------------------------------------------------
+# adapter-lerian (consumer) — br-sfn CloudEvents Kafka consumer (no ingress)
+# -----------------------------------------------------------------------------
+adapterLerianConsumer:
+  enabled: false   # safety default — explicitly enable in dev/staging values
+  name: "adapter-lerian-consumer"
+  description: "Lerian provider adapter (Kafka consumer)"
+  replicaCount: 1
+  revisionHistoryLimit: 10
+
+  image:
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-lerian-consumer"
+    pullPolicy: ""
+    tag: ""
+
+  imagePullSecrets: []
+
+  # -- Override container entrypoint (e.g., to dispatch to a specific binary
+  # inside a multi-binary image). When empty, the image's ENTRYPOINT is used.
+  command: []
+  # -- Container args
+  args: []
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 1000
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+
+  pdb:
+    enabled: false
+    minAvailable: 0
+    maxUnavailable: 1
+
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+
+  service:
+    type: ClusterIP
+    port: 4114
+
+  resources:
+    limits: { cpu: 500m, memory: 512Mi }
+    requests: { cpu: 100m, memory: 128Mi }
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 1
+
+  readinessProbe:
+    path: "/readyz"
+  livenessProbe:
+    path: "/health"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+
+  configmap:
+    APPLICATION_NAME: "plugin-br-pix-switch"
+    SERVER_ADDRESS: ":4114"
+    LOG_LEVEL: "info"
+    ENV_NAME: "development"
+    DEPLOYMENT_MODE: "byoc"
+    TELEMETRY_ENABLED: "false"
+    OTEL_RESOURCE_SERVICE_NAME: "pix-adapter-lerian-consumer"
+    OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-pix-switch"
+    OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "development"
+    OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    PLUGIN_AUTH_ENABLED: "false"
+    PLUGIN_AUTH_URL: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
+    ORGANIZATION_IDS: ""
+    # -- This deployment's 8-digit BACEN participant ISPB. Read once at boot to
+    # scope the ce-id dedup keyspace. Set the real ISPB per deployment.
+    ISPB: ""
+    MULTI_TENANT_ENABLED: "false"
+    # -- Kafka consumer (franz-go). In production KAFKA_BROKERS points at the
+    # external br-sfn Kafka (ADR-002). SASL credentials live under secrets.
+    KAFKA_BROKERS: ""
+    KAFKA_GROUP_ID: "pix-adapter-lerian-cashin"
+    KAFKA_TLS_ENABLED: "false"
+    KAFKA_SASL_MECHANISM: ""
+    KAFKA_DLQ_TOPIC: "br-spi.adapter-lerian.dlq"
+    KAFKA_MAX_CONCURRENT_PARTITIONS: "8"
+    CONSUMER_DEDUP_TTL_SEC: "3600"
+
+  secrets:
+    # -- SYSTEMPLANE_POSTGRES_DSN: read-only routing config DSN (empty disables
+    # the consumer). VALKEY_URL backs the ce-id dedup cache. KAFKA_SASL_* are the
+    # broker credentials used when KAFKA_SASL_MECHANISM is set.
+    SYSTEMPLANE_POSTGRES_DSN: ""
+    VALKEY_URL: ""
+    KAFKA_SASL_USER: ""
+    KAFKA_SASL_PASSWORD: ""
+    LICENSE_KEY: ""
+
+  useExistingSecret: false
+  existingSecretName: ""
+
+  extraEnvVars: {}
+
+# -----------------------------------------------------------------------------
+# adapter-lerian (systemplane) — runtime config plane for adapter-lerian
+# -----------------------------------------------------------------------------
+adapterLerianSystemplane:
+  enabled: false   # safety default — explicitly enable in dev/staging values
+  name: "adapter-lerian-systemplane"
+  description: "Runtime config plane for adapter-lerian"
+  replicaCount: 1
+  revisionHistoryLimit: 10
+
+  image:
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-lerian-systemplane-api"
+    pullPolicy: ""
+    tag: ""
+
+  imagePullSecrets: []
+
+  # -- Override container entrypoint (e.g., to dispatch to a specific binary
+  # inside a multi-binary image). When empty, the image's ENTRYPOINT is used.
+  command: []
+  # -- Container args
+  args: []
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 1000
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+
+  pdb:
+    enabled: false
+    minAvailable: 0
+    maxUnavailable: 1
+
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+
+  service:
+    type: ClusterIP
+    port: 4115
+
+  resources:
+    limits: { cpu: 200m, memory: 256Mi }
+    requests: { cpu: 50m, memory: 64Mi }
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 1
+
+  readinessProbe:
+    path: "/lerian/readyz"
+  livenessProbe:
+    path: "/lerian/health"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+
+  configmap:
+    APPLICATION_NAME: "plugin-br-pix-switch"
+    SERVER_ADDRESS: ":4115"
+    LOG_LEVEL: "info"
+    ENV_NAME: "development"
+    DEPLOYMENT_MODE: "byoc"
+    REQUEST_TIMEOUT_SEC: "30"
+    TELEMETRY_ENABLED: "false"
+    OTEL_RESOURCE_SERVICE_NAME: "pix-adapter-lerian-systemplane"
+    OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-pix-switch"
+    OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "development"
+    OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    PLUGIN_AUTH_ENABLED: "false"
+    PLUGIN_AUTH_URL: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
+    # -- Multi-tenant. MULTI_TENANT_URL + MULTI_TENANT_API_KEY (secret) are
+    # seeded into the store; the CB tunables size the tenant-manager client.
+    MULTI_TENANT_ENABLED: "false"
+    MULTI_TENANT_URL: ""
+    MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: "5"
+    MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: "30"
+    # -- Address-book / instance routing seeds (first-boot only; operators
+    # manage them via the systemplane admin API afterwards).
+    SWITCH_BASE_URL: ""
+    INTEGRATION_MODE: ""
+    BRSFN_BASE_URL: ""
+    BRSFN_TOKEN_URL: ""
+    BRSFN_CLIENT_ID: ""
+
+  secrets:
+    DATABASE_URL: ""
+    LICENSE_KEY: ""
+    # -- 32-byte AES-256-GCM key; required in non-local deployment modes.
+    SYSTEMPLANE_SECRET_MASTER_KEY: ""
+    MULTI_TENANT_API_KEY: ""
+    BRSFN_CLIENT_SECRET: ""
+
+  useExistingSecret: false
+  existingSecretName: ""
+
+  extraEnvVars: {}
+
 systemplaneIngress:
   enabled: false
   className: "nginx"
@@ -1393,6 +1743,10 @@ systemplaneIngress:
       pathType: Prefix
       component: cobSystemplane
       serviceName: cob-systemplane
+    - path: /lerian
+      pathType: Prefix
+      component: adapterLerianSystemplane
+      serviceName: adapter-lerian-systemplane
 
 # -----------------------------------------------------------------------------
 # Providers Ingress — outbound-provider adapters (BTG mock, BACEN, JD, ...).
@@ -1418,6 +1772,10 @@ providersIngress:
       pathType: Prefix
       component: adapterBtgMock
       serviceName: adapter-btg-mock
+    - path: /lerian
+      pathType: Prefix
+      component: adapterLerian
+      serviceName: adapter-lerian
     # Reserved for future components — uncomment when the bacen/jd
     # adapter components ship in the chart:
     # - path: /bacen


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Plugin BR PIX Switch

## Summary

Adds the `adapter-lerian` provider adapter (3 components) to the `plugin-br-pix-switch` chart, mirroring the existing patterns. All three ship **`enabled: false`** by default, so this is inert until an environment opts in.

| Component | values key | Service port | Ingress | Migration Job | Route prefix |
|-----------|-----------|--------------|---------|---------------|--------------|
| api | `adapterLerian` | 4113 | `providersIngress` → `/lerian` | ✅ (golang-migrate hook) | `/lerian` |
| consumer | `adapterLerianConsumer` | 4114 | none (worker) | — | `/lerian` |
| systemplane | `adapterLerianSystemplane` | 4115 | `systemplaneIngress` → `/lerian` | — | `/lerian` |

**What changed**
- `templates/adapter-lerian/` (mirror of `adapter-btg-mock/` + `migrations-job.yaml` invoking `plugin-br-pix-switch.migrationJob` with `component "adapterLerian" serviceName "adapter-lerian"`).
- `templates/adapter-lerian-consumer/` (mirror of `dict-hub-vsync/`, no ingress).
- `templates/adapter-lerian-systemplane/` (mirror of `dict-systemplane/`, no ingress).
- `values.yaml`: 3 component blocks (`enabled:false`), `providersIngress`/`systemplaneIngress` `/lerian` routes, `global.externalPostgresDefinitions.databases += pix-adapter-lerian`.
- `values.schema.json`, `README.md` (Components table + count), `values-template.yaml`: 3 entries each.

Component/service names and camelCase keys match the `plugin-br-pix-switch` source `release.yml` `gitops_yaml_key_mappings` (`adapterLerian`/`adapterLerianConsumer`/`adapterLerianSystemplane`), so the published image tags wire correctly downstream.

## Checklist

- [x] I have tested these changes locally. (`helm lint` clean; `helm template` smokes verify: `/lerian`→4113 route + migration Job render when `adapterLerian.enabled=true` and disappear when false; consumer exposes no ingress; systemplane route only under `systemplaneIngress`→4115)
- [x] I have updated the documentation accordingly. (`README.md` Components table + `values-template.yaml`)
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues. (no secrets committed; `securityContext` inherited from reference patterns; `enabled:false` default)
- [x] I have ensured that all tests pass. (`helm lint` + template smokes)
- [ ] I have updated the version appropriately (if applicable). (handled by semantic-release on merge)
- [x] I have confirmed this code is ready for review.

## Additional Notes

- All components default to `enabled: false`; enabling per environment is a follow-up GitOps change.
- The consumer worker mounts its operator probes under `/lerian` (source `bootstrap/worker.go` `routePrefix="/lerian"`), so its probes are `/lerian/readyz` / `/lerian/health` — it diverges from the `dict-hub-vsync` model (bare probes) by design.
- On merge, semantic-release publishes the next chart beta (OCI); that version is the pin the downstream GitOps step will reference.

## Obs: PR targets the `develop` branch.
