### PR TITLE
fix(pipe): escape Helm template syntax breaking GitHub Pages build

### DIFF
--- a/docs/helm-chart-standard.md
+++ b/docs/helm-chart-standard.md
@@ -1,5 +1,7 @@
 # Helm Chart Standard
 
+{% raw %}
+
 This document defines the repository contract for Lerian Helm charts. It exists so charts do not drift by copying the nearest old outlier.
 
 ## Chart Types
@@ -398,3 +400,4 @@ Charts with required production values use dummy CI-only fixtures under `.github
 ## KEDA Autoscaling
 
 KEDA `cpu` and `memory` scalers must **not** carry an `authenticationRef` — those scalers read the metrics server, not an authenticated external source, and a stray `authenticationRef` makes the ScaledObject invalid. Gate it on the trigger type, e.g. `{{- if not (has .type (list "cpu" "memory")) }}` around the `authenticationRef` block. Queue/broker scalers (e.g. rabbitmq) keep their `authenticationRef`.
+{% endraw %}


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Pipeline
- [x] Documentation

## Summary

Hotfix for the failing `pages-build-deployment` pipeline on `main` (the GitHub Pages source that publishes `charts.lerian.studio`).

**Root cause:** the legacy Jekyll 3.10 build renders every `.md` in the repo and runs Liquid over it. `docs/helm-chart-standard.md` contains a Go template comment (`{{/* ... */}}`) inside a code fence, which Liquid parses as an unterminated variable and aborts with a fatal `Liquid::SyntaxError` (line 227), failing the build and blocking the Pages deploy.

**Fix:** wrap the document body in `{% raw %}...{% endraw %}` so Jekyll emits the Helm template snippets verbatim instead of parsing them. `render_with_liquid` is not an option here — it requires Jekyll 4.0+, and Pages runs 3.10.

Targeting `main` (not `develop`) intentionally: the broken pipeline lives on `main`, so the fix only takes effect once merged there.

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [ ] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Verified green by reproducing the exact CI build locally:

```
docker run --rm -e PAGES_REPO_NWO=LerianStudio/helm -e JEKYLL_GITHUB_TOKEN=*** \
  -v "$PWD":/github/workspace -w /github/workspace \
  --entrypoint /bin/bash ghcr.io/actions/jekyll-build-pages:v1.0.13 \
  -c 'github-pages build'
# => done in 22.949 seconds. EXIT=0
```

Scanned the whole repo: `docs/helm-chart-standard.md` was the only file producing a **fatal** Liquid error. The remaining `{{ }}` occurrences in `UPGRADE-*.md` / chart docs only emit non-fatal Liquid *warnings*. A follow-up hardening (e.g. `_config.yml` excluding internal docs, or a lint check) could prevent a future `.md` with Helm templates from breaking the build again.
