### PR TITLE
docs(doc): add Schedule to pix-btg v1.8.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ For implementation and configuration details, see the [README](https://charts.le
 
 #### Application Version Mapping
 
-| Chart Version | Pix Version | Inbound Version | Outbound Version | Reconciliation Version |
-| :---: | :---: | :---: | :---: | :---: |
-| `3.5.0` | 1.8.0 | 1.8.0 | 1.8.0 | 1.8.0 |
+| Chart Version | Pix Version | Inbound Version | Outbound Version | Reconciliation Version | Schedule Version |
+| :---: | :---: | :---: | :---: | :---: | :---: |
+| `3.5.0` | 1.8.0 | 1.8.0 | 1.8.0 | 1.8.0 | 1.8.0 |
 
 -----------------
 


### PR DESCRIPTION
Requested by: Guilherme Rodrigues - Add Schedule to pix-btg v1.8.0 in README

Adds a **Schedule Version** column to the *Plugin BR Pix Indirect BTG* Application Version Mapping table in the root README, filling in `1.8.0` for chart version `3.5.0` (matches the schedule worker image tag in values.yaml).