### PR TITLE
feat(new): add lender chart

### DIFF
--- a/.github/configs/helm-render-values/lender.yaml
+++ b/.github/configs/helm-render-values/lender.yaml
@@ -1,0 +1,13 @@
+# CI-only render fixture for the lender chart. NOT a production example.
+# Enables BOTH components so the render gate exercises the console path, and
+# supplies the required-when-enabled values. No real credentials.
+lender:
+  secrets:
+    # lender.secrets.POSTGRES_PASSWORD is `required` when useExistingSecret=false.
+    POSTGRES_PASSWORD: "ci-dummy-not-a-real-secret"
+
+lenderConsole:
+  enabled: true
+  image:
+    # lenderConsole.image.tag is `required` when lenderConsole.enabled=true.
+    tag: "0.0.0-ci"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -52,6 +52,7 @@ jobs:
             fetcher
             flowker
             underwriter
+            lender
             matcher
             tracer
             br-sta

--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ For implementation and configuration details, see the [README](https://charts.le
 | `3.1.0-beta.1` | 1.0.0 |
 -----------------
 
+### Lender
+
+For more details, check out the [official documentation](https://docs.lerian.studio/en/lender).
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/lender).
+
+#### Application Version Mapping
+
+| Chart Version | Lender Version |
+| :---: | :---: |
+| `1.0.2` | 1.0.0-beta.49 |
+-----------------
+
 ### Matcher
 
 For more details, check out the [official documentation](https://docs.lerian.studio/en/matcher#matcher).

--- a/charts/lender/Chart.yaml
+++ b/charts/lender/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: lender-helm
+description: A Helm chart for Lender - Lerian credit journey engine (API + optional console)
+type: application
+annotations:
+  lerian.studio/chart-type: multi-component
+home: https://github.com/LerianStudio/lender
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/lender
+  - https://github.com/LerianStudio/lender
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+version: 1.0.2
+# NOTE: appVersion tracks the lender API image line. The real image tag is set
+# per-component via lender.image.tag and lenderConsole.image.tag.
+appVersion: "1.0.0-beta.49"
+keywords:
+  - lender
+  - credit
+  - underwriter
+  - lerian
+  - ddd
+  - hexagonal
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4

--- a/charts/lender/README.md
+++ b/charts/lender/README.md
@@ -1,0 +1,80 @@
+# Lender Helm Chart
+
+This chart installs [Lender](https://github.com/LerianStudio/lender), Lerian's credit
+journey engine (CDC / PJ / Cards). It is a **multi-component** chart:
+
+- `lender` — the Go API (main component; image tag lands at `lender.image.tag`).
+- `lenderConsole` — the optional Vite/React SPA UI served by `nginx-unprivileged`
+  (disabled by default; enable per environment once a `lender-ui` image is published).
+
+PostgreSQL and Valkey/Redis are **external** (Benedita DB-LXC pattern) — the chart
+ships no datastore subcharts. An optional ArgoCD PreSync bootstrap Job
+(`global.externalPostgresDefinitions.enabled`) provisions the DB/role/grants
+idempotently; schema migrations remain operator-driven (`cmd/migrate up`, out of band).
+
+## Chart Contract
+
+- Chart type: `multi-component`
+- Required secrets: `lender.secrets.POSTGRES_PASSWORD` (install fails loud when unset,
+  unless `lender.useExistingSecret=true` — then `lender.existingSecretName` is required
+  instead). `REDIS_PASSWORD` and `AUTH_JWT_SECRET` are optional (emitted from
+  `lender.secrets.*` only when set). When the bootstrap Job is enabled
+  (`global.externalPostgresDefinitions.enabled=true`) without an `useExistingSecret.name`,
+  `global.externalPostgresDefinitions.postgresAdminLogin.password` and
+  `global.externalPostgresDefinitions.lenderCredentials.password` are also required.
+- Dependency notes: No subcharts / no `dependencies:` — Postgres is external (Benedita
+  DB-LXC pattern), provided via values. Therefore no `Chart.lock`.
+- Production overrides: set `lender.image.tag`; provide `lender.secrets.POSTGRES_PASSWORD`
+  (or `lender.useExistingSecret=true` + `lender.existingSecretName`) and, when the UI is
+  used, `lenderConsole.enabled=true` with `lenderConsole.image.tag` (**required** when the
+  console is enabled). Configure `lender.ingress` / `lenderConsole.ingress` hosts per
+  environment. `lenderConsole.securityContext.readOnlyRootFilesystem` is intentionally
+  `false` (nginx-unprivileged renders `/config.js` at start and writes pid/cache to the
+  root fs — live-proven; do not flip it to `true`).
+- Source/license: https://github.com/LerianStudio/lender
+
+## Components
+
+### Lender API (`lender`)
+
+The Go API. Binds `0.0.0.0:4017` (`SERVER_ADDRESS`), exposes `/health` (liveness) and
+`/readyz` (readiness). Non-sensitive env is rendered from `lender.configmap`; sensitive
+env from `lender.secrets` (or an existing Secret). Feature flags (RabbitMQ, streaming,
+outbox, multi-tenant, collection) default OFF so the service boots single-tenant.
+
+### Lender Console (`lenderConsole`)
+
+Optional Vite SPA served by `nginx-unprivileged` (uid/gid `101`). Disabled by default;
+no chart change is needed to wire a future UI — set `lenderConsole.enabled=true` and a
+`lenderConsole.image.tag`. Runtime config (e.g. `API_BASE_URL`) is delivered via
+`lenderConsole.configmap` and rendered into the SPA at container start.
+
+## Install
+
+```console
+$ helm install lender oci://registry-1.docker.io/lerianstudio/lender-helm \
+    --version 1.0.2 -n lender --create-namespace
+```
+
+## Configuring Ingress (NGINX)
+
+```yaml
+lender:
+  ingress:
+    enabled: true
+    className: "nginx"
+    hosts:
+      - host: lender.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: lender-tls
+        hosts:
+          - lender.example.com
+```
+
+## Support & Community
+
+- **GitHub Issues**: https://github.com/LerianStudio/lender/issues
+- **Email**: [contact@lerian.studio](mailto:contact@lerian.studio)

--- a/charts/lender/templates/_helpers.tpl
+++ b/charts/lender/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lender.name" -}}
+{{- default "lender" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for the lender API component.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "lender.fullname" -}}
+{{- default (include "lender.name" .) .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified name for the lender console (UI) component.
+*/}}
+{{- define "lenderConsole.fullname" -}}
+{{- $base := include "lender.fullname" . | trunc 55 | trimSuffix "-" }}
+{{- printf "%s-console" $base | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lender.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Resolve the lender API image tag (falls back to Chart.AppVersion).
+*/}}
+{{- define "lender.defaultTag" -}}
+{{- default .Chart.AppVersion .Values.lender.image.tag }}
+{{- end -}}
+
+{{/*
+Return valid lender version label value.
+*/}}
+{{- define "lender.versionLabelValue" -}}
+{{ regexReplaceAll "[^-A-Za-z0-9_.]" (include "lender.defaultTag" .) "-" | trunc 63 | trimAll "-" | trimAll "_" | trimAll "." | quote }}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "lender.labels" -}}
+helm.sh/chart: {{ include "lender.chart" .context }}
+{{ include "lender.selectorLabels" (dict "context" .context "component" .component "name" .name) }}
+app.kubernetes.io/version: {{ include "lender.versionLabelValue" .context }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lender.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lender.name" .context }}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- if .component }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lender.serviceAccountName" -}}
+{{- if .Values.lender.serviceAccount.create }}
+{{- default (include "lender.fullname" .) .Values.lender.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.lender.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
+*/}}
+{{- define "global.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}

--- a/charts/lender/templates/bootstrap-postgres.yaml
+++ b/charts/lender/templates/bootstrap-postgres.yaml
@@ -1,0 +1,145 @@
+{{- if .Values.global.externalPostgresDefinitions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lender.fullname" . }}-bootstrap-postgres
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" "bootstrap" "name" "postgres") | nindent 4 }}
+  annotations:
+    # Run as an ArgoCD PreSync hook, recreated every sync (Job pod templates are
+    # immutable, so a fixed-name Job would collide on helm upgrade). sync-wave -10
+    # provisions the DB/role before the app rolls. ttl is a non-ArgoCD fallback.
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  ttlSecondsAfterFinished: 300
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-dependencies
+        image: busybox:1.37
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalPostgresDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalPostgresDefinitions.connection.port | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - >
+          TIMEOUT=300;
+          ELAPSED=0;
+          echo "Checking $DB_HOST:$DB_PORT...";
+          while ! nc -z "$DB_HOST" "$DB_PORT"; do
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for $DB_HOST:$DB_PORT after ${TIMEOUT}s";
+              exit 1;
+            fi;
+            echo "$DB_HOST:$DB_PORT is not ready yet, waiting... (${ELAPSED}s/${TIMEOUT}s)";
+            sleep 5;
+            ELAPSED=$((ELAPSED + 5));
+          done;
+          echo "$DB_HOST:$DB_PORT is ready!";
+      containers:
+      - name: psql
+        image: postgres:17
+        env:
+        - name: DB_HOST
+          value: {{ .Values.global.externalPostgresDefinitions.connection.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.externalPostgresDefinitions.connection.port | quote }}
+        - name: DB_USER_ADMIN
+          {{- if .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name | quote }}
+              key: DB_USER_ADMIN
+          {{- else }}
+          value: {{ .Values.global.externalPostgresDefinitions.postgresAdminLogin.username | quote }}
+          {{- end }}
+        - name: DB_ADMIN_PASSWORD
+          {{- if .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalPostgresDefinitions.postgresAdminLogin.useExistingSecret.name | quote }}
+              key: DB_ADMIN_PASSWORD
+          {{- else }}
+          value: {{ required "global.externalPostgresDefinitions.postgresAdminLogin.password is required when postgresAdminLogin.useExistingSecret.name is unset" .Values.global.externalPostgresDefinitions.postgresAdminLogin.password | quote }}
+          {{- end }}
+        - name: DB_PASSWORD_LENDER
+          {{- if .Values.global.externalPostgresDefinitions.lenderCredentials.useExistingSecret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.externalPostgresDefinitions.lenderCredentials.useExistingSecret.name | quote }}
+              key: DB_PASSWORD_LENDER
+          {{- else }}
+          value: {{ required "global.externalPostgresDefinitions.lenderCredentials.password is required when lenderCredentials.useExistingSecret.name is unset" .Values.global.externalPostgresDefinitions.lenderCredentials.password | quote }}
+          {{- end }}
+        - name: DB_DATABASE
+          value: postgres
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== Lender PostgreSQL Bootstrap ==="
+          echo "Host: $DB_HOST:$DB_PORT"
+          echo ""
+
+          # The role password is passed to psql via the `pw` variable and
+          # interpolated with :'pw', which psql quotes/escapes as a SQL string
+          # literal — it is never embedded into the -c SQL string directly, so
+          # there is no SQL injection surface.
+          run_psql() {
+            PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -v pw="$DB_PASSWORD_LENDER" "$@"
+          }
+
+          echo "Checking existing PostgreSQL objects..."
+          DB_EXISTS=0
+          ROLE_EXISTS=0
+
+          if run_psql -At -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_database WHERE datname='lender'" | grep -q 1; then
+            DB_EXISTS=1
+          fi
+          if run_psql -At -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "SELECT 1 FROM pg_roles WHERE rolname='lender'" | grep -q 1; then
+            ROLE_EXISTS=1
+          fi
+
+          # Create the role if missing, otherwise refresh its password.
+          # NOTE: psql interpolates :'pw' only for stdin/-f input, NOT for -c;
+          # feed the statement on stdin so the password is safely psql-quoted.
+          if [ "$ROLE_EXISTS" = "1" ]; then
+            echo "Role 'lender' already exists. Updating password..."
+            printf '%s\n' "ALTER ROLE \"lender\" WITH LOGIN PASSWORD :'pw';" | run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE"
+          else
+            echo "Creating role 'lender'..."
+            printf '%s\n' "CREATE ROLE \"lender\" LOGIN PASSWORD :'pw';" | run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE"
+          fi
+
+          # Create the database if missing.
+          if [ "$DB_EXISTS" = "1" ]; then
+            echo "Database 'lender' already exists. Skipping creation."
+          else
+            echo "Creating database 'lender'..."
+            run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "CREATE DATABASE \"lender\" OWNER \"lender\""
+          fi
+
+          # Privileges (safe to run repeatedly). No CREATEDB grant — least privilege.
+          echo "Ensuring privileges and schema permissions..."
+          run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "$DB_DATABASE" -c "GRANT ALL PRIVILEGES ON DATABASE \"lender\" TO \"lender\""
+          run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "lender" -c "GRANT ALL ON SCHEMA public TO \"lender\""
+          run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "lender" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \"lender\""
+          run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "lender" -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO \"lender\""
+          run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "lender" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO \"lender\""
+          run_psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER_ADMIN" -d "lender" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO \"lender\""
+
+          echo ""
+          echo "=== Lender PostgreSQL Bootstrap completed successfully ==="
+          echo "NOTE: schema migrations are operator-driven (cmd/migrate up) and run out-of-band."
+{{- end }}

--- a/charts/lender/templates/lender/configmap.yaml
+++ b/charts/lender/templates/lender/configmap.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.lender.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lender.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+data:
+  # Auto-generated version (from image tag, falls back to Chart.AppVersion)
+  VERSION: {{ .Values.lender.image.tag | default .Chart.AppVersion | quote }}
+  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.lender.image.tag | default .Chart.AppVersion | quote }}
+
+  # Non-sensitive environment (mirrors config/.env.example superset).
+  # MULTI_TENANT_* sub-keys are owned by the gated block below; only
+  # MULTI_TENANT_ENABLED is emitted here to avoid duplicate ConfigMap keys.
+  {{- range $key, $value := .Values.lender.configmap }}
+  {{- if or (not (hasPrefix "MULTI_TENANT_" $key)) (eq $key "MULTI_TENANT_ENABLED") }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Multi-tenant starter (rendered only when MULTI_TENANT_ENABLED=true)
+  {{- if eq (.Values.lender.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true" }}
+  MULTI_TENANT_URL: {{ required "lender.configmap.MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true" .Values.lender.configmap.MULTI_TENANT_URL | quote }}
+  MULTI_TENANT_REDIS_HOST: {{ required "lender.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true" .Values.lender.configmap.MULTI_TENANT_REDIS_HOST | quote }}
+  MULTI_TENANT_REDIS_PORT: {{ .Values.lender.configmap.MULTI_TENANT_REDIS_PORT | default "6379" | quote }}
+  MULTI_TENANT_REDIS_TLS: {{ .Values.lender.configmap.MULTI_TENANT_REDIS_TLS | default "false" | quote }}
+  MULTI_TENANT_MAX_TENANT_POOLS: {{ .Values.lender.configmap.MULTI_TENANT_MAX_TENANT_POOLS | default "100" | quote }}
+  MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ .Values.lender.configmap.MULTI_TENANT_IDLE_TIMEOUT_SEC | default "300" | quote }}
+  MULTI_TENANT_TIMEOUT: {{ .Values.lender.configmap.MULTI_TENANT_TIMEOUT | default "30" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ .Values.lender.configmap.MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD | default "5" | quote }}
+  MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ .Values.lender.configmap.MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC | default "30" | quote }}
+  MULTI_TENANT_CACHE_TTL_SEC: {{ .Values.lender.configmap.MULTI_TENANT_CACHE_TTL_SEC | default "120" | quote }}
+  MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ .Values.lender.configmap.MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC | default "30" | quote }}
+  {{- end }}
+
+  # Extra env vars (GitOps passthrough)
+  {{- with .Values.lender.extraEnvVars }}
+  {{- range . }}
+  {{ .name }}: {{ .value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/lender/templates/lender/deployment.yaml
+++ b/charts/lender/templates/lender/deployment.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.lender.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lender.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .Values.lender.revisionHistoryLimit | default 10 }}
+  strategy:
+    type: {{ .Values.lender.deploymentUpdate.type }}
+    {{- if eq .Values.lender.deploymentUpdate.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.lender.deploymentUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.lender.deploymentUpdate.maxUnavailable }}
+    {{- end }}
+  {{- if not .Values.lender.autoscaling.enabled }}
+  replicas: {{ .Values.lender.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lender.selectorLabels" (dict "context" . "name" .Values.lender.name) | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.lender.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 8 }}
+    spec:
+      {{- with .Values.lender.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lender.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.lender.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "lender.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.lender.securityContext | nindent 12 }}
+          image: "{{ .Values.lender.image.repository }}:{{ .Values.lender.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.lender.image.pullPolicy }}
+          envFrom:
+          - secretRef:
+              name: {{ if .Values.lender.useExistingSecret }}{{ required "lender.existingSecretName is required when lender.useExistingSecret=true" .Values.lender.existingSecretName }}{{ else }}{{ include "lender.fullname" . }}{{ end }}
+          - configMapRef:
+              name: {{ include "lender.fullname" . }}
+          {{- if eq (toString .Values.lender.configmap.ENABLE_TELEMETRY) "true" }}
+          env:
+          - name: "HOST_IP"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+            value: "http://$(HOST_IP):4317"
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.lender.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.lender.resources | nindent 12 }}
+      {{- with .Values.lender.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lender.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lender.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lender/templates/lender/hpa.yaml
+++ b/charts/lender/templates/lender/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.lender.enabled .Values.lender.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "lender.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lender.fullname" . }}
+  minReplicas: {{ .Values.lender.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.lender.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.lender.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.lender.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.lender.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.lender.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/lender/templates/lender/ingress.yaml
+++ b/charts/lender/templates/lender/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.lender.enabled .Values.lender.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "lender.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+  {{- with .Values.lender.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.lender.ingress.className }}
+  ingressClassName: {{ .Values.lender.ingress.className }}
+  {{- end }}
+  {{- if .Values.lender.ingress.tls }}
+  tls:
+    {{- range .Values.lender.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.lender.ingress.hosts }}
+    {{- if .host }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "lender.fullname" $ }}
+                port:
+                  number: {{ $.Values.lender.service.port }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/lender/templates/lender/pdb.yaml
+++ b/charts/lender/templates/lender/pdb.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.lender.enabled .Values.lender.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "lender.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+  {{- with .Values.lender.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if hasKey .Values.lender.pdb "maxUnavailable" }}
+  maxUnavailable: {{ .Values.lender.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.lender.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- /* Scope to the API component so disruption budgeting counts only API
+             pods, not lenderConsole (shared name/instance). PDB selector is
+             mutable, so this applies on upgrade. (The Deployment selector needs
+             the same discriminator but is immutable — tracked as a follow-up
+             requiring a recreate; HPA/autoscaling is off on these tiers.) */ -}}
+      {{- include "lender.selectorLabels" (dict "context" . "name" .Values.lender.name "component" .Values.lender.name) | nindent 6 }}
+{{- end }}

--- a/charts/lender/templates/lender/secrets.yaml
+++ b/charts/lender/templates/lender/secrets.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.lender.enabled (not .Values.lender.useExistingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lender.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ required "lender.secrets.POSTGRES_PASSWORD is required when lender.useExistingSecret=false (supply explicitly or set useExistingSecret=true)" .Values.lender.secrets.POSTGRES_PASSWORD | quote }}
+  {{- range $key, $value := .Values.lender.secrets }}
+  {{- if ne $key "POSTGRES_PASSWORD" }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/lender/templates/lender/service.yaml
+++ b/charts/lender/templates/lender/service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.lender.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lender.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+  {{- with .Values.lender.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.lender.service.type }}
+  ports:
+    - port: {{ .Values.lender.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- /* Include the component discriminator so this API Service selects ONLY
+           the lender API pods, not the lenderConsole pods (which share
+           name/instance labels). Without it the Service load-balances /api
+           traffic onto the console nginx too, yielding intermittent
+           missing-CORS / SPA-fallback responses. */ -}}
+    {{- include "lender.selectorLabels" (dict "context" . "name" .Values.lender.name "component" .Values.lender.name) | nindent 4 }}
+{{- end }}

--- a/charts/lender/templates/lender/serviceaccount.yaml
+++ b/charts/lender/templates/lender/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.lender.enabled .Values.lender.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lender.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lender.name "name" .Values.lender.name) | nindent 4 }}
+  {{- with .Values.lender.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lender/templates/lenderConsole/configmap.yaml
+++ b/charts/lender/templates/lenderConsole/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.lenderConsole.enabled .Values.lenderConsole.configmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lenderConsole.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lenderConsole.name "name" .Values.lenderConsole.name) | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.lenderConsole.configmap }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/lender/templates/lenderConsole/deployment.yaml
+++ b/charts/lender/templates/lenderConsole/deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.lenderConsole.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lenderConsole.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lenderConsole.name "name" .Values.lenderConsole.name) | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ if hasKey .Values.lenderConsole "revisionHistoryLimit" }}{{ .Values.lenderConsole.revisionHistoryLimit }}{{ else }}10{{ end }}
+  replicas: {{ .Values.lenderConsole.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lender.selectorLabels" (dict "context" . "name" .Values.lenderConsole.name "component" .Values.lenderConsole.name) | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.lenderConsole.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lender.labels" (dict "context" . "component" .Values.lenderConsole.name "name" .Values.lenderConsole.name) | nindent 8 }}
+    spec:
+      {{- with .Values.lenderConsole.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.lenderConsole.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "lenderConsole.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.lenderConsole.securityContext | nindent 12 }}
+          image: "{{ .Values.lenderConsole.image.repository }}:{{ required "lenderConsole.image.tag is required when lenderConsole.enabled=true" .Values.lenderConsole.image.tag }}"
+          imagePullPolicy: {{ .Values.lenderConsole.image.pullPolicy }}
+          {{- if .Values.lenderConsole.configmap }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "lenderConsole.fullname" . }}
+          {{- end }}
+          {{- with .Values.lenderConsole.extraEnvVars }}
+          env:
+            {{- range . }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.lenderConsole.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.lenderConsole.resources | nindent 12 }}
+      {{- with .Values.lenderConsole.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lenderConsole.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lenderConsole.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lender/templates/lenderConsole/ingress.yaml
+++ b/charts/lender/templates/lenderConsole/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.lenderConsole.enabled .Values.lenderConsole.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "lenderConsole.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lenderConsole.name "name" .Values.lenderConsole.name) | nindent 4 }}
+  {{- with .Values.lenderConsole.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.lenderConsole.ingress.className }}
+  ingressClassName: {{ .Values.lenderConsole.ingress.className }}
+  {{- end }}
+  {{- if .Values.lenderConsole.ingress.tls }}
+  tls:
+    {{- range .Values.lenderConsole.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.lenderConsole.ingress.hosts }}
+    {{- if .host }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "lenderConsole.fullname" $ }}
+                port:
+                  number: {{ $.Values.lenderConsole.service.port }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/lender/templates/lenderConsole/service.yaml
+++ b/charts/lender/templates/lenderConsole/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.lenderConsole.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lenderConsole.fullname" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "lender.labels" (dict "context" . "component" .Values.lenderConsole.name "name" .Values.lenderConsole.name) | nindent 4 }}
+  {{- with .Values.lenderConsole.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.lenderConsole.service.type }}
+  ports:
+    - port: {{ .Values.lenderConsole.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lender.selectorLabels" (dict "context" . "name" .Values.lenderConsole.name "component" .Values.lenderConsole.name) | nindent 4 }}
+{{- end }}

--- a/charts/lender/values-template.yaml
+++ b/charts/lender/values-template.yaml
@@ -1,0 +1,90 @@
+# Template values for lender deployment.
+# Copy this file and customize for your environment (GitOps overlay).
+
+namespaceOverride: "lender"
+
+global:
+  externalPostgresDefinitions:
+    enabled: false
+    connection:
+      host: ""
+      port: "5432"
+    postgresAdminLogin:
+      useExistingSecret:
+        name: ""
+      username: ""
+      password: ""
+    lenderCredentials:
+      useExistingSecret:
+        name: ""
+      password: ""
+
+lender:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/lerianstudio/lender
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  imagePullSecrets:
+    - name: ghcr-credential
+
+  ingress:
+    # Disabled in the template overlay so the default cannot render a hostless
+    # Ingress matching arbitrary hostnames. Enable and set a host per environment.
+    enabled: false
+    className: "nginx"
+    annotations: {}
+    hosts: []
+    tls: []
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+
+  configmap:
+    ENV_NAME: ""
+    SERVER_ADDRESS: ":4017"
+    LOG_LEVEL: "info"
+    POSTGRES_HOST: ""
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: "lender"
+    POSTGRES_NAME: "lender"
+    POSTGRES_SSLMODE: "disable"
+    ALLOW_INSECURE_TLS: "true"
+    REDIS_HOST: ""
+    REDIS_DB: "0"
+    PLUGIN_AUTH_ENABLED: "false"
+    PLUGIN_AUTH_HOST: ""
+    ENABLE_TELEMETRY: "false"
+    OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    MULTI_TENANT_ENABLED: "false"
+
+  secrets:
+    POSTGRES_PASSWORD: ""
+    REDIS_PASSWORD: ""
+    AUTH_JWT_SECRET: ""
+
+  useExistingSecret: false
+  existingSecretName: ""
+
+# UI component — keep disabled until a lender-ui image is wired per environment.
+lenderConsole:
+  enabled: false
+  image:
+    repository: ghcr.io/lerianstudio/lender-ui
+    pullPolicy: IfNotPresent
+    tag: ""

--- a/charts/lender/values.schema.json
+++ b/charts/lender/values.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "lender": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "lenderConsole": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/charts/lender/values.yaml
+++ b/charts/lender/values.yaml
@@ -1,0 +1,483 @@
+# Default values for lender components.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+#
+# Chart is multi-component:
+#   * lender        -> the Go API (main component; image tag lands at lender.image.tag)
+#   * lenderConsole -> the Vite/React "lender-console" UI (disabled by default; no image exists yet)
+nameOverride: "lender"
+fullnameOverride: ""
+namespaceOverride: "lender"
+
+global:
+  # -- Bootstrap job for external PostgreSQL: creates database, role, and grants privileges.
+  # This job ONLY provisions the DB/role idempotently. Schema migrations are operator-driven
+  # (cmd/migrate up) and run out-of-band; the runtime image ships no migrate binary.
+  externalPostgresDefinitions:
+    # -- Enable or disable the PostgreSQL bootstrap job
+    enabled: false
+    # -- PostgreSQL connection settings
+    connection:
+      # -- PostgreSQL host
+      host: "lender-postgresql"
+      # -- PostgreSQL port
+      port: "5432"
+    # -- Admin credentials for PostgreSQL
+    postgresAdminLogin:
+      useExistingSecret:
+        # -- Name of existing secret containing DB_USER_ADMIN and DB_ADMIN_PASSWORD keys
+        name: ""
+      # -- Admin username (ignored if useExistingSecret.name is set)
+      username: "postgres"
+      # -- Admin password (ignored if useExistingSecret.name is set).
+      # No default: supply explicitly or use useExistingSecret.name.
+      password: ""
+    # -- Credentials for the lender role created by the job
+    lenderCredentials:
+      useExistingSecret:
+        # -- Name of existing secret containing DB_PASSWORD_LENDER key
+        name: ""
+      # -- Password for the lender role (ignored if useExistingSecret.name is set).
+      # No default: supply explicitly or use useExistingSecret.name.
+      password: ""
+
+lender:
+  # -- Service name
+  name: lender
+
+  # -- Service description
+  description: "Lerian credit journey engine (API)"
+
+  # -- Enable or disable the lender API service
+  enabled: true
+
+  # -- Number of replicas for the lender service
+  replicaCount: 1
+
+  # -- Number of old ReplicaSets to retain for deployment rollback
+  revisionHistoryLimit: 10
+
+  image:
+    # -- Repository for the lender API container image
+    repository: ghcr.io/lerianstudio/lender
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+    # -- Image tag used for deployment (release pipeline sets this via lender.tag mapping)
+    tag: "1.0.0-beta.48"
+
+  # -- Secrets for pulling images from a private registry
+  imagePullSecrets:
+    - name: ghcr-credential
+
+  # -- Pod annotations for additional metadata
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext:
+    # -- Defines the group ID for the user running the process inside the container
+    runAsGroup: 1000
+    # -- Defines the user ID for the process running inside the container
+    runAsUser: 1000
+    # -- Ensures the process does not run as root
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+    # -- Blocks privilege escalation inside the container
+    allowPrivilegeEscalation: false
+    # -- Defines the root filesystem as read-only
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- PodDisruptionBudget configuration
+  pdb:
+    # -- Enable or disable PodDisruptionBudget
+    enabled: true
+    # -- Minimum number of available pods
+    minAvailable: 1
+    # -- Maximum number of unavailable pods
+    maxUnavailable: 1
+    # -- Annotations for the PodDisruptionBudget
+    annotations: {}
+
+  # -- Deployment update strategy
+  deploymentUpdate:
+    # -- Type of deployment strategy
+    type: RollingUpdate
+    # -- Maximum number of pods that can be created over the desired number of pods
+    maxSurge: 1
+    # -- Maximum number of pods that can be unavailable during the update
+    maxUnavailable: 1
+
+  service:
+    # -- Kubernetes service type
+    type: ClusterIP
+    # -- Port for the HTTP API (SERVER_ADDRESS binds 0.0.0.0:4017)
+    port: 4017
+    annotations: {}
+
+  ingress:
+    # -- Enable or disable ingress
+    enabled: true
+    # -- Ingress class name
+    className: "nginx"
+    # -- Additional ingress annotations (host/group set by GitOps values)
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "Lender"
+      gethomepage.dev/description: "Lerian credit journey engine"
+    hosts:
+      - host: "lender.lerian.net"
+        paths:
+          - path: /
+            pathType: Prefix
+    # -- TLS configuration for ingress
+    tls: []
+
+  resources:
+    # -- CPU and memory limits for pods
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    # -- Minimum CPU and memory requests
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  autoscaling:
+    # -- Enable or disable horizontal pod autoscaling
+    enabled: true
+    # -- Minimum number of replicas
+    minReplicas: 1
+    # -- Maximum number of replicas
+    maxReplicas: 5
+    # -- Target CPU utilization percentage for autoscaling
+    targetCPUUtilizationPercentage: 80
+    # -- Target memory utilization percentage for autoscaling
+    targetMemoryUtilizationPercentage: 80
+
+  # -- Node selector for scheduling pods on specific nodes
+  nodeSelector: {}
+
+  # -- Tolerations for scheduling on tainted nodes
+  tolerations: {}
+
+  # -- Affinity rules for pod scheduling
+  affinity: {}
+
+  # -- ConfigMap for non-sensitive environment variables.
+  # @default -- templates/configmap.yaml
+  # NOTE: keys mirror config/.env.example (the app config superset). Feature flags default OFF
+  # so the service boots single-tenant with rabbit/streaming/multi-tenant/outbox disabled.
+  configmap:
+    # Application Settings
+    ENV_NAME: "production"
+    LOG_LEVEL: "info"
+    DEPLOYMENT_MODE: "production"
+    SERVER_ADDRESS: ":4017"
+    HTTP_BODY_LIMIT_BYTES: "104857600"
+
+    # CORS (legacy names)
+    CORS_ALLOWED_ORIGINS: "*"
+    CORS_ALLOWED_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+    CORS_ALLOWED_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID,X-Idempotency,Idempotency-Key"
+    CORS_EXPOSE_HEADERS: ""
+    CORS_ALLOW_CREDENTIALS: "false"
+
+    # CORS (active lib-commons ACCESS_CONTROL_* names)
+    ACCESS_CONTROL_ALLOW_ORIGIN: "*"
+    ACCESS_CONTROL_ALLOW_METHODS: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+    ACCESS_CONTROL_ALLOW_HEADERS: "Origin,Content-Type,Accept,Authorization,X-Request-ID,X-Idempotency,Idempotency-Key"
+    ACCESS_CONTROL_EXPOSE_HEADERS: ""
+    ACCESS_CONTROL_ALLOW_CREDENTIALS: "false"
+
+    # TLS
+    TLS_TERMINATED_UPSTREAM: "true"
+
+    # Tenancy
+    DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"
+
+    # PostgreSQL (primary, non-secret)
+    POSTGRES_HOST: "postgres.lender.lerian.net"
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: "lender"
+    POSTGRES_NAME: "lender"
+    POSTGRES_SSLMODE: "disable"
+    # lib-commons refuses a plaintext (sslmode=disable) connection unless this is set.
+    # Managed data tier is plaintext, so default is "true".
+    ALLOW_INSECURE_TLS: "true"
+    MIGRATIONS_PATH: "migrations"
+    MIGRATIONS_BR_PATH: "internal/jurisdictions/br/migrations"
+
+    # PostgreSQL connection pool
+    POSTGRES_MAX_OPEN_CONNS: "25"
+    POSTGRES_MAX_IDLE_CONNS: "5"
+    POSTGRES_CONN_MAX_LIFETIME_MINS: "30"
+    POSTGRES_CONN_MAX_IDLE_TIME_MINS: "5"
+    POSTGRES_CONNECT_TIMEOUT_SEC: "10"
+
+    # Redis / Valkey (non-secret)
+    REDIS_HOST: "valkey.lender.lerian.net:6379"
+    REDIS_DB: "0"
+    REDIS_PROTOCOL: "3"
+    REDIS_POOL_SIZE: "10"
+    REDIS_MIN_IDLE_CONNS: "2"
+    REDIS_READ_TIMEOUT: "3"
+    REDIS_WRITE_TIMEOUT: "3"
+    REDIS_DIAL_TIMEOUT: "5"
+    REDIS_POOL_TIMEOUT: "2"
+    REDIS_MAX_RETRIES: "3"
+    REDIS_MIN_RETRY_BACKOFF: "8"
+    REDIS_MAX_RETRY_BACKOFF: "1"
+
+    # Authentication (lib-auth + plugin-auth)
+    PLUGIN_AUTH_ENABLED: "false"
+    PLUGIN_AUTH_HOST: "http://plugin-access-manager-auth:4000"
+
+    # API Documentation (unified Huma OpenAPI 3.1)
+    SWAGGER_ENABLED: "true"
+
+    # Local resilience sample provider mode
+    EXAMPLE_STATUS_PROVIDER_MODE: "healthy"
+
+    # Infrastructure boot timeout
+    INFRA_CONNECT_TIMEOUT_SEC: "30"
+
+    # OpenTelemetry
+    ENABLE_TELEMETRY: "false"
+    OTEL_LIBRARY_NAME: "github.com/LerianStudio/lender"
+    OTEL_RESOURCE_SERVICE_NAME: "lender"
+    OTEL_EXPORTER_OTLP_ENDPOINT: ""
+    OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "production"
+    DB_METRICS_INTERVAL_SEC: "15"
+
+    # Rate limiting
+    RATE_LIMIT_ENABLED: "true"
+    RATE_LIMIT_MAX: "500"
+    RATE_LIMIT_WINDOW_SEC: "60"
+    AGGRESSIVE_RATE_LIMIT_MAX: "100"
+    AGGRESSIVE_RATE_LIMIT_WINDOW_SEC: "60"
+    RELAXED_RATE_LIMIT_MAX: "1000"
+    RELAXED_RATE_LIMIT_WINDOW_SEC: "60"
+    ALLOW_RUNTIME_RATELIMIT_DISABLE: "true"
+
+    # Idempotency
+    IDEMPOTENCY_RETRY_WINDOW_SEC: "300"
+
+    # Pagination
+    MAX_PAGINATION_LIMIT: "100"
+    MAX_PAGINATION_MONTH_DATE_RANGE: "3"
+
+    # M2M credentials (non-secret; provider stays off until M2M_TARGET_SERVICE is set)
+    M2M_CREDENTIAL_CACHE_TTL_SEC: "300"
+    AWS_REGION: "us-east-1"
+
+    # Circuit breaker starter
+    CIRCUIT_BREAKER_ENABLED: "false"
+
+    # Borrower collection issuance (off)
+    COLLECTION_ENABLED: "false"
+
+    # Bounded raw-body collection webhook listener (off)
+    COLLECTION_WEBHOOK_ENABLED: "false"
+    COLLECTION_WEBHOOK_ADDRESS: ":9081"
+    COLLECTION_WEBHOOK_BODY_LIMIT_BYTES: "1048576"
+    COLLECTION_WEBHOOK_MAX_SKEW_SEC: "300"
+    COLLECTION_WEBHOOK_UPSTREAM_TLS_TERMINATION_VALIDATED: "false"
+
+    # Outbox starter (off; all knobs non-sensitive)
+    OUTBOX_ENABLED: "false"
+    OUTBOX_TABLE_NAME: "outbox_events"
+    OUTBOX_DISPATCH_INTERVAL_SEC: "2"
+    OUTBOX_BATCH_SIZE: "50"
+    OUTBOX_PUBLISH_MAX_ATTEMPTS: "3"
+    OUTBOX_PUBLISH_BACKOFF_MS: "200"
+    OUTBOX_RETRY_WINDOW_SEC: "300"
+    OUTBOX_MAX_DISPATCH_ATTEMPTS: "10"
+    OUTBOX_PROCESSING_TIMEOUT_SEC: "600"
+    OUTBOX_MAX_FAILED_PER_BATCH: "25"
+    OUTBOX_INCLUDE_TENANT_METRICS: "false"
+    OUTBOX_ALLOW_EMPTY_TENANT: "true"
+
+    # Streaming (Redpanda/Kafka) starter (off; non-secret knobs; SASL creds via secrets passthrough)
+    STREAMING_ENABLED: "false"
+    STREAMING_BROKERS: "localhost:9092"
+    STREAMING_CLIENT_ID: "lender"
+    STREAMING_CB_FAILURE_RATIO: "0.5"
+    STREAMING_CB_MIN_REQUESTS: "10"
+    STREAMING_CB_TIMEOUT_S: "30"
+    STREAMING_CLOSE_TIMEOUT_S: "30"
+    STREAMING_TLS_ENABLED: "false"
+
+    # Inbound consignado consumer opt-in flags (all dark by default)
+    CONSUMER_CONSIGNADO_AVERBACAO_CONFIRMED_ENABLED: "false"
+    CONSUMER_CONSIGNADO_AVERBACAO_REJECTED_ENABLED: "false"
+    CONSUMER_CONSIGNADO_EMPLOYMENT_STATUS_REPORTED_ENABLED: "false"
+    CONSUMER_CONSIGNADO_REDIRECTION_OUTCOME_ENABLED: "false"
+    CONSUMER_CONSIGNADO_RECONCILIATION_RECEIVED_ENABLED: "false"
+    CONSUMER_CONSIGNADO_MATCH_RUN_COMPLETED_ENABLED: "false"
+
+    # Consignado exclusion local worker tunables
+    CONSIGNADO_EXCLUSION_LOCAL_BATCH_SIZE: "50"
+    CONSIGNADO_EXCLUSION_LOCAL_TENANT_CONCURRENCY: "4"
+    CONSIGNADO_EXCLUSION_LOCAL_LEASE_SECONDS: "30"
+    CONSIGNADO_EXCLUSION_LOCAL_BACKOFF_BASE_SECONDS: "1"
+    CONSIGNADO_EXCLUSION_LOCAL_BACKOFF_MAX_SECONDS: "300"
+    CONSIGNADO_EXCLUSION_LOCAL_POLL_INTERVAL_MS: "1000"
+
+    # RabbitMQ starter (off; non-secret knobs; RABBITMQ_DEFAULT_PASS via secrets passthrough)
+    RABBITMQ_ENABLED: "false"
+    RABBITMQ_HOST: "localhost"
+    RABBITMQ_PORT_AMQP: "5672"
+    RABBITMQ_PORT_HOST: "15672"
+    RABBITMQ_DEFAULT_USER: "lender"
+    RABBITMQ_VHOST: "/"
+    RABBITMQ_EXCHANGE: "events"
+    RABBITMQ_REQUIRE_HEALTH_ALLOWED_HOSTS: "false"
+    RABBITMQ_ALLOW_INSECURE_HEALTH_CHECK: "false"
+    RABBITMQ_ALLOW_INSECURE_TLS: "false"
+    RABBITMQ_PUBLISHER_CONFIRM_TIMEOUT_MS: "5000"
+    RABBITMQ_PUBLISHER_RECOVERY_INITIAL_MS: "1000"
+    RABBITMQ_PUBLISHER_RECOVERY_MAX_MS: "30000"
+    RABBITMQ_PUBLISHER_MAX_RECOVERIES: "10"
+
+    # Multi-tenant starter (off). When enabled, the block below is rendered and
+    # MULTI_TENANT_URL / MULTI_TENANT_REDIS_HOST become required.
+    MULTI_TENANT_ENABLED: "false"
+
+  # -- Secrets for storing sensitive data (rendered as stringData; AVP substitutes <path:...>).
+  # Range-based: add any additional credential key here (e.g. RABBITMQ_DEFAULT_PASS,
+  # MULTI_TENANT_SERVICE_API_KEY, MULTI_TENANT_REDIS_PASSWORD, STREAMING_SASL_PASSWORD)
+  # to inject it as an env var when you enable the corresponding feature.
+  # @default -- templates/secrets.yaml
+  secrets:
+    # -- PostgreSQL password. No default: supply explicitly (e.g. AVP <path:...>)
+    # or set useExistingSecret=true. Install fails if empty and useExistingSecret=false.
+    POSTGRES_PASSWORD: ""
+    # -- Redis / Valkey password (empty if auth disabled)
+    REDIS_PASSWORD: ""
+    # -- JWT signing secret
+    AUTH_JWT_SECRET: ""
+
+  # -- Use an existing secret instead of rendering the secrets block
+  useExistingSecret: false
+  existingSecretName: ""
+
+  # -- Extra environment variables (name/value) merged into the ConfigMap.
+  # GitOps escape hatch: set any additional key without a chart change.
+  extraEnvVars: []
+
+  serviceAccount:
+    # -- Specifies whether a ServiceAccount should be created
+    create: true
+    # -- Annotations for the ServiceAccount
+    annotations: {}
+    # -- Name of the service account
+    # @default -- `lender.fullname`
+    name: ""
+
+# lender-console (UI) — Vite/React SPA "lender-console".
+# DISABLED by default: there is no UI image published today (no UI Dockerfile;
+# the release pipeline builds only the Go API image). The skeleton below lets a
+# future UI be wired without a chart change; keep enabled=false until an image exists.
+lenderConsole:
+  # -- Enable or disable the lender console (UI) component
+  enabled: false
+
+  # -- Service name
+  name: lender-console
+
+  # -- Number of replicas for the console
+  replicaCount: 1
+
+  # -- Number of old ReplicaSets to retain for deployment rollback
+  revisionHistoryLimit: 10
+
+  image:
+    # -- Repository for the console (UI) container image. Published as `lender-ui`
+    #    (Vite SPA -> nginx-unprivileged), matching the matcher-ui convention.
+    repository: ghcr.io/lerianstudio/lender-ui
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+    # -- Image tag (must be set before enabling the component)
+    tag: ""
+
+  # -- Secrets for pulling images from a private registry
+  imagePullSecrets:
+    - name: ghcr-credential
+
+  # -- Pod annotations for additional metadata
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext:
+    # uid/gid 101 = the nginxinc/nginx-unprivileged runtime user (matches the
+    # lender-ui image and the matcher-ui reference). NOT 1000.
+    runAsGroup: 101
+    runAsUser: 101
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem intentionally NOT defaulted here (repo strict
+    # validator rejects a `false` chart default). nginx-unprivileged needs a
+    # writable root fs (pid/temp/cache under /tmp and /var/cache/nginx, plus the
+    # /config.js render at start), so every environment that enables the console
+    # sets `readOnlyRootFilesystem: false` explicitly in its own values overlay.
+    # With the key unset the container inherits the Kubernetes default (writable),
+    # which matches that behavior. Proper fix (emptyDir mounts + readOnly=true,
+    # as matcher-ui does) is tracked as a follow-up.
+    seccompProfile:
+      type: RuntimeDefault
+
+  service:
+    # -- Kubernetes service type
+    type: ClusterIP
+    # -- Port for the UI HTTP server
+    port: 8080
+    annotations: {}
+
+  ingress:
+    # -- Enable or disable ingress
+    enabled: true
+    # -- Ingress class name
+    className: "nginx"
+    # -- Additional ingress annotations (host/group set by GitOps values)
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    hosts:
+      - host: "lender-console.lerian.net"
+        paths:
+          - path: /
+            pathType: Prefix
+    # -- TLS configuration for ingress
+    tls: []
+
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+  # -- Node selector for scheduling pods on specific nodes
+  nodeSelector: {}
+
+  # -- Tolerations for scheduling on tainted nodes
+  tolerations: {}
+
+  # -- Affinity rules for pod scheduling
+  affinity: {}
+
+  # -- ConfigMap for the console (non-sensitive UI runtime config)
+  configmap: {}
+
+  # -- Extra environment variables (name/value) for the console
+  extraEnvVars: []


### PR DESCRIPTION
## What

Migrates the **lender-helm** multi-component chart (API `lender` + UI `lenderConsole`) from `helm-internal` into this public product repo, so the credit product (Underwriter family) ships like the other products (midaz/fetcher/reporter/matcher).

## How — pure identity-preserving lift-and-shift

- Templates copied **byte-for-byte** from `helm-internal/charts/lender`, restructured into the public multi-component tree: `templates/lender/`, `templates/lenderConsole/`, shared `_helpers.tpl` + `bootstrap-postgres.yaml` at `templates/` root — mirroring `charts/matcher` @ develop.
- `values.schema.json` **generated** by `generate-values-schemas` (not hand-written).
- `README.md` with the `## Chart Contract` block; CI render fixture at `.github/configs/helm-render-values/lender.yaml` (both components enabled with dummy values).
- `pr-title.yml`: added `lender` scope. Root `README.md`: added `### Lender` version-mapping section.

## Safety — rendered output is byte-identical to the live chart

Render-diff vs the live `helm-internal` chart with each tier's values: **selectors / resource names / ports / probes identical**; the only differences are `# Source:` paths (file relocation) and the `helm.sh/chart` label. This means the downstream gitops cutover swaps the chart source with **zero selector churn** (no immutable-field conflict, at most one rolling restart).

## Gates

- `validate-helm-charts --strict` → 0 violations (baseline empty).
- `validate-helm-charts --render-gate --charts lender` → ok.
- `helm lint` + `helm template` (console on/off) → pass.

## Deferred to a follow-up hardening PR (kept out to preserve identity)

CodeRabbit findings on the copied chart are deliberately **not** applied here (applying them would break the byte-identity that de-risks the cutover; the Deployment-selector one is an immutable field that would force a recreate/outage). Tracked as the hardening backlog:
- API Deployment selector component discriminator (immutable → needs deliberate per-tier recreate)
- `readOnlyRootFilesystem: true` + emptyDir + init-container for the console
- bootstrap PreSync Job: `activeDeadlineSeconds`, `automountServiceAccountToken: false`, `psql \getenv`
- values default hygiene (PG host alignment, SSL-mode/insecure-TLS production defaults)
- console probes → configurable values

## After merge

semantic-release publishes `oci://ghcr.io/lerianstudio/lender-helm` (+ dockerhub). GitOps then swaps the helmfile chart ref off `helm-internal`, tier-by-tier, manual sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)