### PR TITLE
docs(charts): document br-slc OCI install location

### DIFF
--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -335,6 +335,14 @@ because the IBM MQ C client (libmqm) needs a writable `/var/mqm` (mounted as
 an explicit `emptyDir`); it stays non-root, no privilege escalation, all
 capabilities dropped, `RuntimeDefault` seccomp. Service is `ClusterIP` only.
 
+## Installation
+
+The chart is published as an OCI artifact to GitHub Container Registry:
+
+```bash
+helm install my-release oci://ghcr.io/lerianstudio/br-slc-helm --version <chart-version>
+```
+
 ## Port-forward (no Ingress)
 
 ```bash


### PR DESCRIPTION
## Objetivo

Disparar o primeiro release do chart **br-slc** (`1.0.0-beta.1`), que nunca chegou a rodar.

## Contexto

- O run original ([#29526734020](https://github.com/LerianStudio/helm/actions/runs/29526734020)) falhou no passo `update-chart-version-readme-bin` porque faltava a seção `### BR SLC` na matriz de versões do README raiz. Isso foi corrigido em #1664 (já na `develop`).
- Porém o release do br-slc **nunca re-disparou**: o workflow `Helm Release` tem `paths-ignore: [README.md, ...]`, e a #1664 só mexeu no README da raiz → o workflow foi ignorado.

## Mudança

Adiciona uma seção **Installation** ao `charts/br-slc/README.md` documentando o path do artefato OCI (`oci://ghcr.io/lerianstudio/br-slc-helm`), que hoje não está documentado.

Como toca `charts/br-slc/**`, o `get-changed-paths` passa a incluir `br-slc` no matrix de release. Com o fix da #1664 já na `develop`, o pipeline agora vai:

1. Calcular `1.0.0-beta.1` (sem release anterior);
2. Atualizar `Chart.yaml` + achar a seção `### BR SLC` no README (não falha mais);
3. Publicar a tag + o artefato OCI em `ghcr.io/lerianstudio/br-slc-helm`.

## Validação

O path `charts/br-slc/README.md` não cai no `paths-ignore` (que só ignora o `README.md` da raiz, sem `**/`), então o trigger dispara corretamente.