### PR TITLE
feat(new): add opt-in ingress disabled by default

### DIFF
--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -343,7 +343,28 @@ The chart is published as an OCI artifact to GitHub Container Registry:
 helm install my-release oci://ghcr.io/lerianstudio/br-slc-helm --version <chart-version>
 ```
 
-## Port-forward (no Ingress)
+## Ingress (opt-in, disabled by default)
+
+The chart is `ClusterIP`-only by default (BYOC reaches the app over cluster DNS
+or a manually managed edge). An optional Ingress is available for environments
+that want one — enable it and set the class + host(s):
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: br-slc.dev-st.lerian.net
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+```
+
+With `ingress.enabled=false` (the default) no Ingress object is rendered.
+
+### Port-forward (no Ingress)
 
 ```bash
 kubectl port-forward svc/my-release-br-slc 4111:4111

--- a/charts/br-slc/templates/ingress.yaml
+++ b/charts/br-slc/templates/ingress.yaml
@@ -1,0 +1,67 @@
+{{- /*
+Opt-in Ingress — disabled by default (ingress.enabled=false), matching the BYOC
+default where the app is reached over cluster DNS / a manually managed edge. Only
+rendered when ingress.enabled=true. Mirrors the plugin-fees ingress pattern,
+adapted to br-slc's top-level values (no per-app subkey) and the br-slc.* helpers.
+*/ -}}
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "br-slc.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "br-slc.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/br-slc/templates/service.yaml
+++ b/charts/br-slc/templates/service.yaml
@@ -1,4 +1,5 @@
-{{- /* ClusterIP-only Service — no NodePort/LoadBalancer, no Ingress (BYOC scope). */ -}}
+{{- /* ClusterIP-only Service — no NodePort/LoadBalancer. Ingress is opt-in and
+       disabled by default (see ingress.yaml / values.yaml ingress.enabled). */ -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/br-slc/values.yaml
+++ b/charts/br-slc/values.yaml
@@ -61,6 +61,28 @@ service:
   port: 4111
   targetPort: 4111
 
+# Opt-in Ingress — OFF by default. The BYOC default reaches the app over cluster
+# DNS / a manually managed edge (see service.yaml), so an Ingress object is only
+# rendered when enabled=true. Enable per-environment (e.g. internal dev-st) by
+# setting enabled, className, and hosts.
+ingress:
+  # -- Enable or disable ingress
+  enabled: false
+  # -- Ingress class name (e.g. "nginx")
+  className: ""
+  # -- Additional ingress annotations
+  annotations: {}
+  hosts:
+    - host: ""
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration for ingress
+  tls: []
+  #  - secretName: br-slc-tls
+  #    hosts:
+  #      - br-slc.example.local
+
 # Mirrors deployments/helm/slc-signer's hardened posture exactly (Decision 9
 # sidecar precedent): non-root, no privilege escalation, read-only root fs, all
 # capabilities dropped, RuntimeDefault seccomp. /tmp is writable via emptyDir


### PR DESCRIPTION
## Pull Request Type

- [x] BR SLC

## Description

Adds an **opt-in Ingress** to the `br-slc` chart, disabled by default.

Previously the chart was `ClusterIP`-only with no Ingress at all (the `service.yaml`
comment even read "no Ingress (BYOC scope)"). This adds `templates/ingress.yaml`
gated on `ingress.enabled` (default `false`), so the chart stays `ClusterIP`-only
unless an environment opts in — matching the plugin-fees pattern, adapted to
br-slc's **top-level** values (no per-app subkey) and the `br-slc.*` helpers.

Changes:
- `templates/ingress.yaml` — new, `{{- if .Values.ingress.enabled -}}` guarded.
- `values.yaml` — new top-level `ingress` block (`enabled: false`, `className`,
  `annotations`, `hosts`, `tls`).
- `templates/service.yaml` — comment updated (Ingress is now opt-in, not absent).
- `README.md` — new "Ingress (opt-in, disabled by default)" section.

Chart `version`/`appVersion` are left untouched — the repo bumps them via the
automated `chore(release):` commits, not in feature PRs.

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable). (N/A — handled by release automation)
- [x] I have confirmed this code is ready for review.

## Additional Notes

Validated with `alpine/helm:3.16.2` (kube 1.29):
- `helm lint` → 1 chart linted, 0 failed.
- `helm template` (default) → **0** Ingress objects rendered.
- `helm template --set ingress.enabled=true --set ingress.className=nginx ...`
  → correct `networking.k8s.io/v1` Ingress, backend `service: br-slc` port `4111`.

## Obs: Please, always remember to target your PR to develop branch instead of main.
