### PR TITLE
feat(plugin-br-pix-indirect-btg): add SWAGGER_ENABLED env var (default true)

### DIFF
--- a/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
@@ -78,6 +78,7 @@ data:
   MONGO_TLS: {{ .Values.pix.configmap.MONGO_TLS | default "false" | quote }}
 
   # SWAGGER
+  SWAGGER_ENABLED: {{ .Values.pix.configmap.SWAGGER_ENABLED | default "true" | quote }}
   SWAGGER_TITLE: {{ .Values.pix.configmap.SWAGGER_TITLE | default "Plugin BR Pix Indirect BTG" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.pix.configmap.SWAGGER_DESCRIPTION | default "Documentation Plugin PIX BTG" | quote }}
   SWAGGER_VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}


### PR DESCRIPTION
## Contexto

Adiciona a variável de ambiente `SWAGGER_ENABLED` com valor default `true` no template do plugin `plugin-br-pix-indirect-btg` (componente `pix`), para habilitar a documentação OpenAPI/Swagger do plugin.

## Mudança

- `charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml`: adicionada `SWAGGER_ENABLED` no bloco SWAGGER, seguindo o mesmo padrão das demais variáveis do template:

```yaml
SWAGGER_ENABLED: {{ .Values.pix.configmap.SWAGGER_ENABLED | default "true" | quote }}
```

O valor pode ser sobrescrito via `pix.configmap.SWAGGER_ENABLED` em `values.yaml`, mantendo o padrão de defaults declarados no template.

## Verificação

- `helm lint` passou (0 charts failed).
- `helm template` renderiza `SWAGGER_ENABLED: "true"` no ConfigMap.

---

Requested by: Bruno