### PR TITLE
feat(charts): mock-nuclea optional Deployment + prod guard (ADR-23)

### DIFF
--- a/charts/br-slc/CHANGELOG.md
+++ b/charts/br-slc/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the br-slc Helm chart are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `mock-nuclea` fail-closed render guard (ADR-23): `mockNuclea.enabled=true` now
+  **fails** the Helm render under `ENV_NAME=production` or `DEPLOYMENT_MODE=saas`,
+  mirroring the app's `validateDispatchDevRecipientConfig`. The mock stays a
+  **separate optional Deployment** (not a same-pod sidecar — team decision
+  2026-07-23), keeping the app pod small and independently scalable.
+- `mockNuclea.spbKeysSecret` (default disabled): optional external provisioning
+  of the SPB key material for the signed credit round-trip. When enabled, the
+  operator/client supplies a Secret with the recipient PRIVATE key + emitter
+  PUBLIC cert, mounted read-only into the mock and wired via
+  `SPB_RECIPIENT_KEY_PATH`/`SPB_EMITTER_CERT_PATH` — exercising the real BYOC
+  deploy flow where the client sets the key material themselves. Disabled = bare
+  connectivity/health fixture.
+
 ## [0.1.0-beta.2] - 2026-07-15
 
 ### Added

--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -101,6 +101,104 @@ When (and only when) `mqbridge.enabled=true`:
 > (Decisão 21) — escalate as a DOUBT, do not force multi-replica with the
 > bridge enabled.
 
