### PR TITLE
feat(charts): add Helm chart for SISBAJUD plugin

### DIFF
--- a/charts/br-sisbajud/Chart.lock
+++ b/charts/br-sisbajud/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.3.5
+- name: valkey
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.4.7
+digest: sha256:52ff7322d903f193a03cdb12e017ea953e3f7c06cd6019216410086fef3bcd6b
+generated: "2026-07-15T15:30:23.52956-03:00"

--- a/charts/br-sisbajud/Chart.yaml
+++ b/charts/br-sisbajud/Chart.yaml
@@ -1,0 +1,46 @@
+apiVersion: v2
+name: br-sisbajud-helm
+description: A Helm chart for br-sisbajud — the Lerian SISBAJUD plugin (judicial asset blocking/unblocking integration with BACEN SISBAJUD)
+
+type: application
+annotations:
+  lerian.studio/chart-type: single-service
+
+home: https://github.com/LerianStudio/helm
+
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/br-sisbajud
+  - https://github.com/LerianStudio/br-sisbajud
+
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+
+version: 0.1.0-beta.1
+
+# NOTE: appVersion is the default image tag for the app and the migration Job.
+# Override via brSisbajud.image.tag when needed.
+appVersion: "0.1.0-beta.1"
+
+keywords:
+  - br-sisbajud
+  - sisbajud
+  - bacen
+  - judicial
+  - blocking
+  - lerian
+
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+
+# Bitnami subcharts are DECLARED (exact pins, condition-gated) so the chart can
+# optionally bundle infra, but they default to disabled: on the target
+# environments Postgres and Redis are EXTERNAL and pre-provisioned.
+dependencies:
+  - name: postgresql
+    version: "16.3.5"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: postgresql.enabled
+  - name: valkey
+    version: "2.4.7"
+    repository: "oci://registry-1.docker.io/bitnamicharts"
+    condition: valkey.enabled

--- a/charts/br-sisbajud/README.md
+++ b/charts/br-sisbajud/README.md
@@ -1,0 +1,35 @@
+# br-sisbajud Helm Chart
+
+Deploys **br-sisbajud** — the Lerian SISBAJUD plugin (judicial asset blocking/unblocking integration with BACEN SISBAJUD) — into Kubernetes. The service is a single Go binary running the HTTP API + background workers in one process.
+
+## Chart Contract
+
+- Chart type: `single-service`
+- Required secrets: **None for a default render.** For external Postgres (the default), provide `POSTGRES_PASSWORD` via `brSisbajud.secrets.POSTGRES_PASSWORD` or `brSisbajud.useExistingSecret`; on the target environments this is sourced from GitOps/Vault. `REDIS_PASSWORD` is needed when the external Redis requires auth. When the bundled `postgresql`/`valkey` subcharts are enabled instead, those passwords are **single-sourced** from the subchart Secrets (read at runtime via `secretKeyRef`) and are not stored in the app Secrets. No credential is ever placed in a ConfigMap. Optional keys added under `brSisbajud.secrets` are emitted only when set.
+- Dependency notes: Bundled `postgresql` (16.3.5) and `valkey` (2.4.7) Bitnami subcharts are **declared but disabled by default** — Postgres and Redis are external and pre-provisioned on the target environments. Kafka/Redpanda is external and referenced only by `STREAMING_BROKERS`. Enable the subcharts only for a self-contained install.
+- Production overrides: Set `brSisbajud.image.tag` (defaults to `Chart.appVersion`); `POSTGRES_HOST` and `POSTGRES_PASSWORD`; `REDIS_HOST`; `STREAMING_BROKERS` (a producer with `STREAMING_ENABLED=true` and empty `STREAMING_BROKERS` fails closed at boot by design); `KMS_PROVIDER` / `VAULT_ADDR` / `VAULT_AUTH_METHOD` / `VAULT_APPROLE_ROLE_ID` / `VAULT_APPROLE_SECRET_ID` for envelope encryption; `MIDAZ_BASE_URL` for the ledger connector; and `ingress`, `autoscaling`, and `resources` as needed. `useExistingSecret`/`existingSecretName` are supported for the app and the migration Job.
+- Source/license: Source is in `github.com/LerianStudio/helm`; chart license is Apache-2.0. The `br-sisbajud` service source is `github.com/LerianStudio/br-sisbajud`.
+
+## Configuration knobs (ConfigMap passthrough)
+
+`brSisbajud.configmap` is emitted verbatim into the ConfigMap — it is **not** a fixed allowlist. Any additional env can be added under `brSisbajud.configmap` without editing the chart. `POSTGRES_HOST` and `REDIS_HOST` are handled first-class by the template (the hosts derive from the bundled subchart when enabled). Secrets must go under `brSisbajud.secrets`, never `configmap`.
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `ENV_NAME` | `development` | App env; `development` relaxes production boot guards |
+| `SERVER_ADDRESS` | `0.0.0.0:4029` | host:port form (container port is 4029) |
+| `POSTGRES_{HOST,PORT,USER,NAME,SSLMODE}` | see values | External managed Postgres |
+| `REDIS_HOST` | `""` | host:port; required for rate limiting + idempotency |
+| `KMS_PROVIDER` | `vault` | Envelope encryption key manager |
+| `VAULT_ADDR` | `""` | Vault server address |
+| `VAULT_AUTH_METHOD` | `approle` | `token` or `approle` |
+| `VAULT_TRANSIT_MOUNT_PATH` | `transit-st` | Transit secrets-engine mount path |
+| `STREAMING_ENABLED` | `true` | fail-closed when brokers/source empty |
+| `STREAMING_BROKERS` | `""` | CSV; **required when streaming enabled** |
+| `STREAMING_CLOUDEVENTS_SOURCE` | `br-sisbajud` | CloudEvents source identifier |
+| `MIDAZ_BASE_URL` | `""` | Midaz ledger connector URL (required service-wide) |
+| `ENABLE_TELEMETRY` | `false` | when `true`, `OTEL_EXPORTER_OTLP_ENDPOINT` is set to `http://$(HOST_IP):4317` |
+
+## Detached migrations
+
+`migrations.enabled` (default `true`) ships an ArgoCD **PreSync** Secret (`hook-weight: -2`) + Job (`hook-weight: -1`) that runs `ghcr.io/lerianstudio/br-sisbajud-migrations`. That image applies the `golang-migrate` SQL migrations to the `br_sisbajud` database. The Job pod is hardened (non-root, read-only rootfs, drop ALL, no service-account token) and waits for Postgres via a `busybox` initContainer. Supports `migrations.useExistingSecret`/`existingSecretName`.

