### PR TITLE
feat(midaz,plugin-fees): render streaming SASL/TLS secrets in midaz + plugin-fees Secrets

### DIFF
--- a/charts/midaz/Chart.yaml
+++ b/charts/midaz/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to he chart and its templates, including the app version.
-version: 8.5.0
+version: 8.6.0
 # This is the version number of the application being deployed.
 appVersion: "3.7.8"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/midaz/templates/crm/secrets.yaml
+++ b/charts/midaz/templates/crm/secrets.yaml
@@ -24,4 +24,14 @@ data:
   {{- if and (not $mongoInternal) .Values.crm.secrets.MONGO_PASSWORD }}
   MONGO_PASSWORD: {{ .Values.crm.secrets.MONGO_PASSWORD | b64enc | quote }}
   {{- end }}
+
+  # =============================================================================
+  # STREAMING SECRETS (lib-streaming — SASL password + TLS CA, operator-provided)
+  # =============================================================================
+  {{- if .Values.crm.secrets.STREAMING_SASL_PASSWORD }}
+  STREAMING_SASL_PASSWORD: {{ .Values.crm.secrets.STREAMING_SASL_PASSWORD | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.crm.secrets.STREAMING_TLS_CA_CERT }}
+  STREAMING_TLS_CA_CERT: {{ .Values.crm.secrets.STREAMING_TLS_CA_CERT | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/midaz/templates/ledger/secrets.yaml
+++ b/charts/midaz/templates/ledger/secrets.yaml
@@ -62,4 +62,14 @@ data:
   MULTI_TENANT_REDIS_PASSWORD: {{ .Values.ledger.secrets.MULTI_TENANT_REDIS_PASSWORD | b64enc | quote }}
   {{- end }}
   {{- end }}
+
+  # =============================================================================
+  # STREAMING SECRETS (lib-streaming — SASL password + TLS CA, operator-provided)
+  # =============================================================================
+  {{- if .Values.ledger.secrets.STREAMING_SASL_PASSWORD }}
+  STREAMING_SASL_PASSWORD: {{ .Values.ledger.secrets.STREAMING_SASL_PASSWORD | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.ledger.secrets.STREAMING_TLS_CA_CERT }}
+  STREAMING_TLS_CA_CERT: {{ .Values.ledger.secrets.STREAMING_TLS_CA_CERT | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -325,6 +325,11 @@ ledger:
     REDIS_PASSWORD: ""
     RABBITMQ_DEFAULT_PASS: ""
     RABBITMQ_CONSUMER_PASS: ""
+    # -- Streaming (lib-streaming) SASL/TLS material. Operator-provided; only set
+    # when the streaming backend uses SASL auth and/or a private TLS CA. When set,
+    # they are rendered into the ledger Secret (never the ConfigMap).
+    STREAMING_SASL_PASSWORD: ""
+    STREAMING_TLS_CA_CERT: ""
   serviceAccount:
     # -- Specifies whether a ServiceAccount should be created
     create: true
@@ -493,6 +498,11 @@ crm:
     # (key `mongodb-root-password`); only set it for an EXTERNAL MongoDB
     # (subchart disabled / .external=true) without an existingSecret override.
     MONGO_PASSWORD: ""
+    # -- Streaming (lib-streaming) SASL/TLS material. Operator-provided; only set
+    # when the streaming backend uses SASL auth and/or a private TLS CA. When set,
+    # they are rendered into the CRM Secret (never the ConfigMap).
+    STREAMING_SASL_PASSWORD: ""
+    STREAMING_TLS_CA_CERT: ""
   # -- Existing secrets name
   useExistingSecret: false
   existingSecretName: ""

--- a/charts/plugin-fees/Chart.yaml
+++ b/charts/plugin-fees/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 7.1.0
+version: 7.2.0
 # This is the version number of the application being deployed.
 appVersion: "3.3.0"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/plugin-fees/templates/fees/secrets.yaml
+++ b/charts/plugin-fees/templates/fees/secrets.yaml
@@ -29,4 +29,11 @@ stringData:
   MULTI_TENANT_REDIS_PASSWORD: {{ .Values.fees.secrets.MULTI_TENANT_REDIS_PASSWORD | quote }}
   {{- end }}
   {{- end }}
+  # STREAMING SECRETS (lib-streaming — SASL password + TLS CA, operator-provided)
+  {{- if .Values.fees.secrets.STREAMING_SASL_PASSWORD }}
+  STREAMING_SASL_PASSWORD: {{ .Values.fees.secrets.STREAMING_SASL_PASSWORD | quote }}
+  {{- end }}
+  {{- if .Values.fees.secrets.STREAMING_TLS_CA_CERT }}
+  STREAMING_TLS_CA_CERT: {{ .Values.fees.secrets.STREAMING_TLS_CA_CERT | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/plugin-fees/values.yaml
+++ b/charts/plugin-fees/values.yaml
@@ -244,6 +244,11 @@ fees:
     MULTI_TENANT_SERVICE_API_KEY: ""
     # -- Password for the Redis/Valkey instance used by the multi-tenant cache (required when MULTI_TENANT_ENABLED=true)
     MULTI_TENANT_REDIS_PASSWORD: ""
+    # -- Streaming (lib-streaming) SASL/TLS material. Operator-provided; only set
+    # when the streaming backend uses SASL auth and/or a private TLS CA. When set,
+    # they are rendered into the plugin-fees Secret (never the ConfigMap).
+    STREAMING_SASL_PASSWORD: ""
+    STREAMING_TLS_CA_CERT: ""
 mongodb:
   # MongoDB’s flexibility and scalability make it the perfect choice for managing evolving and less structured data.
   enabled: true


### PR DESCRIPTION
Requested by: Andrei Schopf

## Problem
`STREAMING_SASL_PASSWORD` and `STREAMING_TLS_CA_CERT` placed under `.Values.<component>.secrets` were **silently dropped**: the Secret templates enumerate keys explicitly, so any unlisted key never reaches a `kind: Secret`. With streaming SASL auth enabled this caused `lib-streaming` LoadConfig to fail (mechanism requires a username and password) → **CrashLoopBackOff**. The only workaround was `extraEnvVars` (plaintext ConfigMap), unacceptable for a SASL password in prod.

## Change
Render both streaming keys into the appropriate component Secrets:
- `charts/midaz/templates/ledger/secrets.yaml` (`data:` + `b64enc`)
- `charts/midaz/templates/crm/secrets.yaml` (`data:` + `b64enc`)
- `charts/plugin-fees/templates/fees/secrets.yaml` (`stringData:`, no b64enc)

Both keys are optional (`{{- if ... }}` guarded) so existing deployments are unaffected. Documented under `secrets:` in each chart's `values.yaml`. Chart version bumps: midaz `8.5.0 → 8.6.0`, plugin-fees `7.1.0 → 7.2.0`.

## Validation
`helm template` with test values including `STREAMING_SASL_PASSWORD` and `STREAMING_TLS_CA_CERT` under `ledger.secrets`, `crm.secrets`, and `fees.secrets`:
- Both keys appear in `kind: Secret` output (base64 in midaz, plaintext stringData in plugin-fees)
- Confirmed **absent** from all `kind: ConfigMap` output
- `helm lint` passes for both charts
