### PR TITLE
feat(charts): support LICENSE_KEY and ORGANIZATION_IDS in br-ccs secrets

### DIFF
--- a/charts/br-ccs/templates/secrets.yaml
+++ b/charts/br-ccs/templates/secrets.yaml
@@ -64,6 +64,18 @@ stringData:
   FETCHER_CRYPTO_KEY: {{ $s.FETCHER_CRYPTO_KEY | quote }}
   {{- end }}
 
+  # License (lib-license-go). Read as env via the envFrom secretRef. LICENSE_KEY
+  # authorizes the app against the Lerian license gateway at boot (fail-closed);
+  # ORGANIZATION_IDS selects the enforcement scope (e.g. "global"). Held as a
+  # Secret (not a ConfigMap) so the key material is not exposed in plain
+  # manifests, matching the br-slc / br-sta / fetcher convention.
+  {{- if $s.LICENSE_KEY }}
+  LICENSE_KEY: {{ $s.LICENSE_KEY | quote }}
+  {{- end }}
+  {{- if $s.ORGANIZATION_IDS }}
+  ORGANIZATION_IDS: {{ $s.ORGANIZATION_IDS | quote }}
+  {{- end }}
+
   # Object storage credentials (per bucket)
   {{- range $k := (list "OBJECT_STORAGE_STA_ACCESS_KEY" "OBJECT_STORAGE_STA_SECRET_KEY" "OBJECT_STORAGE_CCS_ACCESS_KEY" "OBJECT_STORAGE_CCS_SECRET_KEY" "OBJECT_STORAGE_FETCHER_ACCESS_KEY" "OBJECT_STORAGE_FETCHER_SECRET_KEY") }}
   {{- if index $s $k }}

--- a/charts/br-ccs/values-template.yaml
+++ b/charts/br-ccs/values-template.yaml
@@ -116,6 +116,10 @@ brCcs:
     CCS_CRYPTO_MASTER_KEY: ""  # AES-256-GCM master key, 64 hex chars (openssl rand -hex 32)
     FETCHER_CRYPTO_KEY: ""     # Fetcher snapshot decryption key (base64; = Fetcher APP_ENC_KEY)
 
+    # License (lib-license-go; validated at boot, fail-closed)
+    # LICENSE_KEY: ""          # Lerian license key
+    # ORGANIZATION_IDS: ""     # enforcement scope (e.g. "global")
+
     # Object storage credentials (set alongside the matching *_BUCKET)
     # OBJECT_STORAGE_STA_ACCESS_KEY: ""
     # OBJECT_STORAGE_STA_SECRET_KEY: ""

--- a/charts/br-ccs/values.yaml
+++ b/charts/br-ccs/values.yaml
@@ -564,6 +564,12 @@ brCcs:
     CCS_CRYPTO_MASTER_KEY: ""
     FETCHER_CRYPTO_KEY: ""
 
+    # License (lib-license-go) — validated at boot against the Lerian license
+    # gateway (fail-closed). ORGANIZATION_IDS selects enforcement scope (e.g.
+    # "global"). Held as a Secret; wire via a secrets manager or existing Secret.
+    # LICENSE_KEY: ""
+    # ORGANIZATION_IDS: ""
+
     # Object storage credentials (per bucket)
     OBJECT_STORAGE_STA_ACCESS_KEY: ""
     OBJECT_STORAGE_STA_SECRET_KEY: ""


### PR DESCRIPTION
## Description

The br-ccs chart's `templates/secrets.yaml` renders `brCcs.secrets` through an **explicit allowlist**, so any key not on that list is silently dropped from the rendered Secret. `LICENSE_KEY` and `ORGANIZATION_IDS` (lib-license-go, GLOBAL enforcement) were not on the list — so a consumer wiring them under `brCcs.secrets` got an empty license env and failed the boot-time gateway check (fail-closed).

This adds both keys to the Secret allowlist (gated by `if`, so they render only when set) and documents them in `values.yaml` / `values-template.yaml`. They are held as a **Secret** (not a ConfigMap), matching the br-slc / br-sta / fetcher convention.

Enables the gitops wiring merged in LerianStudio/lerian-internal-gitops#1619 (br-ccs LICENSE_KEY/ORGANIZATION_IDS on dev-st/stg-st/prd-st) to actually render.

## Type of Change

- [x] New feature (chart supports two additional optional secret keys)

## Breaking Changes

None. Both keys are optional and gated by `if`; charts that don't set them render exactly as before.

## Testing

- [x] `helm lint` — 0 charts failed
- [x] `helm template` with `LICENSE_KEY`/`ORGANIZATION_IDS` set → both appear in the rendered Secret
- [x] `helm template` without them → absent (no empty keys)

## Obs

`Chart.yaml` version intentionally not bumped — semantic-release handles it on merge.