### PR TITLE
feat(midaz): add CRM/Fees/Tracer env vars and update tracer image

### DIFF
--- a/charts/midaz/Chart.yaml
+++ b/charts/midaz/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
     email: "support@lerian.studio"
 # This is the chart version. This version number should be incremented each time you make changes
 # to he chart and its templates, including the app version.
-version: 8.6.0
+version: 8.6.1
 # This is the version number of the application being deployed.
 appVersion: "3.7.8"
 # A list of keywords about the chart. This helps others discover the chart.

--- a/charts/midaz/templates/ledger/configmap.yaml
+++ b/charts/midaz/templates/ledger/configmap.yaml
@@ -250,6 +250,36 @@ data:
   ALLOW_RATELIMIT_DISABLED: {{ .Values.ledger.configmap.ALLOW_RATELIMIT_DISABLED | default "" | quote }}
   ALLOW_RATELIMIT_FAIL_OPEN: {{ .Values.ledger.configmap.ALLOW_RATELIMIT_FAIL_OPEN | default "" | quote }}
 
+  # =============================================================================
+  # CRM MODULE (collapsed into ledger — midaz v4 monorepo)
+  # =============================================================================
+  MONGO_CRM_URI: {{ .Values.ledger.configmap.MONGO_CRM_URI | default "mongodb" | quote }}
+  MONGO_CRM_HOST: {{ .Values.ledger.configmap.MONGO_CRM_HOST | default "" | quote }}
+  MONGO_CRM_NAME: {{ .Values.ledger.configmap.MONGO_CRM_NAME | default "" | quote }}
+  MONGO_CRM_USER: {{ .Values.ledger.configmap.MONGO_CRM_USER | default "" | quote }}
+  MONGO_CRM_PORT: {{ .Values.ledger.configmap.MONGO_CRM_PORT | default "27017" | quote }}
+  MONGO_CRM_MAX_POOL_SIZE: {{ .Values.ledger.configmap.MONGO_CRM_MAX_POOL_SIZE | default "20" | quote }}
+  MONGO_CRM_PARAMETERS: {{ .Values.ledger.configmap.MONGO_CRM_PARAMETERS | default "" | quote }}
+  KMS_VENDOR: {{ .Values.ledger.configmap.KMS_VENDOR | default "none" | quote }}
+
+  # =============================================================================
+  # FEES MODULE (collapsed into ledger — midaz v4 monorepo)
+  # =============================================================================
+  MONGO_FEES_URI: {{ .Values.ledger.configmap.MONGO_FEES_URI | default "mongodb" | quote }}
+  MONGO_FEES_HOST: {{ .Values.ledger.configmap.MONGO_FEES_HOST | default "" | quote }}
+  MONGO_FEES_NAME: {{ .Values.ledger.configmap.MONGO_FEES_NAME | default "" | quote }}
+  MONGO_FEES_USER: {{ .Values.ledger.configmap.MONGO_FEES_USER | default "" | quote }}
+  MONGO_FEES_PORT: {{ .Values.ledger.configmap.MONGO_FEES_PORT | default "27017" | quote }}
+  MONGO_FEES_MAX_POOL_SIZE: {{ .Values.ledger.configmap.MONGO_FEES_MAX_POOL_SIZE | default "100" | quote }}
+  MONGO_FEES_PARAMETERS: {{ .Values.ledger.configmap.MONGO_FEES_PARAMETERS | default "" | quote }}
+
+  # =============================================================================
+  # TRACER SEAM (client side; empty TRACER_BASE_URL disables the integration)
+  # =============================================================================
+  TRACER_BASE_URL: {{ .Values.ledger.configmap.TRACER_BASE_URL | default "" | quote }}
+  TRACER_TRANSPORT: {{ .Values.ledger.configmap.TRACER_TRANSPORT | default "rest" | quote }}
+  TRACER_TLS_MODE: {{ .Values.ledger.configmap.TRACER_TLS_MODE | default "" | quote }}
+
   # Extra Env Vars
   {{- with .Values.ledger.extraEnvVars }}
   {{- toYaml . | nindent 2 }}

