### PR TITLE
feat(charts): add per-upstream M2M OAuth2 client credentials to br-ccs secrets

### DIFF
--- a/charts/br-ccs/templates/secrets.yaml
+++ b/charts/br-ccs/templates/secrets.yaml
@@ -89,5 +89,16 @@ stringData:
   {{ $k }}: {{ index $s $k | quote }}
   {{- end }}
   {{- end }}
+
+  # Per-upstream M2M OAuth2 client credentials (single-tenant). The client_id/client_secret
+  # pair authenticates br-ccs to each upstream (Fetcher / Reporter / STA) via the
+  # plugin-auth token endpoint. Multi-tenant (SaaS) resolves per-tenant credentials from
+  # AWS Secrets Manager instead and ignores these. Held as a Secret (never a ConfigMap) so
+  # the client secrets are not exposed in plain manifests, matching the *_API_KEY convention.
+  {{- range $k := (list "FETCHER_CLIENT_ID" "FETCHER_CLIENT_SECRET" "REPORTER_CLIENT_ID" "REPORTER_CLIENT_SECRET" "STA_CLIENT_ID" "STA_CLIENT_SECRET") }}
+  {{- if index $s $k }}
+  {{ $k }}: {{ index $s $k | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/br-ccs/values-template.yaml
+++ b/charts/br-ccs/values-template.yaml
@@ -128,10 +128,18 @@ brCcs:
     # OBJECT_STORAGE_FETCHER_ACCESS_KEY: ""
     # OBJECT_STORAGE_FETCHER_SECRET_KEY: ""
 
-    # Per-upstream M2M API keys (on-prem / local fallback; SaaS uses OAuth2)
+    # Per-upstream M2M API keys (on-prem / local literal-Bearer fallback)
     # FETCHER_API_KEY: ""
     # REPORTER_API_KEY: ""
     # STA_API_KEY: ""
+
+    # Per-upstream M2M OAuth2 client credentials (single-tenant; via plugin-auth token endpoint)
+    # FETCHER_CLIENT_ID: ""
+    # FETCHER_CLIENT_SECRET: ""
+    # REPORTER_CLIENT_ID: ""
+    # REPORTER_CLIENT_SECRET: ""
+    # STA_CLIENT_ID: ""
+    # STA_CLIENT_SECRET: ""
 
     # Multi-tenant (tenant-manager)
     # MULTI_TENANT_SERVICE_API_KEY: ""

--- a/charts/br-ccs/values.yaml
+++ b/charts/br-ccs/values.yaml
@@ -578,10 +578,22 @@ brCcs:
     OBJECT_STORAGE_FETCHER_ACCESS_KEY: ""
     OBJECT_STORAGE_FETCHER_SECRET_KEY: ""
 
-    # Per-upstream M2M API keys (on-prem / local fallback; SaaS uses OAuth2)
+    # Per-upstream M2M API keys (on-prem / local literal-Bearer fallback)
     # FETCHER_API_KEY: ""
     # REPORTER_API_KEY: ""
     # STA_API_KEY: ""
+
+    # Per-upstream M2M OAuth2 client credentials (single-tenant) — the client_id/client_secret
+    # pair that authenticates br-ccs to each upstream (Fetcher / Reporter / STA) via
+    # the plugin-auth token endpoint. Multi-tenant (SaaS) resolves per-tenant credentials
+    # from AWS Secrets Manager instead. Held as a Secret; wire via a secrets manager or
+    # existing Secret.
+    # FETCHER_CLIENT_ID: ""
+    # FETCHER_CLIENT_SECRET: ""
+    # REPORTER_CLIENT_ID: ""
+    # REPORTER_CLIENT_SECRET: ""
+    # STA_CLIENT_ID: ""
+    # STA_CLIENT_SECRET: ""
 
   # -- Existing secrets name
   useExistingSecret: false


### PR DESCRIPTION
## Pull Request Type

- [x] BR CCS

## Checklist

- [x] I have tested these changes locally.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have confirmed this code is ready for review.

## Additional Notes

Adds six per-upstream M2M OAuth2 secret keys (`FETCHER_/REPORTER_/STA_CLIENT_ID` and `_CLIENT_SECRET`) to the br-ccs chart's Opaque Secret, rendered only when set (mirrors the existing `*_API_KEY` block). They back the **single-tenant** M2M mint; multi-tenant (SaaS) resolves per-tenant credentials from AWS Secrets Manager and ignores them. `PLUGIN_AUTH_ENABLED`/`PLUGIN_AUTH_HOST` already render in the ConfigMap (no change).

Validation: `helm lint` 0 failed; `helm template` confirms the keys render into the Secret only (never the ConfigMap), and unset keys are gated out.

This is a `feat` so semantic-release cuts **beta.4** — required by the paired gitops change (LerianStudio/midaz-firmino-gitops) which pins this version to render the new secret handlers.
