### PR TITLE
fix(reporter): update reporter-manager@2.2.0, reporter-worker@2.2.0

### DIFF
--- a/charts/reporter/Chart.yaml
+++ b/charts/reporter/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 # to the chart and its templates, including the app version.
 version: 3.1.1
 # This is the version number of the application being deployed.
-appVersion: "2.1.2"
+appVersion: "2.2.0"
 # A list of keywords about the chart. This helps others discover the chart.
 keywords:
   - midaz

--- a/charts/reporter/values.yaml
+++ b/charts/reporter/values.yaml
@@ -64,7 +64,7 @@ manager:
     # -- Image pull policy
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
-    tag: "2.1.2"
+    tag: "2.2.0"
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
   # -- Overrides the default generated name by Helm
@@ -246,7 +246,7 @@ worker:
     # -- Image pull policy
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
-    tag: "2.1.2"
+    tag: "2.2.0"
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
   # -- Overrides the default generated name by Helm


### PR DESCRIPTION
Bump do Reporter para 2.2.0 (reporter-manager@2.2.0, reporter-worker@2.2.0) direcionado à `main`.

Mesma alteração do #1647 — que foi aberto automaticamente pelo bot com base/branch na `develop`. Esta branch foi tirada da `main` e o PR aponta direto pra `main`.

- `charts/reporter/Chart.yaml`: appVersion 2.1.2 → 2.2.0
- `charts/reporter/values.yaml`: tags reporter-manager/reporter-worker 2.1.2 → 2.2.0