--- a/charts/midaz/templates/ledger/secrets.yaml
+++ b/charts/midaz/templates/ledger/secrets.yaml
@@ -64,6 +64,25 @@ data:
   {{- end }}
 
   # =============================================================================
+  # DATA SECURITY + CRM/FEES SECRETS (collapsed into ledger — midaz v4 monorepo)
+  # LCRYPTO_* is app crypto material; MONGO_CRM/FEES_PASSWORD authenticate the
+  # collapsed CRM/Fees Mongo connections. All operator-provided; only emitted
+  # when set so existing deployments are unaffected.
+  # =============================================================================
+  {{- if .Values.ledger.secrets.LCRYPTO_HASH_SECRET_KEY }}
+  LCRYPTO_HASH_SECRET_KEY: {{ .Values.ledger.secrets.LCRYPTO_HASH_SECRET_KEY | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.ledger.secrets.LCRYPTO_ENCRYPT_SECRET_KEY }}
+  LCRYPTO_ENCRYPT_SECRET_KEY: {{ .Values.ledger.secrets.LCRYPTO_ENCRYPT_SECRET_KEY | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.ledger.secrets.MONGO_CRM_PASSWORD }}
+  MONGO_CRM_PASSWORD: {{ .Values.ledger.secrets.MONGO_CRM_PASSWORD | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.ledger.secrets.MONGO_FEES_PASSWORD }}
+  MONGO_FEES_PASSWORD: {{ .Values.ledger.secrets.MONGO_FEES_PASSWORD | b64enc | quote }}
+  {{- end }}
+
+  # =============================================================================
   # STREAMING SECRETS (lib-streaming — SASL password + TLS CA, operator-provided)
   # =============================================================================
   {{- if .Values.ledger.secrets.STREAMING_SASL_PASSWORD }}

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -295,6 +295,27 @@ ledger:
     RATE_LIMIT_REDIS_TIMEOUT_MS: "500"
     ALLOW_RATELIMIT_DISABLED: ""
     ALLOW_RATELIMIT_FAIL_OPEN: ""
+    # -- CRM module (collapsed into ledger — midaz v4 monorepo). Safe empty defaults.
+    MONGO_CRM_URI: ""
+    MONGO_CRM_HOST: ""
+    MONGO_CRM_NAME: ""
+    MONGO_CRM_USER: ""
+    MONGO_CRM_PORT: ""
+    MONGO_CRM_MAX_POOL_SIZE: ""
+    MONGO_CRM_PARAMETERS: ""
+    KMS_VENDOR: ""
+    # -- Fees module (collapsed into ledger — midaz v4 monorepo). Safe empty defaults.
+    MONGO_FEES_URI: ""
+    MONGO_FEES_HOST: ""
+    MONGO_FEES_NAME: ""
+    MONGO_FEES_USER: ""
+    MONGO_FEES_PORT: ""
+    MONGO_FEES_MAX_POOL_SIZE: ""
+    MONGO_FEES_PARAMETERS: ""
+    # -- Tracer seam (client side); empty TRACER_BASE_URL disables the integration.
+    TRACER_BASE_URL: ""
+    TRACER_TRANSPORT: ""
+    TRACER_TLS_MODE: ""
   # -- Existing secrets name
   useExistingSecret: false
   existingSecretName: ""
@@ -330,6 +351,12 @@ ledger:
     # they are rendered into the ledger Secret (never the ConfigMap).
     STREAMING_SASL_PASSWORD: ""
     STREAMING_TLS_CA_CERT: ""
+    # -- Data security + CRM/Fees material (collapsed into ledger — midaz v4
+    # monorepo). Operator-provided; only rendered into the ledger Secret when set.
+    LCRYPTO_HASH_SECRET_KEY: ""
+    LCRYPTO_ENCRYPT_SECRET_KEY: ""
+    MONGO_CRM_PASSWORD: ""
+    MONGO_FEES_PASSWORD: ""
   serviceAccount:
     # -- Specifies whether a ServiceAccount should be created
     create: true

