### PR TITLE
docs(charts): add BR SLC section to README version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,3 +297,14 @@ For implementation and configuration details, see the [README](https://charts.le
 | :---: | :---: |
 | `1.0.0-beta.2` | 1.0.0 |
 -----------------
+
+### BR SLC
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/br-slc).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `1.0.0-beta.1` | 0.1.0 |
+-----------------


### PR DESCRIPTION
## Problema

O job de release do chart **br-slc** falhou no run [#29526734020](https://github.com/LerianStudio/helm/actions/runs/29526734020/job/87716939703) (merge da PR #1640 na \`develop\`).

O step \`prepare\` do \`@semantic-release/exec\` executa:

\`\`\`
./.github/scripts/update-chart-version-readme-bin --chart br-slc --version 1.0.0-beta.1
\`\`\`

Esse binário normaliza o nome do chart (\`br-slc\` → \`br slc\`) e procura um heading \`### \` que contenha essa string na *version matrix* do README (\`tableutil.ParseTableForChart\`). Não existia seção correspondente, então:

\`\`\`
WARNING: Could not find section for chart 'br-slc'
ERROR: Could not find version matrix table in README.md
Error: Command failed with exit code 1
\`\`\`

O exit code ≠ 0 abortou o \`semantic-release\` **antes** do publish. Nenhuma tag e nenhum package OCI (\`ghcr.io/lerianstudio/br-slc-helm\`) foram gerados — ou seja, **a versão beta não chegou a ser publicada**.

## Correção

Adiciona a seção \`### BR SLC\` com a tabela *Application Version Mapping*, seguindo o mesmo padrão das demais seções (BR STA, Br Ccs).

## Validação

Build + execução local do próprio tool do CI contra o README corrigido:

\`\`\`
Found section for chart 'br-slc' at line 300: ### BR SLC
Found table at lines 306-309
Updated first row: Chart Version = \`1.0.0-beta.1\`
Successfully updated README.md
EXIT=0
\`\`\`

(o warning \`Could not find app.image.tag\` é esperado — \`image.tag\` está vazio no values.yaml e defaulta pro \`appVersion\` — e é não-fatal.)

Após o merge na \`develop\`, o release do br-slc deve concluir e publicar \`1.0.0-beta.1\`.