+## Optional `mock-nuclea` Deployment (ADR-23) — DEV/HML/BYOC-TEST ONLY
+
+`mock-nuclea` is the Núclea clearing-house **simulator**. It ships in this chart
+as a **separate, optional Deployment** (its own pod + `ClusterIP` Service,
+`mockNuclea.enabled: false` by default) — **not** a same-pod sidecar (team
+decision 2026-07-23): keeping it a distinct pod keeps the app pod small and its
+scaling independent, and toggling the fixture never touches the app pod. It lets
+a client validate the **real BYOC deploy flow** (including the signed credit
+round-trip) before they have Núclea access; when they do, it is a simple repoint
+(disable the mock, point the URLs at Núclea).
+
+> **NEVER enabled in production/BYOC-prod.** The Deployment renders a hard `fail`
+> guard when `mockNuclea.enabled=true` under `ENV_NAME=production` or
+> `DEPLOYMENT_MODE=saas` (ADR-23; mirrors the app's own
+> `validateDispatchDevRecipientConfig`). Since the chart's base `ENV_NAME`
+> defaults to `production`, enabling the fixture **requires** an overlay that
+> also sets a non-prod `ENV_NAME` (e.g. `sandbox`/`staging`).
+
+When `mockNuclea.enabled=true`:
+
+- A separate `br-slc-mock-nuclea` Deployment + `ClusterIP` Service is rendered.
+  Point the app at it in the overlay: `NUCLEA_REST_BASE_URL` /
+  `RSFN_CONSUMER_BASE_URL=http://br-slc-mock-nuclea:9190` (cluster DNS).
+- **SPB key material is provisioned EXTERNALLY** (the point of this fixture — it
+  exercises the real flow where the client sets the public/private material). All
+  four files must come from ONE self-consistent set (mint one with the mock
+  image's `-gen`), distributed to the three consumers:
+  | Consumer | Needs | Provisioned via |
+  |---|---|---|
+  | `mock-nuclea` (this pod) | `recipient.key` (unwrap C14) + `emitter.crt` (verify C15) | `mockNuclea.spbKeysSecret` (Secret mounted read-only) |
+  | `slc-signer` (app pod) | `signer.pfx` (sign C15) | `signer.softkeySecret` (existing) |
+  | `br-slc` app (app pod) | `recipient.crt` (encrypt C14) | `extraVolumes`/`extraVolumeMounts` + `DISPATCH_DEV_RECIPIENT_CERT_PATH` (overlay) |
+- `mockNuclea.spbKeysSecret.enabled: false` leaves the mock a bare
+  connectivity/health fixture (no keys, no signed round-trip).
+
+### Provisioning the SPB key set (signed round-trip runbook)
+
+> ⚠️ The four files **must all come from a SINGLE `-gen` run**. `-gen` mints fresh
+> RSA keys on every invocation, and each file is independently valid, so mixing
+> files from different runs **boots green and only fails at dispatch time** with
+> an opaque `verify C15 signature failed` / symmetric-key-unwrap error in the
+> **mock's** logs. Mint once, build all three Secrets from that one output dir,
+> and rotate them together.
+
+**1. Mint the set once.** The image is distroless (no shell, non-root uid 65532),
+so run `-gen` as a one-shot container writing to a host dir the uid can write:
+
+```bash
+mkdir -p spb-keys
+docker run --rm -u 65532:65532 -v "$PWD/spb-keys:/spb-keys" \
+  -e SIGNER_SOFTKEY_PFX_PASSPHRASE="$PFX_PASS" \
+  ghcr.io/lerianstudio/br-slc-mock-nuclea:<tag> -gen -out /spb-keys
+# → spb-keys/{recipient.key, recipient.crt, emitter.crt, signer.pfx}
+```
+
+**2. Build the three Secrets from that ONE dir** (exact key names the chart expects):
+
+```bash
+kubectl create secret generic br-slc-mock-spb-keys \
+  --from-file=recipient.key=spb-keys/recipient.key \
+  --from-file=emitter.crt=spb-keys/emitter.crt      # → mockNuclea.spbKeysSecret
+kubectl create secret generic br-slc-signer-softkey \
+  --from-file=signer.pfx=spb-keys/signer.pfx        # → signer.softkeySecret
+kubectl create secret generic br-slc-dev-recipient \
+  --from-file=recipient.crt=spb-keys/recipient.crt  # → app, via extraVolumes
+```
+
+**3. Wire the overlay** (all under a non-prod `ENV_NAME`, or the guard blocks the render):
+
+```yaml
+mockNuclea:
+  enabled: true
+  spbKeysSecret: { enabled: true, secretName: br-slc-mock-spb-keys }
+signer:
+  softkeySecret: { enabled: true, secretName: br-slc-signer-softkey }
+  secrets:
+    data:
+      # ⚠️ MUST equal the $PFX_PASS used at `-gen` time. Leaving it empty does NOT
+      # fall back to "test-passphrase" (that default is only inside `-gen`); an
+      # empty value here fails the PKCS#12 decode and the signer never gets Ready.
+      SIGNER_SOFTKEY_PFX_PASSPHRASE: "<same as $PFX_PASS>"
+extraVolumes:
+  - name: dev-recipient
+    secret: { secretName: br-slc-dev-recipient }
+extraVolumeMounts:
+  - name: dev-recipient
+    mountPath: /dev-recipient
+    readOnly: true
+configmap:
+  data:
+    # Path MUST equal the mount above + the file name. The app needs a CERTIFICATE
+    # PEM here (not a bare public key). It fails closed at boot if unreadable.
+    DISPATCH_DEV_RECIPIENT_CERT_PATH: /dev-recipient/recipient.crt
+```
+
+Disable everything (or just `spbKeysSecret`) to fall back to a bare
+connectivity/health mock with no signed round-trip.
+
 ## Install
 
 ```bash

--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -150,6 +150,10 @@ so run `-gen` as a one-shot container writing to a host dir the uid can write:
 
 ```bash
 mkdir -p spb-keys
+# The container runs as uid 65532 and writes the four files into the bind mount,
+# so the host dir must be writable by that uid (throwaway dev keys → world-writable
+# is fine). Without this, `-gen` fails with permission-denied on /spb-keys.
+chmod 777 spb-keys
 docker run --rm -u 65532:65532 -v "$PWD/spb-keys:/spb-keys" \
   -e SIGNER_SOFTKEY_PFX_PASSPHRASE="$PFX_PASS" \
   ghcr.io/lerianstudio/br-slc-mock-nuclea:<tag> -gen -out /spb-keys
@@ -159,12 +163,16 @@ docker run --rm -u 65532:65532 -v "$PWD/spb-keys:/spb-keys" \
 **2. Build the three Secrets from that ONE dir** (exact key names the chart expects):
 
 ```bash
-kubectl create secret generic br-slc-mock-spb-keys \
+# All three Secrets MUST live in the same namespace as the br-slc release — the
+# chart renders the pods into `global.namespace` (namespaceOverride, else the
+# install namespace), so a Secret in any other namespace simply won't mount.
+NS=<your br-slc release namespace>   # the -n/--namespace you pass to `helm install`
+kubectl create secret generic br-slc-mock-spb-keys --namespace "$NS" \
   --from-file=recipient.key=spb-keys/recipient.key \
   --from-file=emitter.crt=spb-keys/emitter.crt      # → mockNuclea.spbKeysSecret
-kubectl create secret generic br-slc-signer-softkey \
+kubectl create secret generic br-slc-signer-softkey --namespace "$NS" \
   --from-file=signer.pfx=spb-keys/signer.pfx        # → signer.softkeySecret
-kubectl create secret generic br-slc-dev-recipient \
+kubectl create secret generic br-slc-dev-recipient --namespace "$NS" \
   --from-file=recipient.crt=spb-keys/recipient.crt  # → app, via extraVolumes
 ```
 

--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -118,6 +118,18 @@ round-trip) before they have Núclea access; when they do, it is a simple repoin
 > `validateDispatchDevRecipientConfig`). Since the chart's base `ENV_NAME`
 > defaults to `production`, enabling the fixture **requires** an overlay that
 > also sets a non-prod `ENV_NAME` (e.g. `sandbox`/`staging`).