--- a/charts/tracer/Chart.yaml
+++ b/charts/tracer/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
   - name: "Lerian Studio"
     email: "support@lerian.studio"
 
-version: 2.1.0
+version: 2.1.1
 
 appVersion: "1.0.0"
 

--- a/charts/tracer/templates/configmap.yaml
+++ b/charts/tracer/templates/configmap.yaml
@@ -54,6 +54,11 @@ data:
   CLEANUP_WORKER_ENABLED: {{ .Values.tracer.configmap.CLEANUP_WORKER_ENABLED | default "false" | quote }}
   CLEANUP_INTERVAL_HOURS: {{ .Values.tracer.configmap.CLEANUP_INTERVAL_HOURS | default "24" | quote }}
 
+  # Reservation Reaper + Rule Sync (midaz v4 monorepo)
+  RESERVATION_REAPER_ENABLED: {{ .Values.tracer.configmap.RESERVATION_REAPER_ENABLED | default "false" | quote }}
+  RESERVATION_REAPER_INTERVAL_SECONDS: {{ .Values.tracer.configmap.RESERVATION_REAPER_INTERVAL_SECONDS | default "30" | quote }}
+  RULE_SYNC_POLL_INTERVAL_SECONDS: {{ .Values.tracer.configmap.RULE_SYNC_POLL_INTERVAL_SECONDS | default "10" | quote }}
+
   # Multi-Tenant
   MULTI_TENANT_ENABLED: {{ .Values.tracer.configmap.MULTI_TENANT_ENABLED | default "false" | quote }}
   {{- if eq (.Values.tracer.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true" }}

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -230,6 +230,11 @@ tracer:
     CLEANUP_WORKER_ENABLED: "false"
     CLEANUP_INTERVAL_HOURS: "24"
 
+    # Reservation Reaper + Rule Sync (midaz v4 monorepo)
+    RESERVATION_REAPER_ENABLED: "false"
+    RESERVATION_REAPER_INTERVAL_SECONDS: "30"
+    RULE_SYNC_POLL_INTERVAL_SECONDS: "10"
+
     # Multi-Tenant
     # -- Enable multi-tenant mode. When true, the following fields are required:
     #    MULTI_TENANT_URL, MULTI_TENANT_REDIS_HOST, secrets.MULTI_TENANT_SERVICE_API_KEY.


### PR DESCRIPTION
Requested by: Ygohr

## Contexto
PR LerianStudio/midaz#2159 consolidou tracer, fees e CRM no binário unificado do ledger (midaz v4 monorepo); #2239 corrigiu o Dockerfile. O chart do ledger renderiza apenas chaves explícitas do configmap/secrets (não faz `range` genérico), então as novas env vars precisam de suporte explícito no template para que os overrides do gitops tenham efeito.

## midaz chart (version 8.6.0 → 8.6.1)
- `templates/ledger/configmap.yaml`: renderiza `MONGO_CRM_*`, `KMS_VENDOR`, `MONGO_FEES_*` e o seam do Tracer (`TRACER_BASE_URL`, `TRACER_TRANSPORT`, `TRACER_TLS_MODE`).
- `templates/ledger/secrets.yaml`: renderiza `LCRYPTO_HASH_SECRET_KEY`, `LCRYPTO_ENCRYPT_SECRET_KEY`, `MONGO_CRM_PASSWORD`, `MONGO_FEES_PASSWORD` — todas com guards `{{- if }}`, só emitidas quando setadas (deployments existentes não afetados).
- `values.yaml` (seção `ledger`): defaults seguros (strings vazias) para todas as novas chaves de configmap e secrets.

## tracer chart (version 2.1.0 → 2.1.1)
- `templates/configmap.yaml` + `values.yaml`: adicionadas `RESERVATION_REAPER_ENABLED`, `RESERVATION_REAPER_INTERVAL_SECONDS`, `RULE_SYNC_POLL_INTERVAL_SECONDS` com defaults seguros.

## Verificação
- `helm lint` OK em ambos os charts (warnings de RABBITMQ pré-existentes, não relacionados).
- `helm template` confirma que todas as novas chaves renderizam corretamente.
