### PR TITLE
feat(charts): model br-ccs snapshot quarantine knobs as configmap keys

### DIFF
--- a/charts/br-ccs/templates/configmap.yaml
+++ b/charts/br-ccs/templates/configmap.yaml
@@ -292,6 +292,19 @@ data:
   {{- end }}
 
   # =====================================================================
+  # FETCHER SNAPSHOT QUARANTINE (optional — br-ccs-140 Phase 2)
+  # Opt-in: skip + classify invalid CRM records instead of aborting the
+  # whole batch, up to an invalid/total ceiling above which it fails HIGH.
+  # Unset = app defaults (disabled; ceiling 0.05). Render only when set so
+  # the chart never overrides the app's fail-closed default.
+  # =====================================================================
+  {{- range $k := (list "CCS_SNAPSHOT_QUARANTINE_INVALID_ENABLED" "CCS_SNAPSHOT_QUARANTINE_MAX_INVALID_RATIO") }}
+  {{- if index $cm $k }}
+  {{ $k }}: {{ index $cm $k | quote }}
+  {{- end }}
+  {{- end }}
+
+  # =====================================================================
   # READINESS PROBE + GRACEFUL SHUTDOWN
   # =====================================================================
   READYZ_PROBE_TIMEOUT_SEC: {{ $cm.READYZ_PROBE_TIMEOUT_SEC | default "5" | quote }}

--- a/charts/br-ccs/values.yaml
+++ b/charts/br-ccs/values.yaml
@@ -485,6 +485,17 @@ brCcs:
     # CCS_ACCS005_SECRECY_SITUACAO: "01"
 
     # =================================================================
+    # Fetcher snapshot quarantine (optional — br-ccs-140 Phase 2)
+    # Opt-in: skip + classify invalid CRM records instead of aborting the
+    # whole batch. MAX_INVALID_RATIO is the invalid/total ceiling in [0,1]
+    # above which the batch fails HIGH even with quarantine on. Unset keeps
+    # the app default (disabled; ceiling 0.05 / fail-closed). Enable only on
+    # ST test tiers that tolerate other users' invalid data.
+    # =================================================================
+    # CCS_SNAPSHOT_QUARANTINE_INVALID_ENABLED: "false"
+    # CCS_SNAPSHOT_QUARANTINE_MAX_INVALID_RATIO: "0.05"
+
+    # =================================================================
     # Pagination
     # =================================================================
     MAX_PAGINATION_LIMIT: "100"


### PR DESCRIPTION
## What

Models the br-ccs Fetcher snapshot quarantine knobs (br-ccs-140 Phase 2) as
first-class `brCcs.configmap` keys:

- `CCS_SNAPSHOT_QUARANTINE_INVALID_ENABLED`
- `CCS_SNAPSHOT_QUARANTINE_MAX_INVALID_RATIO`

Both are added to `templates/configmap.yaml` using the existing
render-only-if-set pattern (same as the `CCS_DETAIL_*` / `CCS_ACCS005_*`
knobs), plus documented commented-out defaults in `values.yaml`.

## Why

These knobs are currently deployed via the generic `brCcs.extraEnvVars`
escape hatch in the gitops repo. The escape hatch is meant for optional knobs
not modeled by the chart; now that quarantine is a real, permanent feature, it
should be a modeled key so it is documented and discoverable. This lets gitops
move the vars out of `extraEnvVars` and into `configmap:` once this chart is
released.

## Design

Rendered only when the operator sets them, so the chart never overrides the
application's fail-closed defaults (`Enabled=false`; ceiling `0.05`). Unset =
app default behaviour.

## Scope / release

- `Chart.yaml` version and `CHANGELOG.md` are intentionally untouched — the
  semantic-release bot owns versioning on this repo.
- PR scope is `charts` (reliably present in the pr-title allowlist on the base
  branch).

## Follow-up (not in this PR)

After this chart is released, update the gitops values (dev-st / stg-st) to
move the two vars from `extraEnvVars` to `configmap:`.
