### PR TITLE
feat(new): shared Helm library chart

### DIFF
--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -244,11 +244,18 @@ func collectViolations(root string) ([]violation, error) {
 
 		chartType := chart.Annotations[chartTypeAnnotation]
 		if !allowedChartTypes[chartType] {
-			violations = append(violations, newViolation(chartName, "invalid-chart-type", chartRel, "Chart.yaml must set annotations.lerian.studio/chart-type to single-service, multi-component, or dependency-wrapper"))
+			violations = append(violations, newViolation(chartName, "invalid-chart-type", chartRel, "Chart.yaml must set annotations.lerian.studio/chart-type to single-service, multi-component, dependency-wrapper, or library"))
 		}
 
-		if chart.Type != "application" && chart.Type != "library" {
-			violations = append(violations, newViolation(chartName, "invalid-chart-kind", chartRel, "Chart.yaml type must be application"))
+		isLibrary := chart.Type == "library"
+		if chart.Type != "application" && !isLibrary {
+			violations = append(violations, newViolation(chartName, "invalid-chart-kind", chartRel, "Chart.yaml type must be application or library"))
+		}
+
+		// The library annotation and the Helm chart kind must agree, so an
+		// application chart cannot claim chart-type: library to skip requirements.
+		if (chartType == "library") != isLibrary {
+			violations = append(violations, newViolation(chartName, "chart-type-mismatch", chartRel, "annotations.lerian.studio/chart-type: library requires (and only applies to) Chart.yaml type: library"))
 		}
 
 		for _, required := range []string{"README.md", "values.yaml"} {
@@ -259,7 +266,7 @@ func collectViolations(root string) ([]violation, error) {
 		}
 		violations = append(violations, validateReadmeContract(root, chartDir, chartName, chartType)...)
 
-		if chartType != "dependency-wrapper" && chartType != "library" {
+		if chartType != "dependency-wrapper" && !isLibrary {
 			valuesTemplate := filepath.Join(chartDir, "values-template.yaml")
 			if !fileExists(valuesTemplate) {
 				violations = append(violations, newViolation(chartName, "missing-values-template", rel(root, valuesTemplate), "application charts must provide values-template.yaml"))

--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -1022,6 +1022,18 @@ func buildRenderInventory(root string) ([]renderRow, error) {
 	return buildRenderRows(root, nil, "")
 }
 
+func isLibraryChart(chartDir string) bool {
+	data, err := os.ReadFile(filepath.Join(chartDir, "Chart.yaml"))
+	if err != nil {
+		return false
+	}
+	var c chartYAML
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return false
+	}
+	return c.Type == "library"
+}
+
 func buildRenderGate(root string, chartSelection map[string]bool, sampleValuesDir string) ([]renderRow, error) {
 	rows, err := buildRenderRows(root, chartSelection, sampleValuesDir)
 	if err != nil {
@@ -1056,6 +1068,16 @@ func buildRenderRows(root string, chartSelection map[string]bool, sampleValuesDi
 			continue
 		}
 		row := renderRow{Chart: chartName}
+
+		// Library charts are not installable (helm template fails); their helpers
+		// are exercised through the consumer charts, so skip the render gate.
+		if isLibraryChart(chartDir) {
+			row.Status = "ok"
+			row.Class = "skipped-library"
+			row.Detail = "library chart — not installable; helpers validated via consumer charts"
+			rows = append(rows, row)
+			continue
+		}
 
 		deps, err := chartDependencies(chartDir)
 		if err != nil {

--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -24,6 +24,7 @@ var allowedChartTypes = map[string]bool{
 	"single-service":     true,
 	"multi-component":    true,
 	"dependency-wrapper": true,
+	"library":            true,
 }
 
 var credentialURLPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://[^\s/@]+:[^\s/@]+@`)
@@ -246,7 +247,7 @@ func collectViolations(root string) ([]violation, error) {
 			violations = append(violations, newViolation(chartName, "invalid-chart-type", chartRel, "Chart.yaml must set annotations.lerian.studio/chart-type to single-service, multi-component, or dependency-wrapper"))
 		}
 
-		if chart.Type != "application" {
+		if chart.Type != "application" && chart.Type != "library" {
 			violations = append(violations, newViolation(chartName, "invalid-chart-kind", chartRel, "Chart.yaml type must be application"))
 		}
 
@@ -258,7 +259,7 @@ func collectViolations(root string) ([]violation, error) {
 		}
 		violations = append(violations, validateReadmeContract(root, chartDir, chartName, chartType)...)
 
-		if chartType != "dependency-wrapper" {
+		if chartType != "dependency-wrapper" && chartType != "library" {
 			valuesTemplate := filepath.Join(chartDir, "values-template.yaml")
 			if !fileExists(valuesTemplate) {
 				violations = append(violations, newViolation(chartName, "missing-values-template", rel(root, valuesTemplate), "application charts must provide values-template.yaml"))

--- a/charts/lerian-common/Chart.yaml
+++ b/charts/lerian-common/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: lerian-common
+description: >-
+  Lerian shared Helm library. Factors the logic duplicated across the product
+  charts into render-equivalent helpers consumed via `include`: env contracts
+  (service discovery, streaming, multi-tenant), in-cluster host derivation, and
+  (progressively) naming/labels, securityContext, probes and workload boilerplate.
+  Library chart — renders nothing on its own. Adopting it is a refactor, not a
+  breaking change: every helper reproduces the existing rendered output.
+type: library
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/LerianStudio/helm
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+keywords:
+  - lerian
+  - library
+  - common
+  - service-discovery

--- a/charts/lerian-common/Chart.yaml
+++ b/charts/lerian-common/Chart.yaml
@@ -10,6 +10,8 @@ description: >-
 type: library
 version: 0.1.0
 appVersion: "0.1.0"
+annotations:
+  lerian.studio/chart-type: library
 home: https://github.com/LerianStudio/helm
 icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
 maintainers:

--- a/charts/lerian-common/README.md
+++ b/charts/lerian-common/README.md
@@ -1,0 +1,51 @@
+# lerian-common
+
+Shared Helm **library chart** for the LerianStudio product charts. It renders
+nothing on its own — it provides render-equivalent helpers (`define`s) consumed
+via `include` by the product charts that declare it as a dependency.
+
+## Helpers
+
+- **Env contracts:** `lerian-common.serviceDiscovery.env`, `lerian-common.streaming.env`,
+  `lerian-common.multiTenant.env` — env-wide constants come from `global.*`
+  (set once per environment); the per-app enable knob stays in the component's
+  `extraEnvVars`/`configmap`; a component value overrides the global default; and
+  each helper stays **inert until `global.*` is set** (backward-compatible).
+- **In-cluster host primitives:** `lerian-common.internalHost`, `lerian-common.internalURL`.
+- **Resource helpers:** `lerian-common.hpa`, `.service`, `.serviceAccount`, `.pdb`, `.ingress`.
+- **Deployment pod-spec fragments:** `lerian-common.scheduling`, `.imagePullSecrets`,
+  `.httpProbe`, `.rolesAnywhere.{sidecar,volume,imdsEnv,podSecurityContext}`.
+- **Dependency helpers:** `lerian-common.dependency.fullname`, `.infraSecretRef`.
+- **`lerian-common.deploymentStrategy`.**
+
+See `values.yaml` for the standard `global.{serviceDiscovery,streaming,multiTenant}` template.
+
+## Usage
+
+```yaml
+# consumer Chart.yaml
+dependencies:
+  - name: lerian-common
+    version: "0.1.0"
+    repository: "file://../lerian-common"
+```
+
+```yaml
+# consumer template (example)
+{{- with (include "lerian-common.serviceDiscovery.env" (dict
+      "context" $ "enabled" true "name" (include "myapp.fullname" .)
+      "port" .Values.app.service.port "namespace" (include "global.namespace" $))) }}
+{{ . | nindent 2 }}
+{{- end }}
+```
+
+## Chart Contract
+
+- Chart type: `library`
+- **Required secrets:** none — this is a library chart; it declares and manages no secrets.
+- **Dependency notes:** no subchart dependencies of its own. Consumers reference it via
+  `repository: "file://../lerian-common"` (monorepo) and vendor it at
+  `helm dependency build`; packaged consumer charts embed it in their `.tgz`.
+- **Production overrides:** set `global.serviceDiscovery`, `global.streaming` and
+  `global.multiTenant` once per environment (umbrella/GitOps). Helpers stay inert until set.
+- **Source/License:** https://github.com/LerianStudio/helm — © Lerian Studio.

--- a/charts/lerian-common/templates/_dependency.tpl
+++ b/charts/lerian-common/templates/_dependency.tpl
@@ -1,0 +1,54 @@
+{{/*
+==============================================================================
+lerian-common — subchart dependency helpers (PostgreSQL, Valkey, MongoDB,
+RabbitMQ, SeaweedFS bundled via Bitnami-style subcharts).
+
+These centralize logic each chart duplicates today:
+  - dependency.fullname : the collapse-aware subchart resource name (vendored
+    from Bitnami common; identical in ~16 charts). Consumers keep their existing
+    `common.names.dependency.fullname` as a 1-line alias to this.
+  - infraSecretRef      : a container env entry (secretKeyRef) that single-sources
+    an infra password from the subchart's own Secret (external path uses an
+    existingSecret). Duplicated in ~12 charts.
+==============================================================================
+*/}}
+
+{{/*
+lerian-common.dependency.fullname — collapse-aware "<release>-<name>" (honors
+release-name collapse, nameOverride, fullnameOverride).
+Inputs: chartName, chartValues, context.
+*/}}
+{{- define "lerian-common.dependency.fullname" -}}
+{{- if .chartValues.fullnameOverride -}}
+{{- .chartValues.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .chartName .chartValues.nameOverride -}}
+{{- if contains $name .context.Release.Name -}}
+{{- .context.Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .context.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+lerian-common.infraSecretRef — a single `env:` entry (secretKeyRef) sourcing an
+infra password from the subchart Secret (or its existingSecret override).
+Inputs: context, subchart, key (secret key), envName (container env var name).
+*/}}
+{{- define "lerian-common.infraSecretRef" -}}
+{{- $ctx := .context -}}
+{{- $sub := .subchart -}}
+{{- $auth := default dict (index $ctx.Values $sub "auth") -}}
+{{- $secretName := "" -}}
+{{- if $auth.existingSecret -}}
+{{- $secretName = $auth.existingSecret -}}
+{{- else -}}
+{{- $secretName = include "lerian-common.dependency.fullname" (dict "chartName" $sub "chartValues" (index $ctx.Values $sub) "context" $ctx) -}}
+{{- end -}}
+- name: {{ .envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: {{ .key }}
+{{- end -}}

--- a/charts/lerian-common/templates/_deployment.tpl
+++ b/charts/lerian-common/templates/_deployment.tpl
@@ -105,9 +105,10 @@ Inputs: kind, probe (values map), port, path, initialDelay, period, timeout, suc
   httpGet:
     path: {{ $p.path | default .path }}
     port: {{ .port }}
-  initialDelaySeconds: {{ $p.initialDelaySeconds | default .initialDelay }}
-  periodSeconds: {{ $p.periodSeconds | default .period }}
-  timeoutSeconds: {{ $p.timeoutSeconds | default .timeout }}
-  successThreshold: {{ $p.successThreshold | default .success }}
-  failureThreshold: {{ $p.failureThreshold | default .failure }}
+  {{- /* hasKey (not | default) so an explicit 0 override is honored, not treated as absent. */}}
+  initialDelaySeconds: {{ if hasKey $p "initialDelaySeconds" }}{{ $p.initialDelaySeconds }}{{ else }}{{ .initialDelay }}{{ end }}
+  periodSeconds: {{ if hasKey $p "periodSeconds" }}{{ $p.periodSeconds }}{{ else }}{{ .period }}{{ end }}
+  timeoutSeconds: {{ if hasKey $p "timeoutSeconds" }}{{ $p.timeoutSeconds }}{{ else }}{{ .timeout }}{{ end }}
+  successThreshold: {{ if hasKey $p "successThreshold" }}{{ $p.successThreshold }}{{ else }}{{ .success }}{{ end }}
+  failureThreshold: {{ if hasKey $p "failureThreshold" }}{{ $p.failureThreshold }}{{ else }}{{ .failure }}{{ end }}
 {{- end -}}

--- a/charts/lerian-common/templates/_deployment.tpl
+++ b/charts/lerian-common/templates/_deployment.tpl
@@ -1,0 +1,113 @@
+{{/*
+==============================================================================
+lerian-common — Deployment sub-blocks (pod-spec fragments).
+
+The full Deployment is too variable to share, but these pod-spec tail fragments
+are byte-identical across ~51 workloads. Each renders NOTHING when its value is
+empty, so wrap the include in the caller so it only appears when present:
+
+  {{- if or .Values.fees.nodeSelector .Values.fees.affinity .Values.fees.tolerations }}
+      {{- include "lerian-common.scheduling" .Values.fees | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fees.imagePullSecrets }}
+      {{- include "lerian-common.imagePullSecrets" . | nindent 6 }}
+  {{- end }}
+
+Emitting at base indent 0 (keys) + toYaml nindent 2; the caller's `nindent 6`
+shifts keys to col 6 and values to col 8 — matching the hand-written blocks.
+*/}}
+
+{{/*
+lerian-common.scheduling — nodeSelector / affinity / tolerations.
+Input: the component values map (reads .nodeSelector/.affinity/.tolerations).
+*/}}
+{{- define "lerian-common.scheduling" -}}
+{{- with .nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+lerian-common.imagePullSecrets — the imagePullSecrets block.
+Input: the imagePullSecrets list (wrap the include in `{{- with }}` in the caller).
+*/}}
+{{- define "lerian-common.imagePullSecrets" -}}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+
+{{/*
+lerian-common.deploymentStrategy — the `strategy:` block (type + optional
+rollingUpdate). Byte-identical across the "type + if RollingUpdate" family
+(~11 deployments) whose value shapes differ (flat `deploymentUpdate.*` vs
+nested `deploymentStrategy.rollingUpdate.*`, some with inline `| default`).
+The helper is shape-agnostic: the CALLER pre-resolves the three values (applying
+its own defaults) so the output stays byte-identical.
+
+Usage (flat deploymentUpdate shape):
+  {{- include "lerian-common.deploymentStrategy" (dict
+        "type" .Values.matcher.deploymentUpdate.type
+        "maxSurge" .Values.matcher.deploymentUpdate.maxSurge
+        "maxUnavailable" .Values.matcher.deploymentUpdate.maxUnavailable
+      ) | nindent 2 }}
+
+Usage (nested deploymentStrategy shape):
+  {{- include "lerian-common.deploymentStrategy" (dict
+        "type" .Values.manager.deploymentStrategy.type
+        "maxSurge" .Values.manager.deploymentStrategy.rollingUpdate.maxSurge
+        "maxUnavailable" .Values.manager.deploymentStrategy.rollingUpdate.maxUnavailable
+      ) | nindent 2 }}
+
+Inputs: type, maxSurge, maxUnavailable. Caller: nindent 2 (under spec:).
+*/}}
+{{- define "lerian-common.deploymentStrategy" -}}
+strategy:
+  type: {{ .type }}
+  {{- if eq .type "RollingUpdate" }}
+  rollingUpdate:
+    maxSurge: {{ .maxSurge }}
+    maxUnavailable: {{ .maxUnavailable }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+lerian-common.httpProbe — one httpGet probe block (readiness/liveness/startup).
+Probes appear in ~49 deployments with an identical structure but the ORDER and
+DEFAULTS vary per chart, so this emits ONE block; the chart calls it once per
+probe in its own order, passing its own defaults (byte-identical).
+
+Usage (deployment.yaml, preserving the chart's existing probe order):
+          {{- include "lerian-common.httpProbe" (dict
+                "kind" "readinessProbe" "probe" .Values.fees.readinessProbe
+                "port" .Values.fees.service.port
+                "path" "/readyz" "initialDelay" 10 "period" 5 "timeout" 1 "success" 1 "failure" 3
+              ) | nindent 10 }}
+          {{- include "lerian-common.httpProbe" (dict
+                "kind" "livenessProbe" "probe" .Values.fees.livenessProbe
+                "port" .Values.fees.service.port
+                "path" "/health" "initialDelay" 5 "period" 5 "timeout" 1 "success" 1 "failure" 3
+              ) | nindent 10 }}
+
+Inputs: kind, probe (values map), port, path, initialDelay, period, timeout, success, failure.
+*/}}
+{{- define "lerian-common.httpProbe" -}}
+{{- $p := .probe | default dict -}}
+{{ .kind }}:
+  httpGet:
+    path: {{ $p.path | default .path }}
+    port: {{ .port }}
+  initialDelaySeconds: {{ $p.initialDelaySeconds | default .initialDelay }}
+  periodSeconds: {{ $p.periodSeconds | default .period }}
+  timeoutSeconds: {{ $p.timeoutSeconds | default .timeout }}
+  successThreshold: {{ $p.successThreshold | default .success }}
+  failureThreshold: {{ $p.failureThreshold | default .failure }}
+{{- end -}}

--- a/charts/lerian-common/templates/_hosts.tpl
+++ b/charts/lerian-common/templates/_hosts.tpl
@@ -1,0 +1,36 @@
+{{/*
+==============================================================================
+lerian-common — in-cluster host derivation primitives.
+
+The `name` and `namespace` are ALWAYS computed by the caller (via
+`common.names.dependency.fullname`, `.Release.Name`-prefixing, `global.namespace`,
+`.Release.Namespace`, or a literal) and passed in as strings. The library only
+assembles the FQDN suffix, so the rendered output stays byte-identical to the
+hand-written printf it replaces.
+
+The four axes of variation observed across the charts are explicit flags:
+  dot    (bool)   -> trailing "." after svc.cluster.local  (the ad-hoc-est knob)
+  port   (number) -> ":<port>" suffix
+  scheme (string) -> "<scheme>://" prefix (internalURL only)
+  path   (string) -> trailing path (internalURL only)
+==============================================================================
+*/}}
+
+{{/*
+lerian-common.internalHost -> <name>.<namespace>.svc.cluster.local[.][:port]
+Inputs: name (req), namespace (req), dot (opt bool), port (opt).
+*/}}
+{{- define "lerian-common.internalHost" -}}
+{{- $h := printf "%s.%s.svc.cluster.local" .name .namespace -}}
+{{- if .dot }}{{- $h = printf "%s." $h -}}{{- end -}}
+{{- if .port }}{{- $h = printf "%s:%v" $h .port -}}{{- end -}}
+{{- $h -}}
+{{- end -}}
+
+{{/*
+lerian-common.internalURL -> <scheme>://<internalHost><path>
+Inputs: scheme (req), name (req), namespace (req), dot/port (opt), path (opt).
+*/}}
+{{- define "lerian-common.internalURL" -}}
+{{- printf "%s://%s%s" .scheme (include "lerian-common.internalHost" .) (default "" .path) -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_hpa.tpl
+++ b/charts/lerian-common/templates/_hpa.tpl
@@ -1,0 +1,67 @@
+{{/*
+==============================================================================
+lerian-common — HorizontalPodAutoscaler (autoscaling/v2).
+
+The HPA manifest is near-identical across ~40 workloads; only naming/labels and
+the presence of a `namespace:` line differ per chart. This helper centralizes
+the STRUCTURE (apiVersion, scaleTargetRef, cpu/memory metric blocks) and takes
+naming/labels as strings ALREADY RENDERED by the chart's own helpers — so the
+output stays byte-identical and no naming/label contract has to be unified first.
+
+The caller owns the enable GATE (it varies: some charts also check the component
+`.enabled`), so wrap the include in the chart's existing `{{- if ... }}`.
+
+Usage (chart hpa.yaml):
+  {{- if .Values.fees.autoscaling.enabled }}
+  {{- include "lerian-common.hpa" (dict
+        "autoscaling" .Values.fees.autoscaling
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  autoscaling (req)  the component's `.autoscaling` map (minReplicas, maxReplicas,
+                     targetCPUUtilizationPercentage, targetMemoryUtilizationPercentage)
+  name        (req)  metadata.name (already rendered, e.g. include "<c>.fullname" .)
+  labels      (req)  the labels block already rendered (no leading indent)
+  namespace   (opt)  metadata.namespace (already rendered); omit the line when empty
+  targetName  (opt)  scaleTargetRef.name (defaults to `name`)
+==============================================================================
+*/}}
+{{- define "lerian-common.hpa" -}}
+{{- $a := .autoscaling -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .targetName | default .name }}
+  minReplicas: {{ $a.minReplicas }}
+  maxReplicas: {{ $a.maxReplicas }}
+  metrics:
+    {{- if $a.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $a.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $a.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $a.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_ingress.tpl
+++ b/charts/lerian-common/templates/_ingress.tpl
@@ -1,0 +1,95 @@
+{{/*
+==============================================================================
+lerian-common — Ingress (standard Helm-scaffold shape).
+
+23 of ~29 chart ingresses are the standard scaffold: KubeVersion-aware
+apiVersion + backend, ingressClassName (>=1.18), optional tls, and rules over
+hosts/paths. Naming/labels are passed ALREADY RENDERED by the chart; the caller
+owns the enable gate. Charts with a non-standard ingress keep it inline.
+
+Usage (chart ingress.yaml):
+  {{- if .Values.fees.ingress.enabled -}}
+  {{- include "lerian-common.ingress" (dict
+        "context" .
+        "ingress" .Values.fees.ingress
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+        "svcPort" .Values.fees.service.port
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  context   (req)  root context ($) — for .Capabilities.KubeVersion
+  ingress   (req)  the component's `.ingress` map (className/annotations/tls/hosts)
+  name      (req)  metadata.name + backend service name (already rendered)
+  labels    (req)  labels block already rendered (no leading indent)
+  svcPort   (req)  backend service port
+  namespace (opt)  metadata.namespace (already rendered); omitted when empty
+==============================================================================
+*/}}
+{{- define "lerian-common.ingress" -}}
+{{- $ctx := .context -}}
+{{- $ing := .ingress -}}
+{{- $name := .name -}}
+{{- $svcPort := .svcPort -}}
+{{- if and $ing.className (not (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey $ing.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set $ing.annotations "kubernetes.io/ingress.class" $ing.className }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" $ctx.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $ctx.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with $ing.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $ing.className (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $ing.className }}
+  {{- end }}
+  {{- if $ing.tls }}
+  tls:
+    {{- range $ing.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $ing.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $ctx.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $name }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $name }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -1,0 +1,97 @@
+{{/*
+==============================================================================
+lerian-common — Multi-tenant env (lib-commons/multitenancy contract).
+
+Unlike serviceDiscovery/streaming, multi-tenant does NOT have a single flat
+common block: across the 8 charts that use it, only 4 vars are universal
+(ENABLED, URL, CIRCUIT_BREAKER_THRESHOLD, CIRCUIT_BREAKER_TIMEOUT_SEC) and each
+chart emits a different subset of the long tail (redis / pool / cache / etc.).
+
+So this helper centralizes the canonical DEFAULTS and var NAMES, and each chart
+opts into the GROUPS it currently emits via flags — reproducing its existing
+block exactly (render-equivalent) while removing the duplicated defaults.
+
+Like the other env helpers, it does NOT emit MULTI_TENANT_ENABLED: that stays
+inline in the component configmap as the knob (and the gate source). This helper
+emits only the gated block. Secrets (MULTI_TENANT_SERVICE_API_KEY,
+MULTI_TENANT_REDIS_PASSWORD) are NOT emitted here — they belong in secrets.yaml.
+
+plugin-br-payments is intentionally OUT of scope (different contract:
+MULTI_TENANCY_ENABLED + range-generated configmap) — keep it inline.
+
+Usage (in a component configmap.yaml, replacing the hand-written gated block;
+keep the inline `MULTI_TENANT_ENABLED:` line as the knob):
+
+  {{- include "lerian-common.multiTenant.env" (dict
+        "configmap" .Values.fees.configmap
+        "enabled" (eq (.Values.fees.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true")
+        "requiredUrl" true "requiredRedisHost" true
+        "emitRedis" true "emitPool" true "emitCache" true
+        "emitEnvironment" true "emitAllowInsecure" true
+      ) | nindent 2 }}
+
+Inputs (dict):
+  configmap          (req)  the component's `.configmap` map (override source)
+  enabled            (req)  bool — gate; emit the block only when true
+  requiredUrl        (opt)  bool — MULTI_TENANT_URL uses `required` vs default ""
+  serviceName        (opt)  string — emit MULTI_TENANT_SERVICE_NAME (default = this)
+  circuitBreaker     (opt)  bool (default true) — CB_THRESHOLD (5) + CB_TIMEOUT_SEC (30)
+  emitRedis          (opt)  bool — REDIS_HOST / REDIS_PORT (6379) / REDIS_TLS
+  requiredRedisHost  (opt)  bool — REDIS_HOST uses `required` vs default ""
+  redisTlsDefault    (opt)  string — default for REDIS_TLS ("false"; "true" for tracer)
+  emitPool           (opt)  bool — MAX_TENANT_POOLS (100) + IDLE_TIMEOUT_SEC (300)
+  emitCache          (opt)  bool — TIMEOUT (30) + CACHE_TTL_SEC (120) + CONNECTIONS_CHECK_INTERVAL_SEC (30)
+  emitEnvironment    (opt)  bool — MULTI_TENANT_ENVIRONMENT (default "")
+  emitAllowInsecure  (opt)  bool — MULTI_TENANT_ALLOW_INSECURE_HTTP (default "false")
+==============================================================================
+*/}}
+{{- define "lerian-common.multiTenant.env" -}}
+{{- $c := .configmap | default dict -}}
+{{- /* Env-wide defaults from global.multiTenant (tenant-manager URL + its redis are
+   environment infra, like global.serviceDiscovery/global.streaming). Component
+   .configmap overrides global. Guarded on .context so callers that don't pass it
+   still work (global stays empty → identical to the pre-global behavior). */ -}}
+{{- $g := dict -}}
+{{- with .context }}{{- $g = ((.Values.global | default dict).multiTenant | default dict) -}}{{- end -}}
+{{- if .enabled -}}
+{{- /* URL: universal. Component overrides global; then required or default "". */ -}}
+{{- $url := index $c "MULTI_TENANT_URL" | default $g.url -}}
+{{- if .requiredUrl }}
+MULTI_TENANT_URL: {{ required "lerian-common: MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true (set component configmap.MULTI_TENANT_URL or global.multiTenant.url)" $url | quote }}
+{{- else }}
+MULTI_TENANT_URL: {{ $url | default "" | quote }}
+{{- end }}
+{{- if .serviceName }}
+MULTI_TENANT_SERVICE_NAME: {{ index $c "MULTI_TENANT_SERVICE_NAME" | default .serviceName | quote }}
+{{- end }}
+{{- if ne (.circuitBreaker | default true) false }}
+MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" | default "5" | quote }}
+MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC" | default "30" | quote }}
+{{- end }}
+{{- if .emitRedis }}
+{{- $redisHost := index $c "MULTI_TENANT_REDIS_HOST" | default $g.redisHost -}}
+{{- if .requiredRedisHost }}
+MULTI_TENANT_REDIS_HOST: {{ required "lerian-common: MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true (set component configmap.MULTI_TENANT_REDIS_HOST or global.multiTenant.redisHost)" $redisHost | quote }}
+{{- else }}
+MULTI_TENANT_REDIS_HOST: {{ $redisHost | default "" | quote }}
+{{- end }}
+MULTI_TENANT_REDIS_PORT: {{ index $c "MULTI_TENANT_REDIS_PORT" | default $g.redisPort | default "6379" | quote }}
+MULTI_TENANT_REDIS_TLS: {{ index $c "MULTI_TENANT_REDIS_TLS" | default $g.redisTls | default (.redisTlsDefault | default "false") | quote }}
+{{- end }}
+{{- if .emitPool }}
+MULTI_TENANT_MAX_TENANT_POOLS: {{ index $c "MULTI_TENANT_MAX_TENANT_POOLS" | default "100" | quote }}
+MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ index $c "MULTI_TENANT_IDLE_TIMEOUT_SEC" | default "300" | quote }}
+{{- end }}
+{{- if .emitCache }}
+MULTI_TENANT_TIMEOUT: {{ index $c "MULTI_TENANT_TIMEOUT" | default "30" | quote }}
+MULTI_TENANT_CACHE_TTL_SEC: {{ index $c "MULTI_TENANT_CACHE_TTL_SEC" | default "120" | quote }}
+MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ index $c "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" | default "30" | quote }}
+{{- end }}
+{{- if .emitEnvironment }}
+MULTI_TENANT_ENVIRONMENT: {{ index $c "MULTI_TENANT_ENVIRONMENT" | default "" | quote }}
+{{- end }}
+{{- if .emitAllowInsecure }}
+MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ index $c "MULTI_TENANT_ALLOW_INSECURE_HTTP" | default "false" | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_pdb.tpl
+++ b/charts/lerian-common/templates/_pdb.tpl
@@ -1,0 +1,70 @@
+{{/*
+==============================================================================
+lerian-common — PodDisruptionBudget (policy/v1).
+
+Present in ~39 charts, near-identical. Naming/labels/selector are passed ALREADY
+RENDERED by the chart's own helpers (byte-identical, no contract to unify); the
+caller owns the enable gate. Two spec styles are supported via `specStyle`:
+
+  "preferMax" (default, majority: fees/matcher/underwriter):
+      with .maxUnavailable -> maxUnavailable; else -> minAvailable (| default N)
+  "explicit" (tracer): emit minAvailable and/or maxUnavailable only when set
+
+annotations render via toYaml; since no chart sets PDB annotations today this is
+byte-identical to the range/quote style those charts used (empty -> nothing).
+
+Usage (chart pdb.yaml):
+  {{- if .Values.fees.pdb.enabled }}
+  {{- include "lerian-common.pdb" (dict
+        "pdb" .Values.fees.pdb
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+        "selector" (include "plugin-fees.selectorLabels" (dict "context" . "name" .Values.fees.name))
+        "minAvailableDefault" 0
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  pdb                 (req)  the component's `.pdb` map (minAvailable/maxUnavailable/annotations)
+  name                (req)  metadata.name (already rendered)
+  labels              (req)  labels block already rendered (no leading indent)
+  selector            (req)  selector labels block already rendered (no leading indent)
+  namespace           (opt)  metadata.namespace (already rendered); omitted when empty
+  minAvailableDefault (opt)  default for minAvailable in "preferMax" (default 1; some charts use 0)
+  specStyle           (opt)  "preferMax" (default) | "explicit"
+==============================================================================
+*/}}
+{{- define "lerian-common.pdb" -}}
+{{- $pdb := .pdb -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with $pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if eq (.specStyle | default "preferMax") "explicit" }}
+  {{- if $pdb.minAvailable }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- end }}
+  {{- if $pdb.maxUnavailable }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- end }}
+  {{- else }}
+  {{- with $pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- else }}
+  minAvailable: {{ $pdb.minAvailable | default (.minAvailableDefault | default 1) }}
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- .selector | nindent 6 }}
+{{- end -}}

--- a/charts/lerian-common/templates/_pdb.tpl
+++ b/charts/lerian-common/templates/_pdb.tpl
@@ -50,18 +50,23 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- /* hasKey (not truthiness) so an explicit 0 is honored, not treated as absent. */ -}}
+  {{- $miDefault := 1 -}}
+  {{- if hasKey . "minAvailableDefault" }}{{- $miDefault = .minAvailableDefault -}}{{- end }}
   {{- if eq (.specStyle | default "preferMax") "explicit" }}
-  {{- if $pdb.minAvailable }}
+  {{- if hasKey $pdb "minAvailable" }}
   minAvailable: {{ $pdb.minAvailable }}
   {{- end }}
-  {{- if $pdb.maxUnavailable }}
+  {{- if hasKey $pdb "maxUnavailable" }}
   maxUnavailable: {{ $pdb.maxUnavailable }}
   {{- end }}
   {{- else }}
-  {{- with $pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey $pdb "maxUnavailable" }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else if hasKey $pdb "minAvailable" }}
+  minAvailable: {{ $pdb.minAvailable }}
   {{- else }}
-  minAvailable: {{ $pdb.minAvailable | default (.minAvailableDefault | default 1) }}
+  minAvailable: {{ $miDefault }}
   {{- end }}
   {{- end }}
   selector:

--- a/charts/lerian-common/templates/_pdb.tpl
+++ b/charts/lerian-common/templates/_pdb.tpl
@@ -8,7 +8,8 @@ caller owns the enable gate. Two spec styles are supported via `specStyle`:
 
   "preferMax" (default, majority: fees/matcher/underwriter):
       with .maxUnavailable -> maxUnavailable; else -> minAvailable (| default N)
-  "explicit" (tracer): emit minAvailable and/or maxUnavailable only when set
+  "explicit" (tracer): emit minAvailable or maxUnavailable only when set
+      (they are mutually exclusive in policy/v1; setting both fails fast)
 
 annotations render via toYaml; since no chart sets PDB annotations today this is
 byte-identical to the range/quote style those charts used (empty -> nothing).
@@ -54,6 +55,9 @@ spec:
   {{- $miDefault := 1 -}}
   {{- if hasKey . "minAvailableDefault" }}{{- $miDefault = .minAvailableDefault -}}{{- end }}
   {{- if eq (.specStyle | default "preferMax") "explicit" }}
+  {{- if and (hasKey $pdb "minAvailable") (hasKey $pdb "maxUnavailable") }}
+  {{- fail "lerian-common.pdb: minAvailable and maxUnavailable are mutually exclusive (policy/v1) — set only one" }}
+  {{- end }}
   {{- if hasKey $pdb "minAvailable" }}
   minAvailable: {{ $pdb.minAvailable }}
   {{- end }}

--- a/charts/lerian-common/templates/_rolesanywhere.tpl
+++ b/charts/lerian-common/templates/_rolesanywhere.tpl
@@ -1,0 +1,124 @@
+{{/*
+==============================================================================
+lerian-common — AWS IAM Roles Anywhere pod-spec fragments.
+
+The `aws-signing-helper` sidecar + IMDS env + iam-certs volume + fsGroup pod
+securityContext are BYTE-IDENTICAL across the inline implementations in
+fetcher (manager/worker), matcher and plugin-fees. These helpers reproduce
+those blocks exactly so callers can drop the copy-paste.
+
+Indentation contract (same convention as _deployment.tpl): each helper emits
+its keys at base indent 0; the caller supplies the real indent via `nindent`.
+Nested `toYaml … | nindent N` values use the SMALL N that, once the caller's
+outer nindent is added, lands on the original column.
+
+  sidecar             -> caller nindent 8 (container list item)
+  volume              -> caller nindent 6 (spec.volumes)
+  imdsEnv             -> caller nindent 10 or 12 (container env list)
+  podSecurityContext  -> caller nindent 6 (spec.securityContext); self-contained
+                         if/else, always call it (do NOT wrap in an if)
+
+The sidecar / volume / imdsEnv helpers are PURE (no guard): wrap the include in
+the caller with the standard guard so they render only when enabled:
+
+  {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
+      {{- include "lerian-common.rolesAnywhere.sidecar" (dict "aws" .Values.aws) | nindent 8 }}
+  {{- end }}
+
+NOTE: excludes reporter, whose inline block intentionally differs (no `required`
+wrappers, extra runAsGroup, `$.`-prefixed context). Align reporter before reuse.
+*/}}
+
+{{/*
+lerian-common.rolesAnywhere.sidecar — the aws-signing-helper sidecar container.
+Input: (dict "aws" .Values.aws). Caller: nindent 8.
+*/}}
+{{- define "lerian-common.rolesAnywhere.sidecar" -}}
+{{- $ra := .aws.rolesAnywhere -}}
+- name: aws-signing-helper
+  image: "{{ $ra.sidecar.image.repository }}:{{ $ra.sidecar.image.tag }}"
+  imagePullPolicy: {{ $ra.sidecar.image.pullPolicy | default "IfNotPresent" }}
+  args:
+    - serve
+    - --certificate
+    - /certs/tls.crt
+    - --private-key
+    - /certs/tls.key
+    - --trust-anchor-arn
+    - "{{ required "aws.rolesAnywhere.trustAnchorArn is required when rolesAnywhere is enabled" $ra.trustAnchorArn }}"
+    - --profile-arn
+    - "{{ required "aws.rolesAnywhere.profileArn is required when rolesAnywhere is enabled" $ra.profileArn }}"
+    - --role-arn
+    - "{{ required "aws.rolesAnywhere.roleArn is required when rolesAnywhere is enabled" $ra.roleArn }}"
+    - --region
+    - "{{ $ra.region | default "us-east-2" }}"
+    - --session-duration
+    - "{{ $ra.sessionDuration | default 3600 }}"
+    - --port
+    - "{{ $ra.sidecar.port | default 9911 }}"
+  ports:
+    - name: imds
+      containerPort: {{ $ra.sidecar.port | default 9911 }}
+      protocol: TCP
+  volumeMounts:
+    - name: iam-certs
+      mountPath: /certs
+      readOnly: true
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  resources:
+    {{- toYaml $ra.sidecar.resources | nindent 4 }}
+{{- end -}}
+
+{{/*
+lerian-common.rolesAnywhere.volume — the iam-certs secret volume.
+Input: (dict "aws" .Values.aws "iamTlsDefault" "<chart>-iam-tls"). Caller: nindent 6.
+*/}}
+{{- define "lerian-common.rolesAnywhere.volume" -}}
+{{- $ra := .aws.rolesAnywhere -}}
+volumes:
+  - name: iam-certs
+    secret:
+      secretName: {{ $ra.certificateSecretName | default .iamTlsDefault }}
+      defaultMode: 0440
+      items:
+        - key: tls.crt
+          path: tls.crt
+        - key: tls.key
+          path: tls.key
+{{- end -}}
+
+{{/*
+lerian-common.rolesAnywhere.imdsEnv — env vars pointing the app at the sidecar IMDS.
+Input: (dict "aws" .Values.aws). Caller: nindent 10 or 12 (match the chart's env indent).
+*/}}
+{{- define "lerian-common.rolesAnywhere.imdsEnv" -}}
+{{- $ra := .aws.rolesAnywhere -}}
+- name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+  value: "http://127.0.0.1:{{ $ra.sidecar.port | default 9911 }}"
+- name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
+  value: "IPv4"
+{{- end -}}
+
+{{/*
+lerian-common.rolesAnywhere.podSecurityContext — pod securityContext: fsGroup when
+rolesAnywhere is on, else the chart's podSecurityContext. Self-contained if/else,
+always call it (do NOT wrap in an if).
+Input: (dict "aws" .Values.aws "podSecurityContext" .Values.<comp>.podSecurityContext).
+Caller: nindent 6.
+*/}}
+{{- define "lerian-common.rolesAnywhere.podSecurityContext" -}}
+{{- if and .aws .aws.rolesAnywhere .aws.rolesAnywhere.enabled -}}
+securityContext:
+  fsGroup: 65532
+{{- else -}}
+securityContext:
+  {{- toYaml .podSecurityContext | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_service.tpl
+++ b/charts/lerian-common/templates/_service.tpl
@@ -1,0 +1,51 @@
+{{/*
+==============================================================================
+lerian-common — Service (ClusterIP, single http port).
+
+Near-identical across charts: a single `http` port with targetPort http. Naming,
+labels and selector are passed ALREADY RENDERED by the chart's own helpers, so
+the output is byte-identical and no naming/label contract must be unified. The
+caller owns the enable gate. `namespace` and `annotations` are emitted only when
+provided (some charts include them, some don't).
+
+Usage (chart service.yaml):
+  {{- include "lerian-common.service" (dict
+        "service" .Values.fees.service
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+        "selector" (include "plugin-fees.selectorLabels" (dict "context" . "name" .Values.fees.name))
+      ) }}
+
+Inputs (dict):
+  service   (req)  the component's `.service` map (type, port, optional annotations)
+  name      (req)  metadata.name (already rendered)
+  labels    (req)  labels block already rendered (no leading indent)
+  selector  (req)  selector labels block already rendered (no leading indent)
+  namespace (opt)  metadata.namespace (already rendered); line omitted when empty
+==============================================================================
+*/}}
+{{- define "lerian-common.service" -}}
+{{- $svc := .service -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with $svc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $svc.type }}
+  ports:
+    - port: {{ $svc.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- .selector | nindent 4 }}
+{{- end -}}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -1,0 +1,79 @@
+{{/*
+==============================================================================
+lerian-common — Service Discovery env (lib-service-discovery contract).
+
+Emits the SD_* env block into a ConfigMap `data` map, gated on `enabled`.
+Per-service endpoints are derived from the chart's own primitives; the env-wide
+constants are inherited from `global.serviceDiscovery` (set once per environment
+in GitOps). The contract is identical for every app, so this lives here once.
+
+The design goal is that an app enables discovery with ONLY `SD_ENABLED: "true"`
+in its component `extraEnvVars`; everything else is derived here.
+
+Usage (in a component configmap.yaml, emitted BEFORE the extraEnvVars
+passthrough so an operator can still override any single SD_* key):
+
+  {{- $cv := .Values.identity -}}
+  {{- include "lerian-common.serviceDiscovery.env" (dict
+        "context"     $
+        "enabled"     (eq (toString (dig "SD_ENABLED" "false" ($cv.extraEnvVars | default dict))) "true")
+        "name"        $cv.name
+        "port"        $cv.service.port
+        "namespace"   (include "global.namespace" $)
+        "ingressHost" (include "lerian-common.firstIngressHost" (dict "ingress" $cv.ingress))
+      ) | nindent 2 }}
+
+Inputs (dict):
+  context     (req)  root context ($) — used to read global.serviceDiscovery
+  enabled     (req)  bool — whether to emit the block at all
+  name        (req)  internal service DNS name (SD_INTERNAL_ADDRESS host)
+  port        (req)  internal service port
+  namespace   (req)  resolved namespace string
+  ingressHost (opt)  external host; when non-empty, emits SD_EXTERNAL_*
+                     (omit for consumer-only / internal-only instances)
+
+global.serviceDiscovery (all optional except address when enabled):
+  address, tls, tlsSkipVerify, workload, preferView, internalScheme, externalPort
+==============================================================================
+*/}}
+{{- define "lerian-common.serviceDiscovery.env" -}}
+{{- $sd := (.context.Values.global | default dict).serviceDiscovery | default dict -}}
+{{- /*
+  Derive ONLY when enabled AND global.serviceDiscovery.address is configured.
+  This keeps adoption backward-compatible: a chart carrying this helper but
+  deployed against a not-yet-migrated environment (SD_* still hand-set in
+  extraEnvVars, no global.serviceDiscovery) stays INERT — extraEnvVars drives
+  SD exactly as before, no duplicate keys, no render break. The environment
+  opts into derivation by setting global.serviceDiscovery + stripping the
+  per-app SD_* block down to just SD_ENABLED.
+*/ -}}
+{{- if and .enabled $sd.address -}}
+{{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
+   rendered by the component's own extraEnvVars passthrough. Emitting it again
+   would produce a duplicate key. This helper only adds the derived siblings. */ -}}
+SD_ADDRESS: {{ $sd.address | quote }}
+SD_TLS: {{ $sd.tls | default false | quote }}
+SD_TLS_SKIP_VERIFY: {{ $sd.tlsSkipVerify | default false | quote }}
+SD_WORKLOAD: {{ $sd.workload | default "" | quote }}
+SD_PREFER_VIEW: {{ $sd.preferView | default "external" | quote }}
+SD_INTERNAL_ADDRESS: {{ include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace) | quote }}
+SD_INTERNAL_PORT: {{ .port | quote }}
+SD_INTERNAL_SCHEME: {{ $sd.internalScheme | default "http" | quote }}
+{{- if .ingressHost }}
+SD_EXTERNAL_ADDRESS: {{ printf "https://%s" .ingressHost | quote }}
+SD_EXTERNAL_PORT: {{ $sd.externalPort | default 443 | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+lerian-common.firstIngressHost — the first ingress host, or "" when ingress is
+disabled/absent. Keeps the SD wiring a one-liner and consistent across charts.
+Inputs: ingress (the component's `.ingress` map).
+*/}}
+{{- define "lerian-common.firstIngressHost" -}}
+{{- $ing := .ingress | default dict -}}
+{{- if and $ing.enabled $ing.hosts -}}
+{{- (first $ing.hosts).host | default "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_serviceaccount.tpl
+++ b/charts/lerian-common/templates/_serviceaccount.tpl
@@ -1,0 +1,40 @@
+{{/*
+==============================================================================
+lerian-common — ServiceAccount.
+
+Identical across charts modulo naming/labels and the presence of a `namespace:`
+line. Naming and labels are passed ALREADY RENDERED by the chart's own helpers,
+so the output is byte-identical without unifying any contract. The caller owns
+the create/enable gate. `namespace` and `annotations` are emitted only when set.
+
+Usage (chart serviceaccount.yaml):
+  {{- if .Values.fees.serviceAccount.create -}}
+  {{- include "lerian-common.serviceAccount" (dict
+        "serviceAccount" .Values.fees.serviceAccount
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  serviceAccount (req)  the component's `.serviceAccount` map (optional annotations)
+  name           (req)  metadata.name (already rendered)
+  labels         (req)  labels block already rendered (no leading indent)
+  namespace      (opt)  metadata.namespace (already rendered); line omitted when empty
+==============================================================================
+*/}}
+{{- define "lerian-common.serviceAccount" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with .serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_streaming.tpl
+++ b/charts/lerian-common/templates/_streaming.tpl
@@ -1,0 +1,51 @@
+{{/*
+==============================================================================
+lerian-common — Streaming env (lib-streaming / RedPanda contract).
+
+Streaming is becoming standard across all Lerian charts. This helper emits the
+env-wide streaming CONSTANTS (broker + SASL/TLS transport) into a ConfigMap
+`data` map from `global.streaming`, set once per environment. Per-app IDENTITY
+(STREAMING_CLIENT_ID, STREAMING_CLOUDEVENTS_SOURCE) and the SECRETS
+(STREAMING_SASL_PASSWORD, STREAMING_TLS_CA_CERT) are NOT env-wide — they stay in
+each component (extraEnvVars / secrets), same split as OTEL service identity.
+
+Like serviceDiscovery.env:
+  - it does NOT emit STREAMING_ENABLED (that is the app's knob, rendered by the
+    component's own extraEnvVars passthrough — emitting it here would duplicate);
+  - it is backward-compatible: derives ONLY when enabled AND
+    global.streaming.brokers is set, otherwise stays INERT so a not-yet-migrated
+    environment (STREAMING_* still hand-set in extraEnvVars) renders unchanged.
+
+Usage (in a component configmap.yaml, BEFORE the extraEnvVars passthrough):
+
+  {{- $cv := .Values.ledger -}}
+  {{- include "lerian-common.streaming.env" (dict
+        "context" $
+        "enabled" (eq (toString (dig "STREAMING_ENABLED" "false" ($cv.extraEnvVars | default dict))) "true")
+      ) | nindent 2 }}
+
+Inputs (dict):
+  context           (req)  root context ($) — reads global.streaming
+  enabled           (req)  bool — whether to emit the constants
+  clientId          (opt)  STREAMING_CLIENT_ID — emitted only when provided
+  cloudeventsSource (opt)  STREAMING_CLOUDEVENTS_SOURCE — emitted only when provided
+
+global.streaming (all optional except brokers, which gates emission):
+  brokers, tlsEnabled, saslMechanism, saslUsername
+==============================================================================
+*/}}
+{{- define "lerian-common.streaming.env" -}}
+{{- $s := (.context.Values.global | default dict).streaming | default dict -}}
+{{- if and .enabled $s.brokers -}}
+STREAMING_BROKERS: {{ $s.brokers | quote }}
+STREAMING_TLS_ENABLED: {{ $s.tlsEnabled | default false | quote }}
+STREAMING_SASL_MECHANISM: {{ $s.saslMechanism | default "" | quote }}
+STREAMING_SASL_USERNAME: {{ $s.saslUsername | default "" | quote }}
+{{- if hasKey . "clientId" }}
+STREAMING_CLIENT_ID: {{ .clientId | quote }}
+{{- end }}
+{{- if hasKey . "cloudeventsSource" }}
+STREAMING_CLOUDEVENTS_SOURCE: {{ .cloudeventsSource | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/values.yaml
+++ b/charts/lerian-common/values.yaml
@@ -1,0 +1,41 @@
+# lerian-common is a LIBRARY chart: it renders nothing on its own and has no
+# values of its own. This file DOCUMENTS the shared `global.*` contract the
+# helpers read — the STANDARD template every environment fills in ONCE (at the
+# umbrella/GitOps layer). These are environment-specific (BYOC) and MUST NOT be
+# hardcoded in any product chart.
+#
+# All three domains follow the same pattern: env-wide infra constants live under
+# `global.*`, the per-app enable knob stays in the component `extraEnvVars`
+# (`SD_ENABLED` / `STREAMING_ENABLED`) or `configmap` (`MULTI_TENANT_ENABLED`),
+# and a component's own value overrides the global default. Every helper is
+# backward-compatible: with the `global.*` block absent it stays inert and the
+# component's existing values drive the output unchanged.
+
+global: {}
+  # -- Service Discovery (lib-service-discovery). Set once per environment.
+  # serviceDiscovery:
+  #   address: ""            # REQUIRED when SD_ENABLED=true (e.g. consul.<env>:443). No default.
+  #   tls: false             # SD_TLS
+  #   tlsSkipVerify: false   # SD_TLS_SKIP_VERIFY
+  #   workload: ""           # SD_WORKLOAD — per-env isolation key (provider+consumer must match)
+  #   preferView: external   # SD_PREFER_VIEW — internal|external (lib default: external)
+  #   internalScheme: http   # SD_INTERNAL_SCHEME
+  #   externalPort: 443      # SD_EXTERNAL_PORT (emitted only when a component has an ingress host)
+  #
+  # -- Streaming (lib-streaming / RedPanda). Set once per environment.
+  # streaming:
+  #   brokers: ""            # REQUIRED when STREAMING_ENABLED=true (e.g. redpanda.<env>:9092)
+  #   tlsEnabled: false      # STREAMING_TLS_ENABLED
+  #   saslMechanism: ""      # STREAMING_SASL_MECHANISM (e.g. SCRAM-SHA-256)
+  #   saslUsername: ""       # STREAMING_SASL_USERNAME
+  #   # NOTE: STREAMING_SASL_PASSWORD / STREAMING_TLS_CA_CERT are secrets — set them
+  #   # per component under `.secrets`, never here (they render into the Secret).
+  #
+  # -- Multi-tenant (lib-commons/multitenancy). The tenant-manager URL and its
+  #    Redis are environment infra, so they belong here too; a component's
+  #    configmap.MULTI_TENANT_* overrides these.
+  # multiTenant:
+  #   url: ""                # MULTI_TENANT_URL — tenant-manager base URL
+  #   redisHost: ""          # MULTI_TENANT_REDIS_HOST
+  #   redisPort: "6379"      # MULTI_TENANT_REDIS_PORT
+  #   redisTls: "false"      # MULTI_TENANT_REDIS_TLS


### PR DESCRIPTION
## What

Introduces **`charts/lerian-common`**, a `type: library` Helm chart (renders nothing on its own). It factors logic duplicated across the product charts into render-equivalent helpers consumed via `include`.

### Helpers provided
- **Env contracts:** `serviceDiscovery.env`, `streaming.env`, `multiTenant.env` — env-wide constants come from `global.*` (set once per environment), the per-app enable knob stays in `extraEnvVars`/`configmap`, a component value overrides the global default, and each helper is **inert until `global.*` is set** (backward-compatible).
- **In-cluster host primitives:** `internalHost`, `internalURL`.
- **Resource helpers:** `hpa`, `service`, `serviceAccount`, `pdb`, `ingress`.
- **Deployment pod-spec fragments:** `scheduling`, `imagePullSecrets`, `httpProbe`, `rolesAnywhere.{sidecar,volume,imdsEnv,podSecurityContext}`.
- **Dependency helpers:** `dependency.fullname`, `infraSecretRef`.
- **`deploymentStrategy`.**

`values.yaml` documents the standard `global.{serviceDiscovery,streaming,multiTenant}` template.

## Why

~20 product charts duplicate the same boilerplate (naming, host derivation, resource manifests, infra-secret wiring). Centralizing it here means single-source-of-truth, less drift, and fixes applied once.

## Safety

- Library chart — not installed on its own; only resolved at consumers' `helm dependency build`.
- Consumer adoption lands in **follow-up PRs**, each validated **render-equivalent** (`helm template` diff before/after) against the chart's current output.
- `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)