+>
+> **Guard premise (know this before relying on it):** it keys off the chart's
+> **declared** `configmap.data.ENV_NAME` / `configmap.data.DEPLOYMENT_MODE` — the
+> same values the chart feeds the app — and matches the **exact** strings
+> `production` / `saas`, mirroring the app's `isProductionOrSaaS()`. Two
+> consequences: (1) it does not inspect an `ENV_NAME` sourced outside the chart
+> (e.g. an external Secret); because the base default is `production` this stays
+> fail-safe, but keep `configmap.data.*` authoritative. (2) `DEPLOYMENT_MODE`
+> defaults to `byoc`, so a **BYOC-prod** deploy is caught only by the
+> `ENV_NAME=production` half — a real production tier (BYOC included) **must**
+> carry `ENV_NAME=production` for both this guard and the app's own guard to
+> engage. Never run a prod tier under a non-`production` `ENV_NAME`.
 
 When `mockNuclea.enabled=true`:
 
@@ -166,7 +178,7 @@ docker run --rm -u 65532:65532 -v "$PWD/spb-keys:/spb-keys" \
 # All three Secrets MUST live in the same namespace as the br-slc release — the
 # chart renders the pods into `global.namespace` (namespaceOverride, else the
 # install namespace), so a Secret in any other namespace simply won't mount.
-NS=<your br-slc release namespace>   # the -n/--namespace you pass to `helm install`
+NS=<your br-slc release namespace>   # = namespaceOverride if set, else the -n/--namespace you pass to `helm install`
 kubectl create secret generic br-slc-mock-spb-keys --namespace "$NS" \
   --from-file=recipient.key=spb-keys/recipient.key \
   --from-file=emitter.crt=spb-keys/emitter.crt      # → mockNuclea.spbKeysSecret

--- a/charts/br-slc/templates/mock-nuclea/deployment.yaml
+++ b/charts/br-slc/templates/mock-nuclea/deployment.yaml
@@ -1,13 +1,34 @@
 {{- if .Values.mockNuclea.enabled }}
