### PR TITLE
docs(plugins): add README section + correct appVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,14 @@ For implementation and configuration details, see the [README](https://charts.le
 | :---: | :---: |
 | `1.0.0-beta.4` | 0.1.0 |
 -----------------
+
+### BR SISBAJUD
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/br-sisbajud).
+
+#### Application Version Mapping
+
+| Chart Version | App Version | Migrations Version |
+| :---: | :---: | :---: |
+| `0.1.0-beta.1` | `0.1.0-beta.1` | `0.1.0-beta.1` |
+-----------------

--- a/README.md
+++ b/README.md
@@ -260,5 +260,5 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version | Migrations Version |
 | :---: | :---: | :---: |
-| `0.1.0-beta.1` | `0.1.0-beta.1` | `0.1.0-beta.1` |
+| `0.1.0-beta.1` | `1.0.0-beta.109` | `1.0.0-beta.109` |
 -----------------

--- a/charts/br-sisbajud/Chart.yaml
+++ b/charts/br-sisbajud/Chart.yaml
@@ -20,7 +20,7 @@ version: 0.1.0-beta.1
 
 # NOTE: appVersion is the default image tag for the app and the migration Job.
 # Override via brSisbajud.image.tag when needed.
-appVersion: "0.1.0-beta.1"
+appVersion: "1.0.0-beta.109"
 
 keywords:
   - br-sisbajud


### PR DESCRIPTION
## Summary

Follow-up to the merged PR #1656 that added the br-sisbajud Helm chart.

## Changes

1. **README.md** — add BR SISBAJUD section with chart version mapping table (chart 0.1.0-beta.1, app 1.0.0-beta.109, migrations 1.0.0-beta.109).
2. **Chart.yaml** — correct appVersion from placeholder `0.1.0-beta.1` to the real latest tag `1.0.0-beta.109` (br-sisbajud's latest git tag is v1.0.0-beta.109).

X-Lerian-Ref: 0x1