### PR TITLE
feat(plugins): add PreSync Redpanda topics provisioner Job

### DIFF
--- a/charts/br-sisbajud/Chart.yaml
+++ b/charts/br-sisbajud/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 1.0.1
+version: 1.1.0
 
 # NOTE: appVersion is the default image tag for the app and the migration Job.
 # Override via brSisbajud.image.tag when needed.

--- a/charts/br-sisbajud/templates/_helpers.tpl
+++ b/charts/br-sisbajud/templates/_helpers.tpl
@@ -75,6 +75,24 @@ app.kubernetes.io/component: migrations
 {{- end }}
 
 {{/*
+Topics fullname, e.g. br-sisbajud-topics — the PreSync topics Job references this.
+*/}}
+{{- define "br-sisbajud-topics.fullname" -}}
+{{- printf "%s-topics" (include "br-sisbajud.fullname" . | trunc 56 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Topics labels.
+*/}}
+{{- define "br-sisbajud-topics.labels" -}}
+helm.sh/chart: {{ include "br-sisbajud.chart" . }}
+app.kubernetes.io/name: {{ include "br-sisbajud-topics.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: topics
+{{- end }}
+
+{{/*
 infraSecretRef — emit a `- name: <envName> valueFrom: secretKeyRef: {name,key}`
 env entry pointing at a Bitnami subchart's generated Secret (or the operator's
 existingSecret override). Only used on the bundled-subchart path; the external

--- a/charts/br-sisbajud/templates/topics/job.yaml
+++ b/charts/br-sisbajud/templates/topics/job.yaml
@@ -77,6 +77,10 @@ spec:
           image: "{{ .Values.topics.image.repository }}:{{ .Values.topics.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.topics.image.pullPolicy | default "IfNotPresent" }}
           env:
+            # rpk needs a writable HOME; under readOnlyRootFilesystem the only
+            # writable path is the /tmp emptyDir mounted below.
+            - name: HOME
+              value: /tmp
             - name: TOPICS
               value: {{ join " " .Values.topics.list | quote }}
             - name: TOPIC_PARTITIONS

--- a/charts/br-sisbajud/templates/topics/job.yaml
+++ b/charts/br-sisbajud/templates/topics/job.yaml
@@ -9,23 +9,39 @@
 #
 # STREAMING_* config is resolved from brSisbajud.extraEnvVars (wins) then
 # brSisbajud.configmap — the same idiom the migration Job uses for
-# ALLOW_INSECURE_TLS — so gitops needs no duplicated secret refs. The SASL/TLS
-# values are AVP <path:...> placeholders re-emitted as plain env, exactly as the
-# app itself consumes them.
+# ALLOW_INSECURE_TLS — so gitops needs no duplicated secret refs. extraEnvVars
+# entries are rendered VERBATIM, preserving `valueFrom` (secretKeyRef/configMapKeyRef)
+# sources so secret-backed SASL/TLS settings reach this Job exactly as the
+# Deployment receives them; configmap fallbacks and defaults are emitted as plain
+# `value`. STREAMING_BROKERS/STREAMING_TLS_ENABLED always render (with defaults);
+# the optional SASL/CA entries render only when set.
 {{- $extraEnv := .Values.brSisbajud.extraEnvVars | default list -}}
 {{- $cfg := .Values.brSisbajud.configmap | default dict -}}
-{{- $resolved := dict -}}
+{{- $envByName := dict -}}
 {{- range $extraEnv -}}
-{{-   if hasKey . "value" -}}
-{{-     $_ := set $resolved .name (toString .value) -}}
-{{-   end -}}
+{{- if .name -}}
+{{- $_ := set $envByName .name . -}}
 {{- end -}}
-{{- $brokers := index $resolved "STREAMING_BROKERS" | default (index $cfg "STREAMING_BROKERS") | default "" -}}
-{{- $tlsEnabled := index $resolved "STREAMING_TLS_ENABLED" | default (index $cfg "STREAMING_TLS_ENABLED") | default "false" -}}
-{{- $saslMech := index $resolved "STREAMING_SASL_MECHANISM" | default (index $cfg "STREAMING_SASL_MECHANISM") | default "" -}}
-{{- $saslUser := index $resolved "STREAMING_SASL_USERNAME" | default (index $cfg "STREAMING_SASL_USERNAME") | default "" -}}
-{{- $saslPass := index $resolved "STREAMING_SASL_PASSWORD" | default (index $cfg "STREAMING_SASL_PASSWORD") | default "" -}}
-{{- $caCert := index $resolved "STREAMING_TLS_CA_CERT" | default (index $cfg "STREAMING_TLS_CA_CERT") | default "" -}}
+{{- end -}}
+{{- $streamingSpecs := list -}}
+{{- $streamingSpecs = append $streamingSpecs (dict "name" "STREAMING_BROKERS" "default" "" "required" true) -}}
+{{- $streamingSpecs = append $streamingSpecs (dict "name" "STREAMING_TLS_ENABLED" "default" "false" "required" true) -}}
+{{- $streamingSpecs = append $streamingSpecs (dict "name" "STREAMING_SASL_MECHANISM" "default" "" "required" false) -}}
+{{- $streamingSpecs = append $streamingSpecs (dict "name" "STREAMING_SASL_USERNAME" "default" "" "required" false) -}}
+{{- $streamingSpecs = append $streamingSpecs (dict "name" "STREAMING_SASL_PASSWORD" "default" "" "required" false) -}}
+{{- $streamingSpecs = append $streamingSpecs (dict "name" "STREAMING_TLS_CA_CERT" "default" "" "required" false) -}}
+{{- $streamingEnv := list -}}
+{{- range $spec := $streamingSpecs -}}
+{{- $entry := index $envByName $spec.name -}}
+{{- if $entry -}}
+{{- $streamingEnv = append $streamingEnv $entry -}}
+{{- else -}}
+{{- $val := index $cfg $spec.name | default $spec.default -}}
+{{- if or $spec.required $val -}}
+{{- $streamingEnv = append $streamingEnv (dict "name" $spec.name "value" (toString $val)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- $pullSecrets := .Values.topics.imagePullSecrets | default .Values.imagePullSecrets }}
 apiVersion: batch/v1
 kind: Job
@@ -71,25 +87,8 @@ spec:
             - name: TOPIC_RETENTION_MS
               value: {{ .Values.topics.retentionMs | quote }}
             {{- end }}
-            - name: STREAMING_BROKERS
-              value: {{ $brokers | quote }}
-            - name: STREAMING_TLS_ENABLED
-              value: {{ $tlsEnabled | quote }}
-            {{- if $saslMech }}
-            - name: STREAMING_SASL_MECHANISM
-              value: {{ $saslMech | quote }}
-            {{- end }}
-            {{- if $saslUser }}
-            - name: STREAMING_SASL_USERNAME
-              value: {{ $saslUser | quote }}
-            {{- end }}
-            {{- if $saslPass }}
-            - name: STREAMING_SASL_PASSWORD
-              value: {{ $saslPass | quote }}
-            {{- end }}
-            {{- if $caCert }}
-            - name: STREAMING_TLS_CA_CERT
-              value: {{ $caCert | quote }}
+            {{- with $streamingEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           securityContext:
             runAsUser: 65532

--- a/charts/br-sisbajud/templates/topics/job.yaml
+++ b/charts/br-sisbajud/templates/topics/job.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.topics.enabled }}
+# PreSync topics Job. Runs the dedicated br-sisbajud-topics image (rpk), whose
+# entrypoint idempotently ensures the reactive-bridge Redpanda topics and their
+# .dlq siblings exist before the app boots. hook-weight -1 puts it in the same
+# wave as the migration Job (they are independent — Kafka vs Postgres) and
+# before the main-sync Deployment, so the Midaz balance translator never
+# halt-loops (UNKNOWN_TOPIC_OR_PARTITION) and DLQ publishes never fail on a
+# fresh broker.
+#
+# STREAMING_* config is resolved from brSisbajud.extraEnvVars (wins) then
+# brSisbajud.configmap — the same idiom the migration Job uses for
+# ALLOW_INSECURE_TLS — so gitops needs no duplicated secret refs. The SASL/TLS
+# values are AVP <path:...> placeholders re-emitted as plain env, exactly as the
+# app itself consumes them.
+{{- $extraEnv := .Values.brSisbajud.extraEnvVars | default list -}}
+{{- $cfg := .Values.brSisbajud.configmap | default dict -}}
+{{- $resolved := dict -}}
+{{- range $extraEnv -}}
+{{-   if hasKey . "value" -}}
+{{-     $_ := set $resolved .name (toString .value) -}}
+{{-   end -}}
+{{- end -}}
+{{- $brokers := index $resolved "STREAMING_BROKERS" | default (index $cfg "STREAMING_BROKERS") | default "" -}}
+{{- $tlsEnabled := index $resolved "STREAMING_TLS_ENABLED" | default (index $cfg "STREAMING_TLS_ENABLED") | default "false" -}}
+{{- $saslMech := index $resolved "STREAMING_SASL_MECHANISM" | default (index $cfg "STREAMING_SASL_MECHANISM") | default "" -}}
+{{- $saslUser := index $resolved "STREAMING_SASL_USERNAME" | default (index $cfg "STREAMING_SASL_USERNAME") | default "" -}}
+{{- $saslPass := index $resolved "STREAMING_SASL_PASSWORD" | default (index $cfg "STREAMING_SASL_PASSWORD") | default "" -}}
+{{- $caCert := index $resolved "STREAMING_TLS_CA_CERT" | default (index $cfg "STREAMING_TLS_CA_CERT") | default "" -}}
+{{- $pullSecrets := .Values.topics.imagePullSecrets | default .Values.imagePullSecrets }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "br-sisbajud-topics.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "br-sisbajud-topics.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: {{ .Values.topics.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.topics.activeDeadlineSeconds | default 600 }}
+  ttlSecondsAfterFinished: {{ .Values.topics.ttlSecondsAfterFinished | default 600 }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-sisbajud-topics.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: topics
+          image: "{{ .Values.topics.image.repository }}:{{ .Values.topics.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.topics.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: TOPICS
+              value: {{ join " " .Values.topics.list | quote }}
+            - name: TOPIC_PARTITIONS
+              value: {{ .Values.topics.partitions | default 1 | quote }}
+            - name: TOPIC_REPLICAS
+              value: {{ .Values.topics.replicationFactor | default 1 | quote }}
+            {{- if .Values.topics.retentionMs }}
+            - name: TOPIC_RETENTION_MS
+              value: {{ .Values.topics.retentionMs | quote }}
+            {{- end }}
+            - name: STREAMING_BROKERS
+              value: {{ $brokers | quote }}
+            - name: STREAMING_TLS_ENABLED
+              value: {{ $tlsEnabled | quote }}
+            {{- if $saslMech }}
+            - name: STREAMING_SASL_MECHANISM
+              value: {{ $saslMech | quote }}
+            {{- end }}
+            {{- if $saslUser }}
+            - name: STREAMING_SASL_USERNAME
+              value: {{ $saslUser | quote }}
+            {{- end }}
+            {{- if $saslPass }}
+            - name: STREAMING_SASL_PASSWORD
+              value: {{ $saslPass | quote }}
+            {{- end }}
+            {{- if $caCert }}
+            - name: STREAMING_TLS_CA_CERT
+              value: {{ $caCert | quote }}
+            {{- end }}
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.topics.resources | nindent 12 }}
+      volumes:
+        # rpk needs a writable HOME/config dir + a place for the decoded CA;
+        # emptyDir keeps readOnlyRootFilesystem: true intact.
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/br-sisbajud/values.schema.json
+++ b/charts/br-sisbajud/values.schema.json
@@ -47,6 +47,10 @@
       "type": "object",
       "additionalProperties": true
     },
+    "topics": {
+      "type": "object",
+      "additionalProperties": true
+    },
     "postgresql": {
       "type": "object",
       "additionalProperties": true

--- a/charts/br-sisbajud/values.yaml
+++ b/charts/br-sisbajud/values.yaml
@@ -157,6 +157,42 @@ migrations:
       memory: 256Mi
 
 # =============================================================================
+# Detached topic provisioning — ArgoCD PreSync Job that idempotently ensures the
+# reactive-bridge Redpanda topics (and their .dlq siblings) exist before the app
+# boots. The br-sisbajud-topics image runs `rpk topic create` (list-then-create)
+# reusing the same STREAMING_* env the app consumes (resolved from
+# brSisbajud.extraEnvVars / brSisbajud.configmap — no duplicated secret refs).
+# midaz.balance.changed is NOT listed: Midaz owns and creates it; br-sisbajud
+# only consumes it.
+# =============================================================================
+topics:
+  enabled: true
+  image:
+    repository: ghcr.io/lerianstudio/br-sisbajud-topics
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  partitions: 1
+  replicationFactor: 1        # per-env; 3 on multi-broker prod
+  retentionMs: ""             # optional; empty = broker default
+  list:
+    - br-sisbajud.ledger.balance.changed
+    - br-sisbajud.ledger.balance.changed.dlq
+    - br-sisbajud.block_account.created
+    - br-sisbajud.block_account.created.dlq
+    - br-sisbajud.kek.rotated
+    - br-sisbajud.kek.rotated.dlq
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 600
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+# =============================================================================
 # Bundled infra subcharts — DISABLED by default. On the target environments
 # Postgres and Redis are external and pre-provisioned; wire hosts via
 # brSisbajud.configmap.POSTGRES_HOST / REDIS_HOST. Enable these only for a


### PR DESCRIPTION
## What

Adds a **PreSync Redpanda topics provisioner Job** to the `br-sisbajud` chart, cloned from the existing migrations Job.

- `templates/topics/job.yaml` — ArgoCD PreSync hook (weight `-1`), hardened `securityContext` (runAsNonRoot 65532, `readOnlyRootFilesystem: true`, drop ALL, seccomp RuntimeDefault) plus a writable `/tmp` emptyDir (for the decoded CA + rpk home). Resolves `STREAMING_*` from `brSisbajud.extraEnvVars` → `configmap` (same idiom the migrations Job uses for `ALLOW_INSECURE_TLS`), so gitops needs no duplicated secret refs. Runs the `br-sisbajud-topics` image.
- `templates/_helpers.tpl` — `br-sisbajud-topics.fullname` / `.labels`.
- `values.yaml` — top-level `topics:` block (enabled, image, partitions, replicationFactor, retentionMs, the 6-topic list, resources).
- `values.schema.json` — added `topics` property (root is `additionalProperties: false`).
- `Chart.yaml` — `version 1.0.1 → 1.1.0`.

## Why

Companion to `LerianStudio/br-sisbajud#<topics image PR>`. Provisions the reactive-bridge topics at deploy time so the balance translator/consumer can't halt-loop on a fresh environment. See that PR for the full rationale.

## Validation

- `helm lint` — 0 failures.
- `helm template --set topics.enabled=true` — Job renders with the PreSync hooks, hardened securityContext, `/tmp` emptyDir, and all env resolved. `--set topics.enabled=false` renders no Job.

## Merge order (part of a 3-PR set)

Merge **after** the br-sisbajud image PR (so `br-sisbajud-topics:<tag>` exists) and **before** the gitops PR (which references chart `1.1.0`). Publishing this chart makes `1.1.0` available.