+{{- /* ADR-23 fail-closed guard: the Núclea SIMULATOR is a DEV/HML/BYOC-test
+fixture and must NEVER run under a hardened posture. Mirrors the app's own
+central config guard validateDispatchDevRecipientConfig — the same
+isProductionOrSaaS() test (ENV_NAME=production OR DEPLOYMENT_MODE=saas). The
+chart's base ENV_NAME defaults to "production", so enabling the mock REQUIRES an
+overlay that also sets a non-prod ENV_NAME (e.g. sandbox/staging) — fail-closed
+by default, no escape hatch. */}}
+{{- if or (eq (.Values.configmap.data.ENV_NAME | default "") "production") (eq (.Values.configmap.data.DEPLOYMENT_MODE | default "") "saas") }}
+{{- fail "mockNuclea.enabled=true is a DEV/HML/BYOC-test fixture (Núclea simulator) and MUST NOT run under ENV_NAME=production or DEPLOYMENT_MODE=saas (ADR-23; mirrors validateDispatchDevRecipientConfig)" }}
+{{- end }}
 {{- /*
-Núclea clearing-house SIMULATOR — DEV/HML FIXTURE ONLY, never enable in
-production/BYOC. Standalone Deployment (own image ghcr.io/lerianstudio/
-br-slc-mock-nuclea, published by the br-slc release pipeline). Safe-by-default
-OFF (mockNuclea.enabled=false): like the detached migrations image, a gated
-component that defaults ON with an image the registry doesn't have yet would
-ImagePullBackOff and block the whole ArgoCD sync. The app reaches it over
-cluster DNS (Service br-slc-mock-nuclea:port); wire MOCK_NUCLEA_URL /
-NUCLEA_REST_BASE_URL / RSFN_CONSUMER_BASE_URL in the dev/hml gitops overlay.
+Núclea clearing-house SIMULATOR — DEV/HML/BYOC-TEST FIXTURE ONLY (guarded off in
+production/saas above). SEPARATE, standalone Deployment (own image
+ghcr.io/lerianstudio/br-slc-mock-nuclea, published by the br-slc release
+pipeline) — a distinct optional POD, NOT a same-pod sidecar (team decision
+2026-07-23, superseding the ADR-23 Fase-2 sidecar): keeps the app pod small and
+its scaling independent, and enabling/disabling the fixture never touches the
+app pod. Safe-by-default OFF (mockNuclea.enabled=false): like the detached
+migrations image, a gated component defaulting ON with an image the registry
+doesn't have yet would ImagePullBackOff and block the ArgoCD sync. The app
+reaches it over cluster DNS (Service br-slc-mock-nuclea:port); wire
+NUCLEA_REST_BASE_URL / RSFN_CONSUMER_BASE_URL to it in the dev/hml/BYOC-test
+overlay.
+
+SPB key material for the signed credit round-trip (spb_envelope scenario) is
+provisioned EXTERNALLY by the operator/client (mockNuclea.spbKeysSecret below) —
+this exercises the REAL BYOC deploy flow, where the client sets the public/private
+key material themselves. When they get real Núclea access it is a simple repoint
+(disable the mock, point the URLs at Núclea). Off by default, so the mock also
+runs as a bare connectivity/health fixture with no keys.
 */}}
 {{- $pullSecrets := .Values.mockNuclea.imagePullSecrets | default .Values.imagePullSecrets }}
 apiVersion: apps/v1
@@ -47,6 +68,16 @@ spec:
           env:
             - name: MOCK_NUCLEA_ADDR
               value: {{ printf ":%d" (int .Values.mockNuclea.service.targetPort) | quote }}
+            {{- if .Values.mockNuclea.spbKeysSecret.enabled }}
+            {{- /* Externally provisioned SPB key material (spb_envelope scenario,
+            mock/spbenvelope.go): the recipient PRIVATE key (unwrap C14) and the
+            emitter PUBLIC cert (verify C15), mounted read-only from the operator's
+            Secret (mockNuclea.spbKeysSecret). Absent → the mock runs health-only. */}}
+            - name: SPB_RECIPIENT_KEY_PATH
+              value: {{ printf "%s/recipient.key" .Values.mockNuclea.spbKeysSecret.mountPath | quote }}
+            - name: SPB_EMITTER_CERT_PATH
+              value: {{ printf "%s/emitter.crt" .Values.mockNuclea.spbKeysSecret.mountPath | quote }}
+            {{- end }}
             {{- /* GOMAXPROCS from the container CFS cpu limit — same
             downward-API fix as the app/signer/validator/mqbridge containers
             (Gate 8 FIX 7). Guarded with `with`+`if .cpu` so a nil-limit
@@ -68,4 +99,24 @@ spec:
             {{- toYaml .Values.mockNuclea.resources | nindent 12 }}
           securityContext:
             {{- include "br-slc.containerSecurityContext" .Values.mockNuclea.securityContext | nindent 12 }}
+          {{- if .Values.mockNuclea.spbKeysSecret.enabled }}
+          volumeMounts:
+            - name: spb-keys
+              mountPath: {{ .Values.mockNuclea.spbKeysSecret.mountPath }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.mockNuclea.spbKeysSecret.enabled }}
+      volumes:
+        {{- /* The operator's Secret must expose the recipient PRIVATE key and the
+        emitter PUBLIC cert under the configured item keys; they are surfaced to
+        the container as recipient.key / emitter.crt. */}}
+        - name: spb-keys
+          secret:
+            secretName: {{ .Values.mockNuclea.spbKeysSecret.secretName }}
+            items:
+              - key: {{ .Values.mockNuclea.spbKeysSecret.recipientKeyItem }}
+                path: recipient.key
+              - key: {{ .Values.mockNuclea.spbKeysSecret.emitterCertItem }}
+                path: emitter.crt
+      {{- end }}
 {{- end }}