--- a/charts/br-sisbajud/templates/NOTES.txt
+++ b/charts/br-sisbajud/templates/NOTES.txt
@@ -1,0 +1,12 @@
+br-sisbajud (SISBAJUD plugin) has been deployed to namespace {{ include "global.namespace" . }}.
+
+Verify:
+  kubectl -n {{ include "global.namespace" . }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl -n {{ include "global.namespace" . }} get cm,secret -l app.kubernetes.io/instance={{ .Release.Name }}
+
+{{- if .Values.migrations.enabled }}
+
+Migrations: an ArgoCD PreSync Job ({{ include "br-sisbajud-migrations.fullname" . }})
+applies the SQL schema to the `br_sisbajud` database before the app boots.
+Under plain `helm install` (no ArgoCD) the PreSync hook Job still runs as a normal Job.
+{{- end }}

--- a/charts/br-sisbajud/templates/_helpers.tpl
+++ b/charts/br-sisbajud/templates/_helpers.tpl
@@ -1,0 +1,117 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "br-sisbajud.name" -}}
+{{- default "br-sisbajud" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars because some Kubernetes name fields are limited by the DNS spec.
+*/}}
+{{- define "br-sisbajud.fullname" -}}
+{{- default (include "br-sisbajud.name" .) .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "br-sisbajud.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Expand the namespace of the release. Overridable for multi-namespace layouts.
+*/}}
+{{- define "global.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Name of the service account to use.
+*/}}
+{{- define "br-sisbajud.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "br-sisbajud.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels (stable across image bumps).
+*/}}
+{{- define "br-sisbajud.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "br-sisbajud.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "br-sisbajud.labels" -}}
+helm.sh/chart: {{ include "br-sisbajud.chart" . }}
+{{ include "br-sisbajud.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Migrations fullname, e.g. br-sisbajud-migrations — Job and PreSync Secret reference this.
+*/}}
+{{- define "br-sisbajud-migrations.fullname" -}}
+{{- printf "%s-migrations" (include "br-sisbajud.fullname" . | trunc 52 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Migrations labels.
+*/}}
+{{- define "br-sisbajud-migrations.labels" -}}
+helm.sh/chart: {{ include "br-sisbajud.chart" . }}
+app.kubernetes.io/name: {{ include "br-sisbajud-migrations.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: migrations
+{{- end }}
+
+{{/*
+infraSecretRef — emit a `- name: <envName> valueFrom: secretKeyRef: {name,key}`
+env entry pointing at a Bitnami subchart's generated Secret (or the operator's
+existingSecret override). Only used on the bundled-subchart path; the external
+path reads the app's own Secret.
+Inputs (dict): context (root .), subchart, key, envName.
+*/}}
+{{- define "br-sisbajud.infraSecretRef" -}}
+{{- $ctx := .context -}}
+{{- $sub := .subchart -}}
+{{- $auth := default dict (index $ctx.Values $sub "auth") -}}
+{{- $secretName := "" -}}
+{{- if $auth.existingSecret -}}
+{{- $secretName = $auth.existingSecret -}}
+{{- else -}}
+{{- $secretName = include "common.names.dependency.fullname" (dict "chartName" $sub "chartValues" (index $ctx.Values $sub) "context" $ctx) -}}
+{{- end -}}
+- name: {{ .envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: {{ .key }}
+{{- end }}
+
+{{/*
+Vendored from Bitnami common (charts/common/templates/_names.tpl) so infra
+Secret/Service names render even when all bundled subcharts are disabled
+(external-infra path). Self-contained: no other common.* helpers required.
+*/}}
+{{- define "common.names.dependency.fullname" -}}
+{{- if .chartValues.fullnameOverride -}}
+{{- .chartValues.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .chartName .chartValues.nameOverride -}}
+{{- if contains $name .context.Release.Name -}}
+{{- .context.Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .context.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/br-sisbajud/templates/configmap.yaml
+++ b/charts/br-sisbajud/templates/configmap.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.brSisbajud.enabled -}}
+{{- $pgHost := .Values.brSisbajud.configmap.POSTGRES_HOST -}}
+{{- if and (not $pgHost) (ne (toString .Values.postgresql.enabled) "false") -}}
+{{-   $pgHost = printf "%s.%s.svc.cluster.local." (include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" .)) (include "global.namespace" .) -}}
+{{- end -}}
+{{- $redisHost := .Values.brSisbajud.configmap.REDIS_HOST -}}
+{{- if and (not $redisHost) (ne (toString .Values.valkey.enabled) "false") -}}
+{{-   $redisHost = printf "%s-primary.%s.svc.cluster.local.:6379" (include "common.names.dependency.fullname" (dict "chartName" "valkey" "chartValues" .Values.valkey "context" .)) (include "global.namespace" .) -}}
+{{- end }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "br-sisbajud.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+data:
+  POSTGRES_HOST: {{ $pgHost | default "" | quote }}
+  REDIS_HOST: {{ $redisHost | default "" | quote }}
+  {{- range $k, $v := .Values.brSisbajud.configmap }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end -}}

--- a/charts/br-sisbajud/templates/configmap.yaml
+++ b/charts/br-sisbajud/templates/configmap.yaml
@@ -7,6 +7,7 @@
 {{- if and (not $redisHost) (ne (toString .Values.valkey.enabled) "false") -}}
 {{-   $redisHost = printf "%s-primary.%s.svc.cluster.local.:6379" (include "common.names.dependency.fullname" (dict "chartName" "valkey" "chartValues" .Values.valkey "context" .)) (include "global.namespace" .) -}}
 {{- end }}
+{{- $reserved := list "POSTGRES_HOST" "REDIS_HOST" }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -18,6 +19,8 @@ data:
   POSTGRES_HOST: {{ $pgHost | default "" | quote }}
   REDIS_HOST: {{ $redisHost | default "" | quote }}
   {{- range $k, $v := .Values.brSisbajud.configmap }}
+  {{- if not (has $k $reserved) }}
   {{ $k }}: {{ $v | quote }}
+  {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/br-sisbajud/templates/deployment.yaml
+++ b/charts/br-sisbajud/templates/deployment.yaml
@@ -1,0 +1,158 @@
+{{- if .Values.brSisbajud.enabled -}}
+{{- $fullname := include "br-sisbajud.fullname" . -}}
+{{- if and .Values.brSisbajud.useExistingSecret (not .Values.brSisbajud.existingSecretName) -}}
+{{- fail (printf "br-sisbajud: existingSecretName must be set when useExistingSecret is true") -}}
+{{- end -}}
+{{- $secretName := ternary .Values.brSisbajud.existingSecretName $fullname .Values.brSisbajud.useExistingSecret -}}
+{{- $pullSecrets := .Values.brSisbajud.imagePullSecrets | default .Values.imagePullSecrets -}}
+{{- $telemetry := eq (toString .Values.brSisbajud.configmap.ENABLE_TELEMETRY) "true" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .Values.brSisbajud.revisionHistoryLimit | default 10 }}
+  {{- if not .Values.brSisbajud.autoscaling.enabled }}
+  replicas: {{ .Values.brSisbajud.replicaCount | default 1 }}
+  {{- end }}
+  strategy:
+    type: {{ .Values.brSisbajud.deploymentUpdate.type | default "RollingUpdate" }}
+    {{- if eq (.Values.brSisbajud.deploymentUpdate.type | default "RollingUpdate") "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.brSisbajud.deploymentUpdate.maxSurge | default "100%" }}
+      maxUnavailable: {{ .Values.brSisbajud.deploymentUpdate.maxUnavailable | default 0 }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "br-sisbajud.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.brSisbajud.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "br-sisbajud.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "br-sisbajud.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-dependencies
+          image: {{ .Values.brSisbajud.waitImage | default "busybox" }}
+          envFrom:
+            - configMapRef:
+                name: {{ $fullname }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              if [ -n "$POSTGRES_HOST" ]; then
+                echo "waiting for postgres $POSTGRES_HOST:${POSTGRES_PORT:-5432}...";
+                until nc -z "$POSTGRES_HOST" "${POSTGRES_PORT:-5432}"; do
+                  echo "postgres not ready, waiting..."; sleep 5;
+                done;
+                echo "postgres is ready";
+              fi;
+              if [ -n "$REDIS_HOST" ]; then
+                RH=$(echo "$REDIS_HOST" | cut -d: -f1);
+                RP=$(echo "$REDIS_HOST" | cut -d: -f2);
+                [ -z "$RP" ] && RP=6379;
+                echo "waiting for redis $RH:$RP...";
+                until nc -z "$RH" "$RP"; do
+                  echo "redis not ready, waiting..."; sleep 5;
+                done;
+                echo "redis is ready";
+              fi;
+              echo "dependencies ready"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: {{ $fullname }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.brSisbajud.image.repository }}:{{ .Values.brSisbajud.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.brSisbajud.image.pullPolicy | default "IfNotPresent" }}
+          envFrom:
+            - secretRef:
+                name: {{ $secretName }}
+            - configMapRef:
+                name: {{ $fullname }}
+          env:
+            {{- $pg := .Values.postgresql | default dict }}
+            {{- $pgAuth := $pg.auth | default dict }}
+            {{- if or (and (ne (toString $pg.enabled) "false") (not $pg.external)) $pgAuth.existingSecret }}
+            {{- include "br-sisbajud.infraSecretRef" (dict "context" . "subchart" "postgresql" "key" "password" "envName" "POSTGRES_PASSWORD") | nindent 12 }}
+            {{- else if .Values.brSisbajud.secrets.POSTGRES_PASSWORD }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_PASSWORD
+            {{- end }}
+            {{- $vk := .Values.valkey | default dict }}
+            {{- $vkAuth := $vk.auth | default dict }}
+            {{- if or (and (ne (toString $vk.enabled) "false") (not $vk.external) $vkAuth.enabled) $vkAuth.existingSecret }}
+            {{- include "br-sisbajud.infraSecretRef" (dict "context" . "subchart" "valkey" "key" "valkey-password" "envName" "REDIS_PASSWORD") | nindent 12 }}
+            {{- else if .Values.brSisbajud.secrets.REDIS_PASSWORD }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: REDIS_PASSWORD
+            {{- end }}
+            {{- if $telemetry }}
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://$(HOST_IP):4317"
+            {{- end }}
+            {{- with .Values.brSisbajud.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.brSisbajud.service.port | default 4029 }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.brSisbajud.livenessProbe.path | default "/health" }}
+              port: http
+            initialDelaySeconds: {{ .Values.brSisbajud.livenessProbe.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ .Values.brSisbajud.livenessProbe.periodSeconds | default 20 }}
+            timeoutSeconds: {{ .Values.brSisbajud.livenessProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ .Values.brSisbajud.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.brSisbajud.livenessProbe.failureThreshold | default 3 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.brSisbajud.readinessProbe.path | default "/readyz" }}
+              port: http
+            initialDelaySeconds: {{ .Values.brSisbajud.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.brSisbajud.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.brSisbajud.readinessProbe.timeoutSeconds | default 5 }}
+            successThreshold: {{ .Values.brSisbajud.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.brSisbajud.readinessProbe.failureThreshold | default 3 }}
+          resources:
+            {{- toYaml .Values.brSisbajud.resources | nindent 12 }}
+      {{- with .Values.brSisbajud.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.brSisbajud.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.brSisbajud.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/charts/br-sisbajud/templates/deployment.yaml
+++ b/charts/br-sisbajud/templates/deployment.yaml
@@ -42,11 +42,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "br-sisbajud.serviceAccountName" . }}
+      automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-dependencies
-          image: {{ .Values.brSisbajud.waitImage | default "busybox" }}
+          image: {{ .Values.brSisbajud.waitImage | default "busybox:1.36" }}
           envFrom:
             - configMapRef:
                 name: {{ $fullname }}

--- a/charts/br-sisbajud/templates/hpa.yaml
+++ b/charts/br-sisbajud/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.brSisbajud.enabled .Values.brSisbajud.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "br-sisbajud.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "br-sisbajud.fullname" . }}
+  minReplicas: {{ .Values.brSisbajud.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.brSisbajud.autoscaling.maxReplicas | default 3 }}
+  metrics:
+    {{- with .Values.brSisbajud.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.brSisbajud.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end -}}

--- a/charts/br-sisbajud/templates/ingress.yaml
+++ b/charts/br-sisbajud/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.brSisbajud.enabled .Values.brSisbajud.ingress.enabled -}}
+{{- $svcName := include "br-sisbajud.fullname" . -}}
+{{- $svcPort := .Values.brSisbajud.service.port | default 4029 -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $svcName }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+  {{- with .Values.brSisbajud.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.brSisbajud.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.brSisbajud.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.brSisbajud.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end -}}

--- a/charts/br-sisbajud/templates/migrations/job.yaml
+++ b/charts/br-sisbajud/templates/migrations/job.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.migrations.enabled }}
+# PreSync migration Job. Runs the dedicated br-sisbajud-migrations image, whose
+# entrypoint applies the golang-migrate SQL migrations against the br_sisbajud
+# database. hook-weight -1 puts this after the PreSync Secret (-2) and before
+# the main-sync Deployment, so the app never boots unmigrated.
+{{- $pgHost := .Values.migrations.postgres.host | default .Values.brSisbajud.configmap.POSTGRES_HOST -}}
+{{- if and (not $pgHost) (ne (toString .Values.postgresql.enabled) "false") -}}
+{{-   $pgHost = printf "%s.%s.svc.cluster.local." (include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" .)) (include "global.namespace" .) -}}
+{{- end }}
+{{- $pgPort := .Values.migrations.postgres.port | default .Values.brSisbajud.configmap.POSTGRES_PORT | default "5432" }}
+{{- $pgUser := .Values.migrations.postgres.user | default .Values.brSisbajud.configmap.POSTGRES_USER | default "br_sisbajud" }}
+{{- $pgDb := .Values.migrations.postgres.database | default .Values.brSisbajud.configmap.POSTGRES_NAME | default "br_sisbajud" }}
+{{- $pgSslMode := .Values.migrations.postgres.sslMode | default .Values.brSisbajud.configmap.POSTGRES_SSLMODE | default "disable" }}
+{{- $secretName := ternary .Values.migrations.existingSecretName (include "br-sisbajud-migrations.fullname" .) .Values.migrations.useExistingSecret }}
+{{- $pullSecrets := .Values.migrations.imagePullSecrets | default .Values.imagePullSecrets }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "br-sisbajud-migrations.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud-migrations.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds | default 600 }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished | default 600 }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-sisbajud-migrations.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ .Values.migrations.waitImage | default "busybox" }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              echo "waiting for {{ $pgHost }}:{{ $pgPort }}...";
+              until nc -z {{ $pgHost }} {{ $pgPort }}; do
+                echo "{{ $pgHost }}:{{ $pgPort }} not ready, waiting..."; sleep 5;
+              done;
+              echo "{{ $pgHost }}:{{ $pgPort }} is ready"
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: migrations
+          image: "{{ .Values.migrations.image.repository }}:{{ .Values.migrations.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.migrations.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: POSTGRES_HOST
+              value: {{ $pgHost | quote }}
+            - name: POSTGRES_PORT
+              value: {{ $pgPort | quote }}
+            - name: POSTGRES_USER
+              value: {{ $pgUser | quote }}
+            - name: POSTGRES_DB
+              value: {{ $pgDb | quote }}
+            - name: POSTGRES_SSLMODE
+              value: {{ $pgSslMode | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_PASSWORD
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+{{- end }}

--- a/charts/br-sisbajud/templates/migrations/job.yaml
+++ b/charts/br-sisbajud/templates/migrations/job.yaml
@@ -11,6 +11,9 @@
 {{- $pgUser := .Values.migrations.postgres.user | default .Values.brSisbajud.configmap.POSTGRES_USER | default "br_sisbajud" }}
 {{- $pgDb := .Values.migrations.postgres.database | default .Values.brSisbajud.configmap.POSTGRES_NAME | default "br_sisbajud" }}
 {{- $pgSslMode := .Values.migrations.postgres.sslMode | default .Values.brSisbajud.configmap.POSTGRES_SSLMODE | default "disable" }}
+{{- if and .Values.migrations.useExistingSecret (not .Values.migrations.existingSecretName) -}}
+{{- fail "migrations.existingSecretName is required when migrations.useExistingSecret is true" -}}
+{{- end -}}
 {{- $secretName := ternary .Values.migrations.existingSecretName (include "br-sisbajud-migrations.fullname" .) .Values.migrations.useExistingSecret }}
 {{- $pullSecrets := .Values.migrations.imagePullSecrets | default .Values.imagePullSecrets }}
 apiVersion: batch/v1
@@ -44,7 +47,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-postgres
-          image: {{ .Values.migrations.waitImage | default "busybox" }}
+          image: {{ .Values.migrations.waitImage | default "busybox:1.36" }}
           command:
             - /bin/sh
             - -c

--- a/charts/br-sisbajud/templates/migrations/secrets.yaml
+++ b/charts/br-sisbajud/templates/migrations/secrets.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.migrations.enabled (not .Values.migrations.useExistingSecret) }}
+# Dedicated PreSync Secret carrying only the Postgres password for the migration
+# Job. PreSync hooks run BEFORE the main sync wave, so on a first install the
+# app Secret does not exist yet. This hook Secret (weight -2) is created before
+# the migration Job (weight -1). hook-delete-policy is BeforeHookCreation ONLY
+# (not HookSucceeded) so it survives the whole PreSync phase for the Job to read.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-sisbajud-migrations.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud-migrations.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-2"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ .Values.migrations.postgres.password | default .Values.brSisbajud.secrets.POSTGRES_PASSWORD | quote }}
+{{- end }}

--- a/charts/br-sisbajud/templates/pdb.yaml
+++ b/charts/br-sisbajud/templates/pdb.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.brSisbajud.pdb.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.brSisbajud.pdb.maxUnavailable) }}
   maxUnavailable: {{ .Values.brSisbajud.pdb.maxUnavailable }}
   {{- else }}
   minAvailable: {{ .Values.brSisbajud.pdb.minAvailable | default 1 }}

--- a/charts/br-sisbajud/templates/pdb.yaml
+++ b/charts/br-sisbajud/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.brSisbajud.enabled .Values.brSisbajud.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "br-sisbajud.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+  {{- with .Values.brSisbajud.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.brSisbajud.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.brSisbajud.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.brSisbajud.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "br-sisbajud.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/charts/br-sisbajud/templates/secrets.yaml
+++ b/charts/br-sisbajud/templates/secrets.yaml
@@ -13,16 +13,16 @@ metadata:
   labels:
     {{- include "br-sisbajud.labels" . | nindent 4 }}
 type: Opaque
-data:
+stringData:
   {{- if and (not $pgInternal) (not $pgAuth.existingSecret) .Values.brSisbajud.secrets.POSTGRES_PASSWORD }}
-  POSTGRES_PASSWORD: {{ .Values.brSisbajud.secrets.POSTGRES_PASSWORD | b64enc | quote }}
+  POSTGRES_PASSWORD: {{ .Values.brSisbajud.secrets.POSTGRES_PASSWORD | quote }}
   {{- end }}
   {{- if and (not $vkInternal) (not $vkAuth.existingSecret) .Values.brSisbajud.secrets.REDIS_PASSWORD }}
-  REDIS_PASSWORD: {{ .Values.brSisbajud.secrets.REDIS_PASSWORD | b64enc | quote }}
+  REDIS_PASSWORD: {{ .Values.brSisbajud.secrets.REDIS_PASSWORD | quote }}
   {{- end }}
   {{- range $k, $v := .Values.brSisbajud.secrets }}
   {{- if and (not (has $k (list "POSTGRES_PASSWORD" "REDIS_PASSWORD"))) $v }}
-  {{ $k }}: {{ $v | b64enc | quote }}
+  {{ $k }}: {{ $v | quote }}
   {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/br-sisbajud/templates/secrets.yaml
+++ b/charts/br-sisbajud/templates/secrets.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.brSisbajud.enabled (not .Values.brSisbajud.useExistingSecret) -}}
+{{- $pg := .Values.postgresql | default dict -}}
+{{- $pgAuth := $pg.auth | default dict -}}
+{{- $pgInternal := and (ne (toString $pg.enabled) "false") (not $pg.external) -}}
+{{- $vk := .Values.valkey | default dict -}}
+{{- $vkAuth := $vk.auth | default dict -}}
+{{- $vkInternal := and (ne (toString $vk.enabled) "false") (not $vk.external) $vkAuth.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-sisbajud.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if and (not $pgInternal) (not $pgAuth.existingSecret) .Values.brSisbajud.secrets.POSTGRES_PASSWORD }}
+  POSTGRES_PASSWORD: {{ .Values.brSisbajud.secrets.POSTGRES_PASSWORD | b64enc | quote }}
+  {{- end }}
+  {{- if and (not $vkInternal) (not $vkAuth.existingSecret) .Values.brSisbajud.secrets.REDIS_PASSWORD }}
+  REDIS_PASSWORD: {{ .Values.brSisbajud.secrets.REDIS_PASSWORD | b64enc | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.brSisbajud.secrets }}
+  {{- if and (not (has $k (list "POSTGRES_PASSWORD" "REDIS_PASSWORD"))) $v }}
+  {{ $k }}: {{ $v | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/br-sisbajud/templates/service.yaml
+++ b/charts/br-sisbajud/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.brSisbajud.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "br-sisbajud.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+  {{- with .Values.brSisbajud.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.brSisbajud.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ .Values.brSisbajud.service.port | default 4029 }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "br-sisbajud.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/br-sisbajud/templates/serviceaccount.yaml
+++ b/charts/br-sisbajud/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "br-sisbajud.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/br-sisbajud/values-template.yaml
+++ b/charts/br-sisbajud/values-template.yaml
@@ -20,7 +20,6 @@ brSisbajud:
     VAULT_ADDR: ""               # REQUIRED — Vault address
     VAULT_AUTH_METHOD: "approle"
     VAULT_TRANSIT_MOUNT_PATH: "transit-st"
-    SECRET_STORE_PROVIDER: "local"
     STREAMING_ENABLED: "true"
     STREAMING_BROKERS: ""        # REQUIRED when STREAMING_ENABLED=true
     STREAMING_CLOUDEVENTS_SOURCE: "br-sisbajud"
@@ -28,6 +27,7 @@ brSisbajud:
   secrets:
     POSTGRES_PASSWORD: ""        # REQUIRED for external Postgres
     REDIS_PASSWORD: ""           # set if the external Redis requires auth
+    SECRET_STORE_PROVIDER: "local"  # vault | aws-secrets-manager | local
   extraEnvVars:
     - name: VAULT_APPROLE_ROLE_ID
       value: ""                  # REQUIRED when VAULT_AUTH_METHOD=approle

--- a/charts/br-sisbajud/values-template.yaml
+++ b/charts/br-sisbajud/values-template.yaml
@@ -1,0 +1,50 @@
+# Template values for the br-sisbajud (SISBAJUD plugin) chart.
+# Copy this file and fill in the values for your environment. Postgres and Redis
+# are external on the target environments — point the service at the shared
+# managed instances.
+
+imagePullSecrets:
+  - name: ghcr-credential
+
+brSisbajud:
+  image:
+    tag: ""  # optional — defaults to Chart.appVersion
+  configmap:
+    ENV_NAME: "development"
+    POSTGRES_HOST: ""             # REQUIRED — managed Postgres host
+    POSTGRES_USER: "br_sisbajud"
+    POSTGRES_NAME: "br_sisbajud"
+    POSTGRES_SSLMODE: "disable"
+    REDIS_HOST: ""               # REQUIRED — managed Valkey host:port
+    KMS_PROVIDER: "vault"
+    VAULT_ADDR: ""               # REQUIRED — Vault address
+    VAULT_AUTH_METHOD: "approle"
+    VAULT_TRANSIT_MOUNT_PATH: "transit-st"
+    SECRET_STORE_PROVIDER: "local"
+    STREAMING_ENABLED: "true"
+    STREAMING_BROKERS: ""        # REQUIRED when STREAMING_ENABLED=true
+    STREAMING_CLOUDEVENTS_SOURCE: "br-sisbajud"
+    MIDAZ_BASE_URL: ""           # REQUIRED — Midaz ledger URL
+  secrets:
+    POSTGRES_PASSWORD: ""        # REQUIRED for external Postgres
+    REDIS_PASSWORD: ""           # set if the external Redis requires auth
+  extraEnvVars:
+    - name: VAULT_APPROLE_ROLE_ID
+      value: ""                  # REQUIRED when VAULT_AUTH_METHOD=approle
+    - name: VAULT_APPROLE_SECRET_ID
+      value: ""                  # REQUIRED when VAULT_AUTH_METHOD=approle
+
+migrations:
+  enabled: true
+  postgres:
+    host: ""                     # defaults to brSisbajud.configmap.POSTGRES_HOST
+    password: ""                 # defaults to brSisbajud.secrets.POSTGRES_PASSWORD
+
+# External infra (default). Enable only for a self-contained install.
+postgresql:
+  enabled: false
+  external: true
+
+valkey:
+  enabled: false
+  external: true

--- a/charts/br-sisbajud/values.schema.json
+++ b/charts/br-sisbajud/values.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "brSisbajud": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "migrations": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "postgresql": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "valkey": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/charts/br-sisbajud/values.yaml
+++ b/charts/br-sisbajud/values.yaml
@@ -1,0 +1,169 @@
+# Default values for the br-sisbajud (SISBAJUD plugin) chart.
+# Single-service chart: one Go binary (HTTP API + background workers in one
+# process). The configmap map is emitted VERBATIM into the ConfigMap (not a
+# fixed allowlist), so any extra env can be added under brSisbajud.configmap
+# without a chart change.
+nameOverride: "br-sisbajud"
+fullnameOverride: ""
+namespaceOverride: ""
+
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
+# -- Default pull secret for the app + migration Job (single GHCR credential).
+imagePullSecrets:
+  - name: ghcr-credential
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# -- Pod-level security context
+podSecurityContext: {}
+
+# -- Container security context (distroless static-debian12:nonroot — UID/GID 65532)
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# =============================================================================
+# brSisbajud — the single SISBAJUD service component.
+# =============================================================================
+brSisbajud:
+  enabled: true
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-sisbajud
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  waitImage: busybox
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 1
+  service:
+    type: ClusterIP
+    # Matches the Dockerfile EXPOSE 4029 and SERVER_ADDRESS=:4029.
+    port: 4029
+    annotations: {}
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+  pdb:
+    enabled: true
+    minAvailable: 0
+    maxUnavailable: 1
+    annotations: {}
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  livenessProbe:
+    path: /health
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  readinessProbe:
+    path: /readyz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  nodeSelector: {}
+  tolerations: {}
+  affinity: {}
+  # -- ConfigMap entries emitted verbatim into the ConfigMap.
+  configmap:
+    ENV_NAME: "development"
+    SERVER_ADDRESS: "0.0.0.0:4029"
+    LOG_LEVEL: "info"
+  # -- Secrets emitted into the app Secret (base64-encoded by the template).
+  # Use AVP <path:...> placeholders in GitOps values, never real credentials.
+  secrets:
+    POSTGRES_PASSWORD: ""
+    REDIS_PASSWORD: ""
+  # -- Use an operator-provided Secret instead of the chart-managed one.
+  useExistingSecret: false
+  existingSecretName: ""
+  # -- Extra env vars rendered as explicit `env:` entries on the pod.
+  extraEnvVars: []
+
+# =============================================================================
+# Detached migrations — ArgoCD PreSync Secret + Job that applies the SQL schema
+# to the br_sisbajud database before the app boots. The br-sisbajud-migrations
+# image runs golang-migrate against the /migrations directory.
+# =============================================================================
+migrations:
+  enabled: true
+  image:
+    repository: ghcr.io/lerianstudio/br-sisbajud-migrations
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  waitImage: busybox
+  useExistingSecret: false
+  existingSecretName: ""
+  # -- Postgres connection for the migration Job. Empty fields fall back to
+  # brSisbajud.configmap / brSisbajud.secrets values.
+  postgres:
+    host: ""
+    port: ""
+    user: ""
+    database: ""
+    sslMode: ""
+    password: ""
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 600
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+# =============================================================================
+# Bundled infra subcharts — DISABLED by default. On the target environments
+# Postgres and Redis are external and pre-provisioned; wire hosts via
+# brSisbajud.configmap.POSTGRES_HOST / REDIS_HOST. Enable these only for a
+# self-contained install.
+# =============================================================================
+postgresql:
+  enabled: false
+  external: true
+
+valkey:
+  enabled: false
+  external: true

--- a/charts/br-sisbajud/values.yaml
+++ b/charts/br-sisbajud/values.yaml
@@ -78,7 +78,9 @@ brSisbajud:
   pdb:
     enabled: true
     minAvailable: 0
-    maxUnavailable: 1
+    # maxUnavailable is intentionally unset so minAvailable takes effect.
+    # Set to an integer (including 0) to switch to maxUnavailable mode.
+    # maxUnavailable: 1
     annotations: {}
   resources:
     requests:

--- a/charts/br-sisbajud/values.yaml
+++ b/charts/br-sisbajud/values.yaml
@@ -49,7 +49,7 @@ brSisbajud:
     pullPolicy: IfNotPresent
   imagePullSecrets: []
   podAnnotations: {}
-  waitImage: busybox
+  waitImage: busybox:1.36
   deploymentUpdate:
     type: RollingUpdate
     maxSurge: 1
@@ -134,7 +134,7 @@ migrations:
     tag: ""
     pullPolicy: IfNotPresent
   imagePullSecrets: []
-  waitImage: busybox
+  waitImage: busybox:1.36
   useExistingSecret: false
   existingSecretName: ""
   # -- Postgres connection for the migration Job. Empty fields fall back to


### PR DESCRIPTION
## Summary

Add a `single-service` Helm chart for **br-sisbajud** (judicial asset blocking/unblocking integration with BACEN SISBAJUD), following the [helm-chart-standard](https://github.com/LerianStudio/helm/blob/main/docs/helm-chart-standard.md) conventions and modeled after the `br-spi` chart.

## Files added

| File | Purpose |
|------|---------|
| `Chart.yaml` | `br-sisbajud-helm` v0.1.0-beta.1, appVersion 0.1.0-beta.1, `single-service` type, Bitnami postgresql 16.3.5 + valkey 2.4.7 (condition-gated, disabled by default) |
| `Chart.lock` | Dependency lock file |
| `templates/_helpers.tpl` | Name/fullname/labels helpers, `infraSecretRef`, vendored Bitnami `common.names.dependency.fullname` |
| `templates/serviceaccount.yaml` | Shared ServiceAccount |
| `templates/configmap.yaml` | ConfigMap with first-class POSTGRES_HOST/REDIS_HOST derivation + verbatim passthrough |
| `templates/secrets.yaml` | Opaque Secret using `stringData` (matching migrations Secret) with single-source infra password handling |
| `templates/deployment.yaml` | Deployment with initContainer dependency wait, envFrom Secret+ConfigMap, discrete secretKeyRef for infra passwords, OTEL hostIP injection, probes on /health + /readyz, containerPort 4029 |
| `templates/service.yaml` | ClusterIP Service on port 4029 |
| `templates/ingress.yaml` | Optional Ingress |
| `templates/hpa.yaml` | Optional HPA |
| `templates/pdb.yaml` | PodDisruptionBudget |
| `templates/migrations/secrets.yaml` | PreSync Secret (hook-weight -2) for migration Job |
| `templates/migrations/job.yaml` | PreSync Job (hook-weight -1) running br-sisbajud-migrations image with busybox wait-for-postgres initContainer |
| `templates/NOTES.txt` | Post-install notes |
| `values.yaml` | Full defaults: distroless nonroot (UID 65532), port 4029, disabled bundled subcharts |
| `values-template.yaml` | Operator template with required fields marked |
| `values.schema.json` | Closed-root schema (generated shape) |
| `README.md` | Chart Contract block + configuration knobs table |

## Key design decisions

- **`single-service` chart type** — br-sisbajud is one Go binary (HTTP API + background workers in one process), not multi-component like br-spi.
- **Service port 4029** — matches the Dockerfile `EXPOSE 4029` and `SERVER_ADDRESS=:4029`.
- **Distroless nonroot UID 65532** — matches the app's `gcr.io/distroless/static-debian12:nonroot` base.
- **`stringData` in secrets.yaml** — so AVP `<path:...>` placeholders are resolved as plaintext (no double base64 encoding), matching the migrations Secret template.
- **Detached migrations** — ArgoCD PreSync Secret (weight -2) + Job (weight -1) running `ghcr.io/lerianstudio/br-sisbajud-migrations`, following the br-spi/br-sta pattern. The migrations image is published in the same release pipeline as the app (see [br-sisbajud PR #153](https://github.com/LerianStudio/br-sisbajud/pull/153)).
- **Bitnami subcharts disabled by default** — Postgres and Redis are external on target environments; wire hosts via `brSisbajud.configmap`.

## Validation

- `helm template` renders all 8 resources correctly (PDB, SA, migration Secret, app Secret, ConfigMap, Service, Deployment, migration Job).
- `helm dependency update` pulls and pins Bitnami postgresql 16.3.5 + valkey 2.4.7.
- Chart structure follows the single-service tree from the helm-chart-standard.

X-Lerian-Ref: 0x1