### PR TITLE
feat(plugin-br-pix-indirect-btg): add missing env defaults to Helm chart

### DIFF
--- a/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
@@ -12,6 +12,7 @@ data:
   VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}
   SERVER_PORT: {{ .Values.pix.configmap.SERVER_PORT | default "4014" | quote }}
   SERVER_ADDRESS: {{ .Values.pix.configmap.SERVER_ADDRESS | default ":4014" | quote }}
+  DEPLOYMENT_MODE: {{ .Values.pix.configmap.DEPLOYMENT_MODE | default "local" | quote }}
 
   # AUTH PLUGIN
   PLUGIN_AUTH_ENABLED: {{ .Values.pix.configmap.PLUGIN_AUTH_ENABLED | default "false" | quote }}
@@ -74,6 +75,7 @@ data:
   MONGO_NAME: {{ .Values.pix.configmap.MONGO_NAME | default "pix-btg-db" | quote }}
   MONGO_USER: {{ .Values.pix.configmap.MONGO_USER | default "pix-btg" | quote }}
   MONGO_MAX_POOL_SIZE: {{ .Values.pix.configmap.MONGO_MAX_POOL_SIZE | default "1000" | quote }}
+  MONGO_TLS: {{ .Values.pix.configmap.MONGO_TLS | default "false" | quote }}
 
   # SWAGGER
   SWAGGER_TITLE: {{ .Values.pix.configmap.SWAGGER_TITLE | default "Plugin BR Pix Indirect BTG" | quote }}
@@ -142,6 +144,12 @@ data:
 
   # RECONCILIATION
   RECONCILIATION_INTERNAL_CIDR: {{ .Values.pix.configmap.RECONCILIATION_INTERNAL_CIDR | default "" | quote }}
+
+  # Schedule Business Rules
+  SCHEDULE_MAX_FUTURE_DAYS: {{ .Values.pix.configmap.SCHEDULE_MAX_FUTURE_DAYS | default "180" | quote }}
+  SCHEDULE_MIN_FUTURE_SECONDS: {{ .Values.pix.configmap.SCHEDULE_MIN_FUTURE_SECONDS | default "60" | quote }}
+  SCHEDULE_DEFAULT_EXECUTE_HOUR_BRT: {{ .Values.pix.configmap.SCHEDULE_DEFAULT_EXECUTE_HOUR_BRT | default "6" | quote }}
+  SCHEDULE_MAX_ATTEMPTS: {{ .Values.pix.configmap.SCHEDULE_MAX_ATTEMPTS | default "2" | quote }}
 
   # BTG Webhook Validation
   BTG_WEBHOOK_VALIDATION_ENABLED: {{ .Values.pix.configmap.BTG_WEBHOOK_VALIDATION_ENABLED | default "true" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -151,6 +151,8 @@ pix:
   # @default -- templates/configmap.yaml
   configmap:
     ALLOW_INSECURE_TLS: "true"
+    # Deployment Mode
+    DEPLOYMENT_MODE: "local"
     # Database Configuration
     # Infra hosts are derived collapse-aware in templates/*/configmap.yaml from the bundled
     # subchart Service names when left empty. Set explicitly only for external infra.
@@ -164,6 +166,7 @@ pix:
     MONGO_HOST: ""
     MONGO_NAME: "plugin-br-pix-indirect-btg-db"
     MONGO_USER: "pix_btg"
+    MONGO_TLS: "false"
     # Redis Configuration
     REDIS_HOST: ""
     # External Services
@@ -190,6 +193,11 @@ pix:
     MTLS_HTTP_TIMEOUT: "10s"
     # BTG Webhook Validation
     BTG_WEBHOOK_VALIDATION_ENABLED: "true"
+    # Schedule Business Rules
+    SCHEDULE_MAX_FUTURE_DAYS: "180"
+    SCHEDULE_MIN_FUTURE_SECONDS: "60"
+    SCHEDULE_DEFAULT_EXECUTE_HOUR_BRT: "6"
+    SCHEDULE_MAX_ATTEMPTS: "2"
   # -- Secrets for storing sensitive data
   # -- All secrets are declared in the templates/secrets.yaml
   # @default -- templates/secrets.yaml


### PR DESCRIPTION
Adiciona os defaults das variáveis de ambiente do plugin-br-pix-indirect-btg que estavam faltando no chart, evitando que o cliente precise preenchê-las manualmente quando os defaults da aplicação já são suficientes.

Variáveis adicionadas (em `pix.configmap` do `values.yaml`, referenciadas em `templates/pix/configmap.yaml`):
- `DEPLOYMENT_MODE` (default: `local`)
- `MONGO_TLS` (default: `false`)
- `SCHEDULE_MAX_FUTURE_DAYS` (default: `180`)
- `SCHEDULE_MIN_FUTURE_SECONDS` (default: `60`)
- `SCHEDULE_DEFAULT_EXECUTE_HOUR_BRT` (default: `6`)
- `SCHEDULE_MAX_ATTEMPTS` (default: `2`)

Validado com `helm template` (as 6 chaves renderizam com seus defaults).

Requested by: Bruno