--- a/charts/br-slc/values.schema.json
+++ b/charts/br-slc/values.schema.json
@@ -497,7 +497,7 @@
           "properties": {
             "enabled": { "type": "boolean" },
             "secretName": { "type": "string" },
-            "mountPath": { "type": "string", "minLength": 1 },
+            "mountPath": { "type": "string", "minLength": 1, "pattern": "^/" },
             "recipientKeyItem": { "type": "string", "minLength": 1 },
             "emitterCertItem": { "type": "string", "minLength": 1 }
           }

--- a/charts/br-slc/values.schema.json
+++ b/charts/br-slc/values.schema.json
@@ -489,6 +489,19 @@
             "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
           }
         },
+        "spbKeysSecret": {
+          "type": "object",
+          "required": ["enabled"],
+          "if": { "properties": { "enabled": { "const": true } } },
+          "then": { "required": ["secretName"], "properties": { "secretName": { "minLength": 1 } } },
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "secretName": { "type": "string" },
+            "mountPath": { "type": "string", "minLength": 1 },
+            "recipientKeyItem": { "type": "string", "minLength": 1 },
+            "emitterCertItem": { "type": "string", "minLength": 1 }
+          }
+        },
         "resources": {
           "type": "object",
           "properties": {

--- a/charts/br-slc/values.yaml
+++ b/charts/br-slc/values.yaml
@@ -912,6 +912,28 @@ mockNuclea:
     type: ClusterIP
     port: 9190
     targetPort: 9190
+  # Externally provisioned SPB key material for the signed credit round-trip
+  # (spb_envelope scenario). OFF by default — the mock then runs as a bare
+  # connectivity/health fixture. When enabled, the OPERATOR/CLIENT provides a
+  # Secret (this exercises the REAL BYOC deploy flow: the client sets the
+  # public/private key material themselves, exactly like the ICP-Brasil cert in
+  # production) exposing the recipient PRIVATE key (mock unwraps C14) and the
+  # emitter PUBLIC cert (mock verifies C15). The signer's own signer.pfx is
+  # provisioned separately via signer.softkeySecret; the app's recipient PUBLIC
+  # cert via extraVolumes + DISPATCH_DEV_RECIPIENT_CERT_PATH — all from the SAME
+  # self-consistent set (mint one with the mock image's `-gen`). Reached over
+  # cluster DNS; the mock is a SEPARATE pod, so no in-pod key sharing.
+  spbKeysSecret:
+    enabled: false
+    # Existing Secret holding the SPB key material, e.g.:
+    #   kubectl create secret generic br-slc-mock-spb-keys \
+    #     --from-file=recipient.key=./recipient.key --from-file=emitter.crt=./emitter.crt
+    secretName: ""
+    mountPath: "/spb-keys"
+    # Key names WITHIN the Secret (surfaced to the container as recipient.key /
+    # emitter.crt regardless of the Secret's own key names).
+    recipientKeyItem: "recipient.key"
+    emitterCertItem: "emitter.crt"
   # Distroless static nonroot binary (USER 65532) that writes nothing to disk,
   # so readOnlyRootFilesystem is safe with no /tmp emptyDir needed (unlike the
   # app/signer/validator containers above).


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type

- [x] BR SLC

## Checklist

- [x] I have tested these changes locally. — `helm lint` PASS; `helm template` renders valid YAML across: mock OFF (default, nothing), mock ON as a **separate Deployment+Service** (`ENV_NAME=staging`; health-only with `spbKeysSecret` off, SPB env + Secret mount with it on), guard FAIL under `ENV_NAME=production` and `DEPLOYMENT_MODE=saas`, and schema rejects `spbKeysSecret.enabled=true` without `secretName`.
- [x] I have updated the documentation accordingly. — README section (topology, guard, external key provisioning) + `CHANGELOG.md` `[Unreleased]`.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards. — separate optional Deployment mirrors the `plugin-br-pix-indirect-btg` optional-component pattern; ClusterIP-only; hardened `securityContext`; health probes.
- [x] I have checked for any potential security issues. — fail-closed guard blocks the fixture under `production`/`saas`; SPB key material is provisioned externally by the operator (never in the chart/git).
- [x] I have ensured that all tests pass. — chart validation (`helm lint` + `helm-chart-standard` CI); no unit-test suite for this chart.
- [x] I have updated the version appropriately (if applicable). — N/A: chart version is release-automation-managed (consistent with #1697, which did not bump `Chart.yaml`).
- [x] I have confirmed this code is ready for review. — **DRAFT**: pending merge-order coordination with #1697.

## Additional Notes

**What this is** — keep `mock-nuclea` (the Núclea clearing-house SIMULATOR, a **DEV/HML/BYOC-test fixture**) as a **separate, optional Deployment** in the br-slc chart — its own pod + `ClusterIP` Service, reached over cluster DNS — **not** a same-pod sidecar. This is the **team decision of 2026-07-23** (Arthur / Ferreira / Jefferson / Guilherme / Marco), superseding the ADR-23 Fase-2 sidecar approach: a separate pod keeps the app pod small and independently scalable, and toggling the fixture never touches the app pod (mirrors the `plugin-br-pix-indirect-btg` optional-component pattern). Default `mockNuclea.enabled=false`.

> ⚠️ This draft previously proposed a same-pod **sidecar**; it was reworked to the separate-pod design above per the team decision. The branch history was amended to a single clean commit.

**What it adds on top of the pre-existing standalone mock**
- **Fail-closed render guard**: `mockNuclea.enabled=true` fails the render under `ENV_NAME=production` or `DEPLOYMENT_MODE=saas` (mirrors the app's `validateDispatchDevRecipientConfig`). Base `ENV_NAME` defaults to `production`, so enabling the fixture requires an overlay that also sets a non-prod `ENV_NAME` (e.g. `sandbox`/`staging`).
- **`mockNuclea.spbKeysSecret`** (default disabled): optional **external** provisioning of the SPB key material for the signed credit round-trip. The operator/client supplies a Secret with the recipient PRIVATE key + emitter PUBLIC cert; it is mounted read-only into the mock and wired via `SPB_RECIPIENT_KEY_PATH`/`SPB_EMITTER_CERT_PATH`. This deliberately exercises the **real BYOC deploy flow** — the client sets the public/private key material themselves, exactly like the ICP-Brasil cert in production; a simple repoint to real Núclea later. The signer's `signer.pfx` keeps coming from `signer.softkeySecret`, and the app's recipient PUBLIC cert from `extraVolumes` + `DISPATCH_DEV_RECIPIENT_CERT_PATH` — all from ONE self-consistent set (mint with the mock image's `-gen`). Disabled = bare connectivity/health fixture.

**⚠️ Merge-order coordination** — based on **#1697** (`feat/br-slc-optional-ingress`), so **#1697 should merge first**. Overlap is only in `README.md`; the mock changes are isolated to `templates/mock-nuclea/deployment.yaml`, `values.yaml`, `values.schema.json`, `CHANGELOG.md`.

**Follow-up (separate repo)** — **ADR-23 in `br-slc/docs/decisions.md`** (which codified the sidecar) needs to be superseded/amended to record this separate-pod decision.