### PR TITLE
feat(common): add lerian-common library chart

### DIFF
--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -24,6 +24,7 @@ var allowedChartTypes = map[string]bool{
 	"single-service":     true,
 	"multi-component":    true,
 	"dependency-wrapper": true,
+	"library":            true,
 }
 
 var credentialURLPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://[^\s/@]+:[^\s/@]+@`)
@@ -243,11 +244,18 @@ func collectViolations(root string) ([]violation, error) {
 
 		chartType := chart.Annotations[chartTypeAnnotation]
 		if !allowedChartTypes[chartType] {
-			violations = append(violations, newViolation(chartName, "invalid-chart-type", chartRel, "Chart.yaml must set annotations.lerian.studio/chart-type to single-service, multi-component, or dependency-wrapper"))
+			violations = append(violations, newViolation(chartName, "invalid-chart-type", chartRel, "Chart.yaml must set annotations.lerian.studio/chart-type to single-service, multi-component, dependency-wrapper, or library"))
 		}
 
-		if chart.Type != "application" {
-			violations = append(violations, newViolation(chartName, "invalid-chart-kind", chartRel, "Chart.yaml type must be application"))
+		isLibrary := chart.Type == "library"
+		if chart.Type != "application" && !isLibrary {
+			violations = append(violations, newViolation(chartName, "invalid-chart-kind", chartRel, "Chart.yaml type must be application or library"))
+		}
+
+		// The library annotation and the Helm chart kind must agree, so an
+		// application chart cannot claim chart-type: library to skip requirements.
+		if (chartType == "library") != isLibrary {
+			violations = append(violations, newViolation(chartName, "chart-type-mismatch", chartRel, "annotations.lerian.studio/chart-type: library requires (and only applies to) Chart.yaml type: library"))
 		}
 
 		for _, required := range []string{"README.md", "values.yaml"} {
@@ -258,7 +266,7 @@ func collectViolations(root string) ([]violation, error) {
 		}
 		violations = append(violations, validateReadmeContract(root, chartDir, chartName, chartType)...)
 
-		if chartType != "dependency-wrapper" {
+		if chartType != "dependency-wrapper" && !isLibrary {
 			valuesTemplate := filepath.Join(chartDir, "values-template.yaml")
 			if !fileExists(valuesTemplate) {
 				violations = append(violations, newViolation(chartName, "missing-values-template", rel(root, valuesTemplate), "application charts must provide values-template.yaml"))
@@ -1021,6 +1029,18 @@ func buildRenderInventory(root string) ([]renderRow, error) {
 	return buildRenderRows(root, nil, "")
 }
 
+func isLibraryChart(chartDir string) bool {
+	data, err := os.ReadFile(filepath.Join(chartDir, "Chart.yaml"))
+	if err != nil {
+		return false
+	}
+	var c chartYAML
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return false
+	}
+	return c.Type == "library"
+}
+
 func buildRenderGate(root string, chartSelection map[string]bool, sampleValuesDir string) ([]renderRow, error) {
 	rows, err := buildRenderRows(root, chartSelection, sampleValuesDir)
 	if err != nil {
@@ -1055,6 +1075,16 @@ func buildRenderRows(root string, chartSelection map[string]bool, sampleValuesDi
 			continue
 		}
 		row := renderRow{Chart: chartName}
+
+		// Library charts are not installable (helm template fails); their helpers
+		// are exercised through the consumer charts, so skip the render gate.
+		if isLibraryChart(chartDir) {
+			row.Status = "ok"
+			row.Class = "skipped-library"
+			row.Detail = "library chart — not installable; helpers validated via consumer charts"
+			rows = append(rows, row)
+			continue
+		}
 
 		deps, err := chartDependencies(chartDir)
 		if err != nil {

--- a/charts/lerian-common/Chart.yaml
+++ b/charts/lerian-common/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   Library chart — renders nothing on its own. Adopting it is a refactor, not a
   breaking change: every helper reproduces the existing rendered output.
 type: library
-version: 0.1.0
-appVersion: "0.1.0"
+version: 1.0.0
+appVersion: "1.0.0"
 annotations:
   lerian.studio/chart-type: library
 home: https://github.com/LerianStudio/helm

--- a/charts/lerian-common/Chart.yaml
+++ b/charts/lerian-common/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: lerian-common
+description: >-
+  Lerian shared Helm library. Factors the logic duplicated across the product
+  charts into render-equivalent helpers consumed via `include`: env contracts
+  (service discovery, streaming, multi-tenant), in-cluster host derivation, and
+  (progressively) naming/labels, securityContext, probes and workload boilerplate.
+  Library chart — renders nothing on its own. Adopting it is a refactor, not a
+  breaking change: every helper reproduces the existing rendered output.
+type: library
+version: 0.1.0
+appVersion: "0.1.0"
+annotations:
+  lerian.studio/chart-type: library
+home: https://github.com/LerianStudio/helm
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+keywords:
+  - lerian
+  - library
+  - common
+  - service-discovery

--- a/charts/lerian-common/README.md
+++ b/charts/lerian-common/README.md
@@ -1,0 +1,51 @@
+# lerian-common
+
+Shared Helm **library chart** for the LerianStudio product charts. It renders
+nothing on its own — it provides render-equivalent helpers (`define`s) consumed
+via `include` by the product charts that declare it as a dependency.
+
+## Helpers
+
+- **Env contracts:** `lerian-common.serviceDiscovery.env`, `lerian-common.streaming.env`,
+  `lerian-common.multiTenant.env` — env-wide constants come from `global.*`
+  (set once per environment); the per-app enable knob stays in the component's
+  `extraEnvVars`/`configmap`; a component value overrides the global default; and
+  each helper stays **inert until `global.*` is set** (backward-compatible).
+- **In-cluster host primitives:** `lerian-common.internalHost`, `lerian-common.internalURL`.
+- **Resource helpers:** `lerian-common.hpa`, `.service`, `.serviceAccount`, `.pdb`, `.ingress`.
+- **Deployment pod-spec fragments:** `lerian-common.scheduling`, `.imagePullSecrets`,
+  `.httpProbe`, `.rolesAnywhere.{sidecar,volume,imdsEnv,podSecurityContext}`.
+- **Dependency helpers:** `lerian-common.dependency.fullname`, `.infraSecretRef`.
+- **`lerian-common.deploymentStrategy`.**
+
+See `values.yaml` for the standard `global.{serviceDiscovery,streaming,multiTenant}` template.
+
+## Usage
+
+```yaml
+# consumer Chart.yaml
+dependencies:
+  - name: lerian-common
+    version: "0.1.0"
+    repository: "file://../lerian-common"
+```
+
+```yaml
+# consumer template (example)
+{{- with (include "lerian-common.serviceDiscovery.env" (dict
+      "context" $ "enabled" true "name" (include "myapp.fullname" .)
+      "port" .Values.app.service.port "namespace" (include "global.namespace" $))) }}
+{{ . | nindent 2 }}
+{{- end }}
+```
+
+## Chart Contract
+
+- Chart type: `library`
+- **Required secrets:** none — this is a library chart; it declares and manages no secrets.
+- **Dependency notes:** no subchart dependencies of its own. Consumers reference it via
+  `repository: "file://../lerian-common"` (monorepo) and vendor it at
+  `helm dependency build`; packaged consumer charts embed it in their `.tgz`.
+- **Production overrides:** set `global.serviceDiscovery`, `global.streaming` and
+  `global.multiTenant` once per environment (umbrella/GitOps). Helpers stay inert until set.
+- **Source/License:** https://github.com/LerianStudio/helm — © Lerian Studio.

--- a/charts/lerian-common/templates/_auth.tpl
+++ b/charts/lerian-common/templates/_auth.tpl
@@ -1,0 +1,27 @@
+{{/*
+==============================================================================
+lerian-common — Auth env (plugin-access-manager).
+
+Emits the auth ConfigMap keys from the shared `global.auth` contract, with the
+component's own `configmap.<KEY>` overriding (same precedence as the other env
+helpers). Enable is env-wide (global.auth.enabled) with per-component override.
+
+The host env key differs per product (ledger uses PLUGIN_AUTH_HOST, crm uses
+PLUGIN_AUTH_ADDRESS), so the caller passes `hostKey`.
+
+Usage (component configmap.yaml):
+  {{- include "lerian-common.auth.env" (dict
+        "context" $ "configmap" .Values.ledger.configmap
+        "hostKey" "PLUGIN_AUTH_HOST") | nindent 2 }}
+
+Inputs (dict):
+  context     (req)  root context ($) — reads global.auth
+  configmap   (req)  the component's `.configmap` map (override source)
+  hostKey     (req)  the host env key (PLUGIN_AUTH_HOST | PLUGIN_AUTH_ADDRESS)
+  hostDefault (opt)  legacy default for the host key (keeps standalone identical)
+==============================================================================
+*/}}
+{{- define "lerian-common.auth.env" -}}
+PLUGIN_AUTH_ENABLED: {{ include "lerian-common.globalValue" (dict "context" .context "configmap" .configmap "block" "auth" "field" "enabled" "nativeKey" "PLUGIN_AUTH_ENABLED" "default" "false") | quote }}
+{{ .hostKey }}: {{ include "lerian-common.globalValue" (dict "context" .context "configmap" .configmap "block" "auth" "field" "host" "nativeKey" .hostKey "default" (.hostDefault | default "")) | quote }}
+{{- end -}}

--- a/charts/lerian-common/templates/_datastore.tpl
+++ b/charts/lerian-common/templates/_datastore.tpl
@@ -1,0 +1,39 @@
+{{/*
+==============================================================================
+lerian-common — Datastore mask resolver.
+
+Lets a product emit its native datastore env keys from an operator "mask", so the
+operator writes `postgres.host` (not `DB_ONBOARDING_HOST`). Two deploy modes:
+
+  - SHARED    → global.datastores.<type>.<field>       (all products, one instance)
+  - DEDICATED → <product>.datastores.<type>.<field>    (this product's own instance)
+
+Precedence per field (backward-compatible):
+  native configmap key  >  dedicated (<product>.datastores)  >  shared (global.datastores)  >  default
+
+Standalone (no umbrella, no mask): falls through to the native key or the default →
+render-equivalent, existing users unaffected. In an umbrella, `.context.Values` is
+the subchart's root, so `.Values.datastores` = the per-product `<product>.datastores`
+block (dedicated) and `.Values.global.datastores` = the shared mask.
+==============================================================================
+*/}}
+
+{{/*
+lerian-common.datastore.value — resolve ONE datastore field via the mask.
+Inputs (dict):
+  context   (req)  product root ($)
+  configmap (req)  the component's `.configmap` map (native key — top precedence)
+  type      (req)  mask block: postgres | mongo | redis | redisMt | broker | <role>
+  field     (req)  canonical field. Shared across a product's modules:
+                     host | replicaHost | user | port | ssl | params
+                   Per-module fields (database/name) stay native, NOT masked.
+  nativeKey (req)  the product's real env key (e.g. DB_ONBOARDING_HOST)
+  default   (opt)  fallback when neither native key nor mask is set (keep it equal
+                   to the pre-mask render so standalone stays byte-identical)
+*/}}
+{{- define "lerian-common.datastore.value" -}}
+{{- $cm := .configmap | default dict -}}
+{{- $dedicated := index (.context.Values.datastores | default dict) .type | default dict -}}
+{{- $shared := index ((.context.Values.global | default dict).datastores | default dict) .type | default dict -}}
+{{- index $cm .nativeKey | default (index $dedicated .field) | default (index $shared .field) | default .default | default "" -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_datastore.tpl
+++ b/charts/lerian-common/templates/_datastore.tpl
@@ -35,5 +35,18 @@ Inputs (dict):
 {{- $cm := .configmap | default dict -}}
 {{- $dedicated := index (.context.Values.datastores | default dict) .type | default dict -}}
 {{- $shared := index ((.context.Values.global | default dict).datastores | default dict) .type | default dict -}}
-{{- index $cm .nativeKey | default (index $dedicated .field) | default (index $shared .field) | default .default | default "" -}}
+{{/* Ordered presence checks (not chained sprig `default`) so an explicit `false`
+     at any tier — native key, dedicated, shared, or default — wins instead of
+     falling through to a lower-priority value. */}}
+{{- if hasKey $cm .nativeKey -}}
+{{- index $cm .nativeKey -}}
+{{- else if hasKey $dedicated .field -}}
+{{- index $dedicated .field -}}
+{{- else if hasKey $shared .field -}}
+{{- index $shared .field -}}
+{{- else if hasKey . "default" -}}
+{{- .default -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
 {{- end -}}

--- a/charts/lerian-common/templates/_dependency.tpl
+++ b/charts/lerian-common/templates/_dependency.tpl
@@ -1,0 +1,54 @@
+{{/*
+==============================================================================
+lerian-common — subchart dependency helpers (PostgreSQL, Valkey, MongoDB,
+RabbitMQ, SeaweedFS bundled via Bitnami-style subcharts).
+
+These centralize logic each chart duplicates today:
+  - dependency.fullname : the collapse-aware subchart resource name (vendored
+    from Bitnami common; identical in ~16 charts). Consumers keep their existing
+    `common.names.dependency.fullname` as a 1-line alias to this.
+  - infraSecretRef      : a container env entry (secretKeyRef) that single-sources
+    an infra password from the subchart's own Secret (external path uses an
+    existingSecret). Duplicated in ~12 charts.
+==============================================================================
+*/}}
+
+{{/*
+lerian-common.dependency.fullname — collapse-aware "<release>-<name>" (honors
+release-name collapse, nameOverride, fullnameOverride).
+Inputs: chartName, chartValues, context.
+*/}}
+{{- define "lerian-common.dependency.fullname" -}}
+{{- if .chartValues.fullnameOverride -}}
+{{- .chartValues.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .chartName .chartValues.nameOverride -}}
+{{- if contains $name .context.Release.Name -}}
+{{- .context.Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .context.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+lerian-common.infraSecretRef — a single `env:` entry (secretKeyRef) sourcing an
+infra password from the subchart Secret (or its existingSecret override).
+Inputs: context, subchart, key (secret key), envName (container env var name).
+*/}}
+{{- define "lerian-common.infraSecretRef" -}}
+{{- $ctx := .context -}}
+{{- $sub := .subchart -}}
+{{- $auth := default dict (index $ctx.Values $sub "auth") -}}
+{{- $secretName := "" -}}
+{{- if $auth.existingSecret -}}
+{{- $secretName = $auth.existingSecret -}}
+{{- else -}}
+{{- $secretName = include "lerian-common.dependency.fullname" (dict "chartName" $sub "chartValues" (index $ctx.Values $sub) "context" $ctx) -}}
+{{- end -}}
+- name: {{ .envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: {{ .key }}
+{{- end -}}

--- a/charts/lerian-common/templates/_deployment.tpl
+++ b/charts/lerian-common/templates/_deployment.tpl
@@ -1,0 +1,114 @@
+{{/*
+==============================================================================
+lerian-common — Deployment sub-blocks (pod-spec fragments).
+
+The full Deployment is too variable to share, but these pod-spec tail fragments
+are byte-identical across ~51 workloads. Each renders NOTHING when its value is
+empty, so wrap the include in the caller so it only appears when present:
+
+  {{- if or .Values.fees.nodeSelector .Values.fees.affinity .Values.fees.tolerations }}
+      {{- include "lerian-common.scheduling" .Values.fees | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fees.imagePullSecrets }}
+      {{- include "lerian-common.imagePullSecrets" . | nindent 6 }}
+  {{- end }}
+
+Emitting at base indent 0 (keys) + toYaml nindent 2; the caller's `nindent 6`
+shifts keys to col 6 and values to col 8 — matching the hand-written blocks.
+*/}}
+
+{{/*
+lerian-common.scheduling — nodeSelector / affinity / tolerations.
+Input: the component values map (reads .nodeSelector/.affinity/.tolerations).
+*/}}
+{{- define "lerian-common.scheduling" -}}
+{{- with .nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+lerian-common.imagePullSecrets — the imagePullSecrets block.
+Input: the imagePullSecrets list (wrap the include in `{{- with }}` in the caller).
+*/}}
+{{- define "lerian-common.imagePullSecrets" -}}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+
+{{/*
+lerian-common.deploymentStrategy — the `strategy:` block (type + optional
+rollingUpdate). Byte-identical across the "type + if RollingUpdate" family
+(~11 deployments) whose value shapes differ (flat `deploymentUpdate.*` vs
+nested `deploymentStrategy.rollingUpdate.*`, some with inline `| default`).
+The helper is shape-agnostic: the CALLER pre-resolves the three values (applying
+its own defaults) so the output stays byte-identical.
+
+Usage (flat deploymentUpdate shape):
+  {{- include "lerian-common.deploymentStrategy" (dict
+        "type" .Values.matcher.deploymentUpdate.type
+        "maxSurge" .Values.matcher.deploymentUpdate.maxSurge
+        "maxUnavailable" .Values.matcher.deploymentUpdate.maxUnavailable
+      ) | nindent 2 }}
+
+Usage (nested deploymentStrategy shape):
+  {{- include "lerian-common.deploymentStrategy" (dict
+        "type" .Values.manager.deploymentStrategy.type
+        "maxSurge" .Values.manager.deploymentStrategy.rollingUpdate.maxSurge
+        "maxUnavailable" .Values.manager.deploymentStrategy.rollingUpdate.maxUnavailable
+      ) | nindent 2 }}
+
+Inputs: type, maxSurge, maxUnavailable. Caller: nindent 2 (under spec:).
+*/}}
+{{- define "lerian-common.deploymentStrategy" -}}
+strategy:
+  type: {{ .type }}
+  {{- if eq .type "RollingUpdate" }}
+  rollingUpdate:
+    maxSurge: {{ .maxSurge }}
+    maxUnavailable: {{ .maxUnavailable }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+lerian-common.httpProbe — one httpGet probe block (readiness/liveness/startup).
+Probes appear in ~49 deployments with an identical structure but the ORDER and
+DEFAULTS vary per chart, so this emits ONE block; the chart calls it once per
+probe in its own order, passing its own defaults (byte-identical).
+
+Usage (deployment.yaml, preserving the chart's existing probe order):
+          {{- include "lerian-common.httpProbe" (dict
+                "kind" "readinessProbe" "probe" .Values.fees.readinessProbe
+                "port" .Values.fees.service.port
+                "path" "/readyz" "initialDelay" 10 "period" 5 "timeout" 1 "success" 1 "failure" 3
+              ) | nindent 10 }}
+          {{- include "lerian-common.httpProbe" (dict
+                "kind" "livenessProbe" "probe" .Values.fees.livenessProbe
+                "port" .Values.fees.service.port
+                "path" "/health" "initialDelay" 5 "period" 5 "timeout" 1 "success" 1 "failure" 3
+              ) | nindent 10 }}
+
+Inputs: kind, probe (values map), port, path, initialDelay, period, timeout, success, failure.
+*/}}
+{{- define "lerian-common.httpProbe" -}}
+{{- $p := .probe | default dict -}}
+{{ .kind }}:
+  httpGet:
+    path: {{ $p.path | default .path }}
+    port: {{ .port }}
+  {{- /* hasKey (not | default) so an explicit 0 override is honored, not treated as absent. */}}
+  initialDelaySeconds: {{ if hasKey $p "initialDelaySeconds" }}{{ $p.initialDelaySeconds }}{{ else }}{{ .initialDelay }}{{ end }}
+  periodSeconds: {{ if hasKey $p "periodSeconds" }}{{ $p.periodSeconds }}{{ else }}{{ .period }}{{ end }}
+  timeoutSeconds: {{ if hasKey $p "timeoutSeconds" }}{{ $p.timeoutSeconds }}{{ else }}{{ .timeout }}{{ end }}
+  successThreshold: {{ if hasKey $p "successThreshold" }}{{ $p.successThreshold }}{{ else }}{{ .success }}{{ end }}
+  failureThreshold: {{ if hasKey $p "failureThreshold" }}{{ $p.failureThreshold }}{{ else }}{{ .failure }}{{ end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_global.tpl
+++ b/charts/lerian-common/templates/_global.tpl
@@ -1,0 +1,65 @@
+{{/*
+==============================================================================
+lerian-common — generic global-contract resolver.
+
+Same idea as the datastore mask, for any cross-product concern that lives under
+`global.<block>` (auth, observability, ...). A product emits its native env key
+from a shared default, so the operator declares it ONCE at the umbrella level.
+
+Precedence (backward-compatible):
+  native configmap key  >  global.<block>.<field>  >  default
+
+Standalone (no umbrella / no global.<block>): falls through to the native key or
+the default → render-equivalent, existing users unaffected. Keep `default` equal
+to the pre-contract render so standalone stays byte-identical.
+
+Inputs (dict):
+  context   (req)  product root ($)
+  configmap (req)  the component's `.configmap` map (native key — top precedence)
+  block     (req)  the global sub-block: auth | observability | ...
+  field     (req)  canonical field within the block: enabled | host | ...
+  nativeKey (req)  the product's real env key (e.g. PLUGIN_AUTH_HOST)
+  default   (opt)  fallback when neither native key nor global is set
+*/}}
+{{- define "lerian-common.globalValue" -}}
+{{- $cm := .configmap | default dict -}}
+{{- $blk := index (.context.Values.global | default dict) .block | default dict -}}
+{{- $native := index $cm .nativeKey -}}
+{{/* Use presence checks (not sprig `default`) so an explicit boolean `false` in the
+     global block wins instead of falling through to the default. */}}
+{{- if not (empty $native) -}}
+{{- $native -}}
+{{- else if hasKey $blk .field -}}
+{{- index $blk .field -}}
+{{- else -}}
+{{- .default | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+lerian-common.cfgValue — productized config resolver (product-level, no global block).
+Lets a chart expose a clean grouped param (e.g. ledger.audit.enabled) while the raw
+`configmap.<KEY>` still works and wins — backward-compatible with the legacy format.
+
+Precedence:  configmap native key  >  clean param (params.<field>)  >  default
+
+Presence-aware (hasKey) so an explicit boolean `false` in the clean param wins.
+Inputs (dict):
+  configmap (req)  the component's `.configmap` map (legacy native key — top precedence)
+  nativeKey (req)  the real env key (e.g. AUDIT_LOG_ENABLED)
+  params    (req)  the clean param sub-map (e.g. .Values.ledger.audit)
+  field     (req)  field within params (e.g. enabled)
+  default   (opt)  fallback = the legacy template default (keeps standalone byte-identical)
+*/}}
+{{- define "lerian-common.cfgValue" -}}
+{{- $cm := .configmap | default dict -}}
+{{- $p := .params | default dict -}}
+{{- $native := index $cm .nativeKey -}}
+{{- if not (empty $native) -}}
+{{- $native -}}
+{{- else if hasKey $p .field -}}
+{{- index $p .field -}}
+{{- else -}}
+{{- .default | default "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_global.tpl
+++ b/charts/lerian-common/templates/_global.tpl
@@ -24,15 +24,17 @@ Inputs (dict):
 {{- define "lerian-common.globalValue" -}}
 {{- $cm := .configmap | default dict -}}
 {{- $blk := index (.context.Values.global | default dict) .block | default dict -}}
-{{- $native := index $cm .nativeKey -}}
-{{/* Use presence checks (not sprig `default`) so an explicit boolean `false` in the
-     global block wins instead of falling through to the default. */}}
-{{- if not (empty $native) -}}
-{{- $native -}}
+{{/* Use presence checks (not sprig `default`/`empty`) at every tier so an explicit
+     boolean `false` (native key, global block, or default) wins instead of falling
+     through to a lower-priority value. */}}
+{{- if hasKey $cm .nativeKey -}}
+{{- index $cm .nativeKey -}}
 {{- else if hasKey $blk .field -}}
 {{- index $blk .field -}}
+{{- else if hasKey . "default" -}}
+{{- .default -}}
 {{- else -}}
-{{- .default | default "" -}}
+{{- "" -}}
 {{- end -}}
 {{- end -}}
 
@@ -54,12 +56,13 @@ Inputs (dict):
 {{- define "lerian-common.cfgValue" -}}
 {{- $cm := .configmap | default dict -}}
 {{- $p := .params | default dict -}}
-{{- $native := index $cm .nativeKey -}}
-{{- if not (empty $native) -}}
-{{- $native -}}
+{{- if hasKey $cm .nativeKey -}}
+{{- index $cm .nativeKey -}}
 {{- else if hasKey $p .field -}}
 {{- index $p .field -}}
+{{- else if hasKey . "default" -}}
+{{- .default -}}
 {{- else -}}
-{{- .default | default "" -}}
+{{- "" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/lerian-common/templates/_hosts.tpl
+++ b/charts/lerian-common/templates/_hosts.tpl
@@ -1,0 +1,36 @@
+{{/*
+==============================================================================
+lerian-common — in-cluster host derivation primitives.
+
+The `name` and `namespace` are ALWAYS computed by the caller (via
+`common.names.dependency.fullname`, `.Release.Name`-prefixing, `global.namespace`,
+`.Release.Namespace`, or a literal) and passed in as strings. The library only
+assembles the FQDN suffix, so the rendered output stays byte-identical to the
+hand-written printf it replaces.
+
+The four axes of variation observed across the charts are explicit flags:
+  dot    (bool)   -> trailing "." after svc.cluster.local  (the ad-hoc-est knob)
+  port   (number) -> ":<port>" suffix
+  scheme (string) -> "<scheme>://" prefix (internalURL only)
+  path   (string) -> trailing path (internalURL only)
+==============================================================================
+*/}}
+
+{{/*
+lerian-common.internalHost -> <name>.<namespace>.svc.cluster.local[.][:port]
+Inputs: name (req), namespace (req), dot (opt bool), port (opt).
+*/}}
+{{- define "lerian-common.internalHost" -}}
+{{- $h := printf "%s.%s.svc.cluster.local" .name .namespace -}}
+{{- if .dot }}{{- $h = printf "%s." $h -}}{{- end -}}
+{{- if .port }}{{- $h = printf "%s:%v" $h .port -}}{{- end -}}
+{{- $h -}}
+{{- end -}}
+
+{{/*
+lerian-common.internalURL -> <scheme>://<internalHost><path>
+Inputs: scheme (req), name (req), namespace (req), dot/port (opt), path (opt).
+*/}}
+{{- define "lerian-common.internalURL" -}}
+{{- printf "%s://%s%s" .scheme (include "lerian-common.internalHost" .) (default "" .path) -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_hpa.tpl
+++ b/charts/lerian-common/templates/_hpa.tpl
@@ -1,0 +1,67 @@
+{{/*
+==============================================================================
+lerian-common — HorizontalPodAutoscaler (autoscaling/v2).
+
+The HPA manifest is near-identical across ~40 workloads; only naming/labels and
+the presence of a `namespace:` line differ per chart. This helper centralizes
+the STRUCTURE (apiVersion, scaleTargetRef, cpu/memory metric blocks) and takes
+naming/labels as strings ALREADY RENDERED by the chart's own helpers — so the
+output stays byte-identical and no naming/label contract has to be unified first.
+
+The caller owns the enable GATE (it varies: some charts also check the component
+`.enabled`), so wrap the include in the chart's existing `{{- if ... }}`.
+
+Usage (chart hpa.yaml):
+  {{- if .Values.fees.autoscaling.enabled }}
+  {{- include "lerian-common.hpa" (dict
+        "autoscaling" .Values.fees.autoscaling
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  autoscaling (req)  the component's `.autoscaling` map (minReplicas, maxReplicas,
+                     targetCPUUtilizationPercentage, targetMemoryUtilizationPercentage)
+  name        (req)  metadata.name (already rendered, e.g. include "<c>.fullname" .)
+  labels      (req)  the labels block already rendered (no leading indent)
+  namespace   (opt)  metadata.namespace (already rendered); omit the line when empty
+  targetName  (opt)  scaleTargetRef.name (defaults to `name`)
+==============================================================================
+*/}}
+{{- define "lerian-common.hpa" -}}
+{{- $a := .autoscaling -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .targetName | default .name }}
+  minReplicas: {{ $a.minReplicas }}
+  maxReplicas: {{ $a.maxReplicas }}
+  metrics:
+    {{- if $a.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $a.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $a.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $a.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_ingress.tpl
+++ b/charts/lerian-common/templates/_ingress.tpl
@@ -1,0 +1,95 @@
+{{/*
+==============================================================================
+lerian-common — Ingress (standard Helm-scaffold shape).
+
+23 of ~29 chart ingresses are the standard scaffold: KubeVersion-aware
+apiVersion + backend, ingressClassName (>=1.18), optional tls, and rules over
+hosts/paths. Naming/labels are passed ALREADY RENDERED by the chart; the caller
+owns the enable gate. Charts with a non-standard ingress keep it inline.
+
+Usage (chart ingress.yaml):
+  {{- if .Values.fees.ingress.enabled -}}
+  {{- include "lerian-common.ingress" (dict
+        "context" .
+        "ingress" .Values.fees.ingress
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+        "svcPort" .Values.fees.service.port
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  context   (req)  root context ($) — for .Capabilities.KubeVersion
+  ingress   (req)  the component's `.ingress` map (className/annotations/tls/hosts)
+  name      (req)  metadata.name + backend service name (already rendered)
+  labels    (req)  labels block already rendered (no leading indent)
+  svcPort   (req)  backend service port
+  namespace (opt)  metadata.namespace (already rendered); omitted when empty
+==============================================================================
+*/}}
+{{- define "lerian-common.ingress" -}}
+{{- $ctx := .context -}}
+{{- $ing := .ingress -}}
+{{- $name := .name -}}
+{{- $svcPort := .svcPort -}}
+{{- if and $ing.className (not (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey $ing.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set $ing.annotations "kubernetes.io/ingress.class" $ing.className }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" $ctx.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $ctx.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with $ing.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $ing.className (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $ing.className }}
+  {{- end }}
+  {{- if $ing.tls }}
+  tls:
+    {{- range $ing.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $ing.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $ctx.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $name }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $name }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_ingress.tpl
+++ b/charts/lerian-common/templates/_ingress.tpl
@@ -54,11 +54,10 @@ Inputs (dict):
 {{- $svcPort := .svcPort -}}
 {{- $className := $ing.className | default $g.className -}}
 {{- $annotations := merge (deepCopy ($g.annotations | default dict)) ($ing.annotations | default dict) -}}
-{{- $tls := $ing.tls | default $g.tls -}}
+{{- $tls := $g.tls -}}
+{{- if hasKey $ing "tls" -}}{{- $tls = $ing.tls -}}{{- end -}}
 {{- $hosts := $ing.hosts | default list -}}
-{{- $firstHost := "" -}}
-{{- if gt (len $hosts) 0 }}{{- $firstHost = (index $hosts 0).host -}}{{- end }}
-{{- if and (not $firstHost) $g.domain .subdomain -}}
+{{- if and (eq (len $hosts) 0) $g.domain .subdomain -}}
 {{- $hosts = list (dict "host" (printf "%s.%s" .subdomain $g.domain) "paths" (list (dict "path" "/" "pathType" "Prefix"))) -}}
 {{- end -}}
 {{- if and $className (not (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion)) }}

--- a/charts/lerian-common/templates/_ingress.tpl
+++ b/charts/lerian-common/templates/_ingress.tpl
@@ -1,17 +1,34 @@
 {{/*
 ==============================================================================
-lerian-common — Ingress (standard Helm-scaffold shape).
+lerian-common — Ingress (standard Helm-scaffold shape) + shared contract.
 
-23 of ~29 chart ingresses are the standard scaffold: KubeVersion-aware
-apiVersion + backend, ingressClassName (>=1.18), optional tls, and rules over
-hosts/paths. Naming/labels are passed ALREADY RENDERED by the chart; the caller
-owns the enable gate. Charts with a non-standard ingress keep it inline.
+Most chart ingresses are the standard scaffold: KubeVersion-aware apiVersion +
+backend, ingressClassName (>=1.18), optional tls, and rules over hosts/paths.
+Naming/labels are passed ALREADY RENDERED by the chart; the caller owns the
+enable gate. Charts with a non-standard ingress keep it inline.
+
+SHARED CONTRACT (optional): pass `global` (=.Values.global.ingress) and a
+`subdomain`, and each field falls back to the umbrella-level default — so an
+operator declares className/domain/annotations/tls ONCE and every product derives
+its host as "<subdomain>.<domain>". Per-product values always win.
+
+Resolution (per field):
+  className   : <chart>.ingress.className  | global.ingress.className
+  annotations : merge(global.ingress.annotations, <chart>.ingress.annotations)  (chart wins)
+  tls         : <chart>.ingress.tls        | global.ingress.tls
+  hosts       : <chart>.ingress.hosts (explicit list wins)
+                else derived [{ host: "<subdomain>.<global.ingress.domain>", paths: [/ Prefix] }]
+
+Standalone (no `global`): every field falls back to the chart's own ingress.* →
+render is byte-equivalent to the previous hand-written scaffold.
 
 Usage (chart ingress.yaml):
   {{- if .Values.fees.ingress.enabled -}}
   {{- include "lerian-common.ingress" (dict
         "context" .
         "ingress" .Values.fees.ingress
+        "global" (.Values.global).ingress
+        "subdomain" "fees"
         "name" (include "plugin-fees.fullname" .)
         "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
         "svcPort" .Values.fees.service.port
@@ -24,17 +41,29 @@ Inputs (dict):
   name      (req)  metadata.name + backend service name (already rendered)
   labels    (req)  labels block already rendered (no leading indent)
   svcPort   (req)  backend service port
+  global    (opt)  `.Values.global.ingress` — shared contract defaults
+  subdomain (opt)  host prefix used with global.ingress.domain to derive the host
   namespace (opt)  metadata.namespace (already rendered); omitted when empty
 ==============================================================================
 */}}
 {{- define "lerian-common.ingress" -}}
 {{- $ctx := .context -}}
 {{- $ing := .ingress -}}
+{{- $g := .global | default dict -}}
 {{- $name := .name -}}
 {{- $svcPort := .svcPort -}}
-{{- if and $ing.className (not (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey $ing.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set $ing.annotations "kubernetes.io/ingress.class" $ing.className }}
+{{- $className := $ing.className | default $g.className -}}
+{{- $annotations := merge (deepCopy ($g.annotations | default dict)) ($ing.annotations | default dict) -}}
+{{- $tls := $ing.tls | default $g.tls -}}
+{{- $hosts := $ing.hosts | default list -}}
+{{- $firstHost := "" -}}
+{{- if gt (len $hosts) 0 }}{{- $firstHost = (index $hosts 0).host -}}{{- end }}
+{{- if and (not $firstHost) $g.domain .subdomain -}}
+{{- $hosts = list (dict "host" (printf "%s.%s" .subdomain $g.domain) "paths" (list (dict "path" "/" "pathType" "Prefix"))) -}}
+{{- end -}}
+{{- if and $className (not (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set $annotations "kubernetes.io/ingress.class" $className }}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" $ctx.Capabilities.KubeVersion.GitVersion -}}
@@ -52,17 +81,17 @@ metadata:
   {{- end }}
   labels:
     {{- .labels | nindent 4 }}
-  {{- with $ing.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and $ing.className (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ $ing.className }}
+  {{- if and $className (semverCompare ">=1.18-0" $ctx.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $className }}
   {{- end }}
-  {{- if $ing.tls }}
+  {{- if $tls }}
   tls:
-    {{- range $ing.tls }}
+    {{- range $tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -71,7 +100,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range $ing.hosts }}
+    {{- range $hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/charts/lerian-common/templates/_ingress.tpl
+++ b/charts/lerian-common/templates/_ingress.tpl
@@ -53,7 +53,8 @@ Inputs (dict):
 {{- $name := .name -}}
 {{- $svcPort := .svcPort -}}
 {{- $className := $ing.className | default $g.className -}}
-{{- $annotations := merge (deepCopy ($g.annotations | default dict)) ($ing.annotations | default dict) -}}
+{{- /* mergeOverwrite (not merge): per-ingress annotations must win over same-key global. */ -}}
+{{- $annotations := mergeOverwrite (deepCopy ($g.annotations | default dict)) ($ing.annotations | default dict) -}}
 {{- $tls := $g.tls -}}
 {{- if hasKey $ing "tls" -}}{{- $tls = $ing.tls -}}{{- end -}}
 {{- $hosts := $ing.hosts | default list -}}

--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -65,7 +65,7 @@ MULTI_TENANT_URL: {{ $url | default "" | quote }}
 {{- if .serviceName }}
 MULTI_TENANT_SERVICE_NAME: {{ index $c "MULTI_TENANT_SERVICE_NAME" | default .serviceName | quote }}
 {{- end }}
-{{- if ne (.circuitBreaker | default true) false }}
+{{- if not (and (hasKey . "circuitBreaker") (eq .circuitBreaker false)) }}
 MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" | default "5" | quote }}
 MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC" | default "30" | quote }}
 {{- end }}

--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -1,0 +1,153 @@
+{{/*
+==============================================================================
+lerian-common — Multi-tenant env (lib-commons/multitenancy contract).
+
+Unlike serviceDiscovery/streaming, multi-tenant does NOT have a single flat
+common block: across the 8 charts that use it, only 4 vars are universal
+(ENABLED, URL, CIRCUIT_BREAKER_THRESHOLD, CIRCUIT_BREAKER_TIMEOUT_SEC) and each
+chart emits a different subset of the long tail (redis / pool / cache / etc.).
+
+So this helper centralizes the canonical DEFAULTS and var NAMES, and each chart
+opts into the GROUPS it currently emits via flags — reproducing its existing
+block exactly (render-equivalent) while removing the duplicated defaults.
+
+Like the other env helpers, it does NOT emit MULTI_TENANT_ENABLED: that stays
+inline in the component configmap as the knob (and the gate source). This helper
+emits only the gated ConfigMap block. The SECRETS (MULTI_TENANT_SERVICE_API_KEY,
+MULTI_TENANT_REDIS_PASSWORD) are emitted into the chart's own Secret by the
+companion `lerian-common.multiTenant.secret` helper below (never in the ConfigMap).
+
+plugin-br-payments is intentionally OUT of scope (different contract:
+MULTI_TENANCY_ENABLED + range-generated configmap) — keep it inline.
+
+Usage (in a component configmap.yaml, replacing the hand-written gated block;
+keep the inline `MULTI_TENANT_ENABLED:` line as the knob):
+
+  {{- include "lerian-common.multiTenant.env" (dict
+        "configmap" .Values.fees.configmap
+        "enabled" (eq (.Values.fees.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true")
+        "requiredUrl" true "requiredRedisHost" true
+        "emitRedis" true "emitPool" true "emitCache" true
+        "emitEnvironment" true "emitAllowInsecure" true
+      ) | nindent 2 }}
+
+Inputs (dict):
+  configmap          (req)  the component's `.configmap` map (override source)
+  enabled            (req)  bool — gate; emit the block only when true
+  requiredUrl        (opt)  bool — MULTI_TENANT_URL uses `required` vs default ""
+  serviceName        (opt)  string — emit MULTI_TENANT_SERVICE_NAME (default = this)
+  circuitBreaker     (opt)  bool (default true) — CB_THRESHOLD (5) + CB_TIMEOUT_SEC (30)
+  emitRedis          (opt)  bool — REDIS_HOST / REDIS_PORT (6379) / REDIS_TLS
+  requiredRedisHost  (opt)  bool — REDIS_HOST uses `required` vs default ""
+  redisTlsDefault    (opt)  string — default for REDIS_TLS ("false"; "true" for tracer)
+  emitPool           (opt)  bool — MAX_TENANT_POOLS (100) + IDLE_TIMEOUT_SEC (300)
+  emitCache          (opt)  bool — TIMEOUT (30) + CACHE_TTL_SEC (120) + CONNECTIONS_CHECK_INTERVAL_SEC (30)
+  emitEnvironment    (opt)  bool — MULTI_TENANT_ENVIRONMENT (default "")
+  emitAllowInsecure  (opt)  bool — MULTI_TENANT_ALLOW_INSECURE_HTTP (default "false")
+==============================================================================
+*/}}
+{{- define "lerian-common.multiTenant.env" -}}
+{{- $c := .configmap | default dict -}}
+{{- /* Env-wide defaults from global.multiTenant (tenant-manager URL + its redis are
+   environment infra, like global.serviceDiscovery/global.streaming). Component
+   .configmap overrides global. Guarded on .context so callers that don't pass it
+   still work (global stays empty → identical to the pre-global behavior). */ -}}
+{{- $g := dict -}}
+{{- with .context }}{{- $g = ((.Values.global | default dict).multiTenant | default dict) -}}{{- end -}}
+{{- if .enabled -}}
+{{- /* URL: universal. Component overrides global; then required or default "". */ -}}
+{{- $url := index $c "MULTI_TENANT_URL" | default $g.url -}}
+{{- if .requiredUrl }}
+MULTI_TENANT_URL: {{ required "lerian-common: MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true (set component configmap.MULTI_TENANT_URL or global.multiTenant.url)" $url | quote }}
+{{- else }}
+MULTI_TENANT_URL: {{ $url | default "" | quote }}
+{{- end }}
+{{- if .serviceName }}
+MULTI_TENANT_SERVICE_NAME: {{ index $c "MULTI_TENANT_SERVICE_NAME" | default .serviceName | quote }}
+{{- end }}
+{{- if ne (.circuitBreaker | default true) false }}
+MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" | default "5" | quote }}
+MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC" | default "30" | quote }}
+{{- end }}
+{{- if .emitRedis }}
+{{- $redisHost := index $c "MULTI_TENANT_REDIS_HOST" | default $g.redisHost -}}
+{{- if .requiredRedisHost }}
+MULTI_TENANT_REDIS_HOST: {{ required "lerian-common: MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true (set component configmap.MULTI_TENANT_REDIS_HOST or global.multiTenant.redisHost)" $redisHost | quote }}
+{{- else }}
+MULTI_TENANT_REDIS_HOST: {{ $redisHost | default "" | quote }}
+{{- end }}
+MULTI_TENANT_REDIS_PORT: {{ index $c "MULTI_TENANT_REDIS_PORT" | default $g.redisPort | default "6379" | quote }}
+MULTI_TENANT_REDIS_TLS: {{ index $c "MULTI_TENANT_REDIS_TLS" | default $g.redisTls | default (.redisTlsDefault | default "false") | quote }}
+{{- end }}
+{{- if .emitPool }}
+MULTI_TENANT_MAX_TENANT_POOLS: {{ index $c "MULTI_TENANT_MAX_TENANT_POOLS" | default "100" | quote }}
+MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ index $c "MULTI_TENANT_IDLE_TIMEOUT_SEC" | default "300" | quote }}
+{{- end }}
+{{- if .emitCache }}
+MULTI_TENANT_TIMEOUT: {{ index $c "MULTI_TENANT_TIMEOUT" | default "30" | quote }}
+MULTI_TENANT_CACHE_TTL_SEC: {{ index $c "MULTI_TENANT_CACHE_TTL_SEC" | default "120" | quote }}
+MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ index $c "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" | default "30" | quote }}
+{{- end }}
+{{- if .emitEnvironment }}
+MULTI_TENANT_ENVIRONMENT: {{ index $c "MULTI_TENANT_ENVIRONMENT" | default "" | quote }}
+{{- end }}
+{{- if .emitAllowInsecure }}
+MULTI_TENANT_ALLOW_INSECURE_HTTP: {{ index $c "MULTI_TENANT_ALLOW_INSECURE_HTTP" | default "false" | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+------------------------------------------------------------------------------
+lerian-common.multiTenant.secret — the uniform multi-tenant Secret keys.
+
+Companion to multiTenant.env: the .env helper emits the non-secret block into the
+ConfigMap; this one emits the SECRET keys into the chart's own Secret. Key names
+are uniform across all charts (only the value differs per environment).
+
+Emits nothing (and never fails) unless BOTH: the feature is enabled AND the chart
+is not using an external Secret — the value lives outside the chart when
+useExistingSecret=true, so requiring it inline is wrong. When active:
+MULTI_TENANT_SERVICE_API_KEY is required; MULTI_TENANT_REDIS_PASSWORD is optional.
+For a required-but-empty key it fails with an actionable message (Bitnami-style),
+on install AND upgrade (these values are operator/Vault-provided, never generated).
+
+`mode` matches the chart's Secret form: "data" (b64enc) | "stringData". Output is
+`KEY: value` lines with no leading/trailing newline; the caller nindents under the
+matching `data:`/`stringData:` key:
+
+  # Multi-Tenant Secrets
+  {{- with (include "lerian-common.multiTenant.secret" (dict
+        "context" . "secrets" .Values.ledger.secrets
+        "secretName" (include "midaz.ledger.fullname" .)
+        "valuesPrefix" "ledger.secrets." "mode" "data"
+        "enabled" (eq (.Values.ledger.configmap.MULTI_TENANT_ENABLED | default "false" | toString) "true")
+        "useExistingSecret" .Values.ledger.useExistingSecret)) }}
+  {{- . | nindent 2 }}
+  {{- end }}
+
+Inputs: context, secrets, secretName, valuesPrefix, mode,
+        enabled (bool — MULTI_TENANT_ENABLED),
+        useExistingSecret (bool — skip entirely when true).
+------------------------------------------------------------------------------
+*/}}
+{{- define "lerian-common.multiTenant.secret" -}}
+{{- if and .enabled (not .useExistingSecret) -}}
+{{- $s := .secrets | default dict -}}
+{{- $b64 := eq (.mode | default "stringData") "data" -}}
+{{- $ns := .context.Release.Namespace -}}
+{{- $lines := list -}}
+{{- /* MULTI_TENANT_SERVICE_API_KEY — required */ -}}
+{{- $apiKey := index $s "MULTI_TENANT_SERVICE_API_KEY" -}}
+{{- if not $apiKey -}}
+{{- fail (printf "\n[lerian-common] Secret value required but empty: MULTI_TENANT_SERVICE_API_KEY\n  set:     --set %sMULTI_TENANT_SERVICE_API_KEY=<value>   (or configure an existingSecret)\n  recover: kubectl get secret %s -n %s -o jsonpath=\"{.data.MULTI_TENANT_SERVICE_API_KEY}\" | base64 -d\n" .valuesPrefix .secretName $ns) -}}
+{{- end -}}
+{{- $lines = append $lines (printf "MULTI_TENANT_SERVICE_API_KEY: %s" (ternary ($apiKey | b64enc | quote) ($apiKey | quote) $b64)) -}}
+{{- /* MULTI_TENANT_REDIS_PASSWORD — optional */ -}}
+{{- $redisPw := index $s "MULTI_TENANT_REDIS_PASSWORD" -}}
+{{- if $redisPw -}}
+{{- $lines = append $lines (printf "MULTI_TENANT_REDIS_PASSWORD: %s" (ternary ($redisPw | b64enc | quote) ($redisPw | quote) $b64)) -}}
+{{- end -}}
+{{- join "\n" $lines -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_otel.tpl
+++ b/charts/lerian-common/templates/_otel.tpl
@@ -1,0 +1,60 @@
+{{/*
+==============================================================================
+lerian-common — Observability / OTEL env.
+
+Emits the shared telemetry keys (ENABLE_TELEMETRY + OTEL exporter endpoint) from
+the `global.observability` contract, with the component's `configmap.<KEY>`
+overriding. Per-service OTEL IDENTITY (OTEL_RESOURCE_SERVICE_NAME/VERSION,
+OTEL_LIBRARY_NAME) stays inline in each component (same split as streaming).
+
+Usage (component configmap.yaml):
+  {{- include "lerian-common.otel.env" (dict
+        "context" $ "configmap" .Values.ledger.configmap) | nindent 2 }}
+
+Inputs (dict):
+  context         (req)  root context ($) — reads global.observability
+  configmap       (req)  the component's `.configmap` map (override source)
+  enabledDefault  (opt)  legacy default for ENABLE_TELEMETRY (default "false")
+  endpointDefault (opt)  legacy default for the OTLP endpoint (default "midaz-grafana:4317")
+  deploymentEnvironmentDefault (opt)  legacy default for OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT
+                                      (default "production"); the shared env-wide value comes
+                                      from global.observability.deploymentEnvironment
+==============================================================================
+*/}}
+{{- define "lerian-common.otel.env" -}}
+ENABLE_TELEMETRY: {{ include "lerian-common.globalValue" (dict "context" .context "configmap" .configmap "block" "observability" "field" "enabled" "nativeKey" "ENABLE_TELEMETRY" "default" (.enabledDefault | default "false")) | quote }}
+OTEL_EXPORTER_OTLP_ENDPOINT: {{ include "lerian-common.globalValue" (dict "context" .context "configmap" .configmap "block" "observability" "field" "otlpEndpoint" "nativeKey" "OTEL_EXPORTER_OTLP_ENDPOINT" "default" (.endpointDefault | default "midaz-grafana:4317")) | quote }}
+OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ include "lerian-common.globalValue" (dict "context" .context "configmap" .configmap "block" "observability" "field" "deploymentEnvironment" "nativeKey" "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT" "default" (.deploymentEnvironmentDefault | default "production")) | quote }}
+{{- end -}}
+
+{{/*
+lerian-common.otel.podEnv — OTEL runtime env for the Deployment container.
+Points OTEL_EXPORTER_OTLP_ENDPOINT at the node-local collector via the downward
+HOST_IP. With podAttributes=true it also adds POD_IP + OTEL_RESOURCE_ATTRIBUTES.
+Caller gates on whether the collector is enabled and nindents (usually 10).
+
+Usage (in a component deployment.yaml, inside `env:`):
+  {{- if (index .Values "otel-collector-lerian").enabled }}
+  {{- include "lerian-common.otel.podEnv" (dict "port" 4317) | nindent 10 }}
+  {{- end }}
+
+Inputs (dict):
+  port          (opt)  OTLP port (default 4317)
+  podAttributes (opt)  bool — also emit POD_IP + OTEL_RESOURCE_ATTRIBUTES
+*/}}
+{{- define "lerian-common.otel.podEnv" -}}
+- name: "HOST_IP"
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+- name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+  value: "$(HOST_IP):{{ .port | default 4317 }}"
+{{- if .podAttributes }}
+- name: "POD_IP"
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: "OTEL_RESOURCE_ATTRIBUTES"
+  value: "k8s.pod.ip=$(POD_IP)"
+{{- end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_pdb.tpl
+++ b/charts/lerian-common/templates/_pdb.tpl
@@ -1,0 +1,79 @@
+{{/*
+==============================================================================
+lerian-common — PodDisruptionBudget (policy/v1).
+
+Present in ~39 charts, near-identical. Naming/labels/selector are passed ALREADY
+RENDERED by the chart's own helpers (byte-identical, no contract to unify); the
+caller owns the enable gate. Two spec styles are supported via `specStyle`:
+
+  "preferMax" (default, majority: fees/matcher/underwriter):
+      with .maxUnavailable -> maxUnavailable; else -> minAvailable (| default N)
+  "explicit" (tracer): emit minAvailable or maxUnavailable only when set
+      (they are mutually exclusive in policy/v1; setting both fails fast)
+
+annotations render via toYaml; since no chart sets PDB annotations today this is
+byte-identical to the range/quote style those charts used (empty -> nothing).
+
+Usage (chart pdb.yaml):
+  {{- if .Values.fees.pdb.enabled }}
+  {{- include "lerian-common.pdb" (dict
+        "pdb" .Values.fees.pdb
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+        "selector" (include "plugin-fees.selectorLabels" (dict "context" . "name" .Values.fees.name))
+        "minAvailableDefault" 0
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  pdb                 (req)  the component's `.pdb` map (minAvailable/maxUnavailable/annotations)
+  name                (req)  metadata.name (already rendered)
+  labels              (req)  labels block already rendered (no leading indent)
+  selector            (req)  selector labels block already rendered (no leading indent)
+  namespace           (opt)  metadata.namespace (already rendered); omitted when empty
+  minAvailableDefault (opt)  default for minAvailable in "preferMax" (default 1; some charts use 0)
+  specStyle           (opt)  "preferMax" (default) | "explicit"
+==============================================================================
+*/}}
+{{- define "lerian-common.pdb" -}}
+{{- $pdb := .pdb -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with $pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- /* hasKey (not truthiness) so an explicit 0 is honored, not treated as absent. */ -}}
+  {{- $miDefault := 1 -}}
+  {{- if hasKey . "minAvailableDefault" }}{{- $miDefault = .minAvailableDefault -}}{{- end }}
+  {{- if eq (.specStyle | default "preferMax") "explicit" }}
+  {{- if and (hasKey $pdb "minAvailable") (hasKey $pdb "maxUnavailable") }}
+  {{- fail "lerian-common.pdb: minAvailable and maxUnavailable are mutually exclusive (policy/v1) — set only one" }}
+  {{- end }}
+  {{- if hasKey $pdb "minAvailable" }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- end }}
+  {{- if hasKey $pdb "maxUnavailable" }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- end }}
+  {{- else }}
+  {{- if hasKey $pdb "maxUnavailable" }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else if hasKey $pdb "minAvailable" }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else }}
+  minAvailable: {{ $miDefault }}
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- .selector | nindent 6 }}
+{{- end -}}

--- a/charts/lerian-common/templates/_ratelimit.tpl
+++ b/charts/lerian-common/templates/_ratelimit.tpl
@@ -1,0 +1,38 @@
+{{/*
+==============================================================================
+lerian-common — Rate-limit env.
+
+Emits the shared three-tier rate-limit keys (Redis-backed) that every Lerian app
+exposes with the SAME contract. Productized surface: the operator sets clean
+`<product>.rateLimit.<field>` params; the raw `configmap.<KEY>` still works and
+OVERRIDES (backward-compatible). Defaults match the legacy template defaults, so
+existing installs render byte-identical.
+
+Usage (component configmap.yaml):
+  {{- include "lerian-common.rateLimit.env" (dict
+        "configmap" .Values.ledger.configmap
+        "params"    .Values.ledger.rateLimit) | nindent 2 }}
+
+Inputs (dict):
+  configmap  (req)  the component's `.configmap` map (native key — top precedence)
+  params     (opt)  the component's `.rateLimit` map (productized knobs)
+
+Precedence per key: native configmap.<KEY>  >  params.<field>  >  default.
+Reason strings ALLOW_RATELIMIT_DISABLED / ALLOW_RATELIMIT_FAIL_OPEN are productized
+too (params.allowDisabled / allowFailOpen; default "" = not set).
+==============================================================================
+*/}}
+{{- define "lerian-common.rateLimit.env" -}}
+{{- $cm := .configmap | default dict -}}
+{{- $rl := .params | default dict -}}
+RATE_LIMIT_ENABLED: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "RATE_LIMIT_ENABLED" "params" $rl "field" "enabled" "default" "true") | quote }}
+ALLOW_RATELIMIT_DISABLED: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "ALLOW_RATELIMIT_DISABLED" "params" $rl "field" "allowDisabled" "default" "") | quote }}
+ALLOW_RATELIMIT_FAIL_OPEN: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "ALLOW_RATELIMIT_FAIL_OPEN" "params" $rl "field" "allowFailOpen" "default" "") | quote }}
+RATE_LIMIT_MAX: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "RATE_LIMIT_MAX" "params" $rl "field" "max" "default" "500") | quote }}
+RATE_LIMIT_WINDOW_SEC: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "RATE_LIMIT_WINDOW_SEC" "params" $rl "field" "windowSec" "default" "60") | quote }}
+AGGRESSIVE_RATE_LIMIT_MAX: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "AGGRESSIVE_RATE_LIMIT_MAX" "params" $rl "field" "aggressiveMax" "default" "100") | quote }}
+AGGRESSIVE_RATE_LIMIT_WINDOW_SEC: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "AGGRESSIVE_RATE_LIMIT_WINDOW_SEC" "params" $rl "field" "aggressiveWindowSec" "default" "60") | quote }}
+RELAXED_RATE_LIMIT_MAX: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "RELAXED_RATE_LIMIT_MAX" "params" $rl "field" "relaxedMax" "default" "1000") | quote }}
+RELAXED_RATE_LIMIT_WINDOW_SEC: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "RELAXED_RATE_LIMIT_WINDOW_SEC" "params" $rl "field" "relaxedWindowSec" "default" "60") | quote }}
+RATE_LIMIT_REDIS_TIMEOUT_MS: {{ include "lerian-common.cfgValue" (dict "configmap" $cm "nativeKey" "RATE_LIMIT_REDIS_TIMEOUT_MS" "params" $rl "field" "redisTimeoutMs" "default" "500") | quote }}
+{{- end -}}

--- a/charts/lerian-common/templates/_rolesanywhere.tpl
+++ b/charts/lerian-common/templates/_rolesanywhere.tpl
@@ -1,0 +1,124 @@
+{{/*
+==============================================================================
+lerian-common — AWS IAM Roles Anywhere pod-spec fragments.
+
+The `aws-signing-helper` sidecar + IMDS env + iam-certs volume + fsGroup pod
+securityContext are BYTE-IDENTICAL across the inline implementations in
+fetcher (manager/worker), matcher and plugin-fees. These helpers reproduce
+those blocks exactly so callers can drop the copy-paste.
+
+Indentation contract (same convention as _deployment.tpl): each helper emits
+its keys at base indent 0; the caller supplies the real indent via `nindent`.
+Nested `toYaml … | nindent N` values use the SMALL N that, once the caller's
+outer nindent is added, lands on the original column.
+
+  sidecar             -> caller nindent 8 (container list item)
+  volume              -> caller nindent 6 (spec.volumes)
+  imdsEnv             -> caller nindent 10 or 12 (container env list)
+  podSecurityContext  -> caller nindent 6 (spec.securityContext); self-contained
+                         if/else, always call it (do NOT wrap in an if)
+
+The sidecar / volume / imdsEnv helpers are PURE (no guard): wrap the include in
+the caller with the standard guard so they render only when enabled:
+
+  {{- if and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled }}
+      {{- include "lerian-common.rolesAnywhere.sidecar" (dict "aws" .Values.aws) | nindent 8 }}
+  {{- end }}
+
+NOTE: excludes reporter, whose inline block intentionally differs (no `required`
+wrappers, extra runAsGroup, `$.`-prefixed context). Align reporter before reuse.
+*/}}
+
+{{/*
+lerian-common.rolesAnywhere.sidecar — the aws-signing-helper sidecar container.
+Input: (dict "aws" .Values.aws). Caller: nindent 8.
+*/}}
+{{- define "lerian-common.rolesAnywhere.sidecar" -}}
+{{- $ra := .aws.rolesAnywhere -}}
+- name: aws-signing-helper
+  image: "{{ $ra.sidecar.image.repository }}:{{ $ra.sidecar.image.tag }}"
+  imagePullPolicy: {{ $ra.sidecar.image.pullPolicy | default "IfNotPresent" }}
+  args:
+    - serve
+    - --certificate
+    - /certs/tls.crt
+    - --private-key
+    - /certs/tls.key
+    - --trust-anchor-arn
+    - "{{ required "aws.rolesAnywhere.trustAnchorArn is required when rolesAnywhere is enabled" $ra.trustAnchorArn }}"
+    - --profile-arn
+    - "{{ required "aws.rolesAnywhere.profileArn is required when rolesAnywhere is enabled" $ra.profileArn }}"
+    - --role-arn
+    - "{{ required "aws.rolesAnywhere.roleArn is required when rolesAnywhere is enabled" $ra.roleArn }}"
+    - --region
+    - "{{ $ra.region | default "us-east-2" }}"
+    - --session-duration
+    - "{{ $ra.sessionDuration | default 3600 }}"
+    - --port
+    - "{{ $ra.sidecar.port | default 9911 }}"
+  ports:
+    - name: imds
+      containerPort: {{ $ra.sidecar.port | default 9911 }}
+      protocol: TCP
+  volumeMounts:
+    - name: iam-certs
+      mountPath: /certs
+      readOnly: true
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  resources:
+    {{- toYaml $ra.sidecar.resources | nindent 4 }}
+{{- end -}}
+
+{{/*
+lerian-common.rolesAnywhere.volume — the iam-certs secret volume.
+Input: (dict "aws" .Values.aws "iamTlsDefault" "<chart>-iam-tls"). Caller: nindent 6.
+*/}}
+{{- define "lerian-common.rolesAnywhere.volume" -}}
+{{- $ra := .aws.rolesAnywhere -}}
+volumes:
+  - name: iam-certs
+    secret:
+      secretName: {{ $ra.certificateSecretName | default .iamTlsDefault }}
+      defaultMode: 0440
+      items:
+        - key: tls.crt
+          path: tls.crt
+        - key: tls.key
+          path: tls.key
+{{- end -}}
+
+{{/*
+lerian-common.rolesAnywhere.imdsEnv — env vars pointing the app at the sidecar IMDS.
+Input: (dict "aws" .Values.aws). Caller: nindent 10 or 12 (match the chart's env indent).
+*/}}
+{{- define "lerian-common.rolesAnywhere.imdsEnv" -}}
+{{- $ra := .aws.rolesAnywhere -}}
+- name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+  value: "http://127.0.0.1:{{ $ra.sidecar.port | default 9911 }}"
+- name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
+  value: "IPv4"
+{{- end -}}
+
+{{/*
+lerian-common.rolesAnywhere.podSecurityContext — pod securityContext: fsGroup when
+rolesAnywhere is on, else the chart's podSecurityContext. Self-contained if/else,
+always call it (do NOT wrap in an if).
+Input: (dict "aws" .Values.aws "podSecurityContext" .Values.<comp>.podSecurityContext).
+Caller: nindent 6.
+*/}}
+{{- define "lerian-common.rolesAnywhere.podSecurityContext" -}}
+{{- if and .aws .aws.rolesAnywhere .aws.rolesAnywhere.enabled -}}
+securityContext:
+  fsGroup: 65532
+{{- else -}}
+securityContext:
+  {{- toYaml .podSecurityContext | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_service.tpl
+++ b/charts/lerian-common/templates/_service.tpl
@@ -1,0 +1,51 @@
+{{/*
+==============================================================================
+lerian-common — Service (ClusterIP, single http port).
+
+Near-identical across charts: a single `http` port with targetPort http. Naming,
+labels and selector are passed ALREADY RENDERED by the chart's own helpers, so
+the output is byte-identical and no naming/label contract must be unified. The
+caller owns the enable gate. `namespace` and `annotations` are emitted only when
+provided (some charts include them, some don't).
+
+Usage (chart service.yaml):
+  {{- include "lerian-common.service" (dict
+        "service" .Values.fees.service
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+        "selector" (include "plugin-fees.selectorLabels" (dict "context" . "name" .Values.fees.name))
+      ) }}
+
+Inputs (dict):
+  service   (req)  the component's `.service` map (type, port, optional annotations)
+  name      (req)  metadata.name (already rendered)
+  labels    (req)  labels block already rendered (no leading indent)
+  selector  (req)  selector labels block already rendered (no leading indent)
+  namespace (opt)  metadata.namespace (already rendered); line omitted when empty
+==============================================================================
+*/}}
+{{- define "lerian-common.service" -}}
+{{- $svc := .service -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with $svc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $svc.type }}
+  ports:
+    - port: {{ $svc.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- .selector | nindent 4 }}
+{{- end -}}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -1,0 +1,79 @@
+{{/*
+==============================================================================
+lerian-common — Service Discovery env (lib-service-discovery contract).
+
+Emits the SD_* env block into a ConfigMap `data` map, gated on `enabled`.
+Per-service endpoints are derived from the chart's own primitives; the env-wide
+constants are inherited from `global.serviceDiscovery` (set once per environment
+in GitOps). The contract is identical for every app, so this lives here once.
+
+The design goal is that an app enables discovery with ONLY `SD_ENABLED: "true"`
+in its component `extraEnvVars`; everything else is derived here.
+
+Usage (in a component configmap.yaml, emitted BEFORE the extraEnvVars
+passthrough so an operator can still override any single SD_* key):
+
+  {{- $cv := .Values.identity -}}
+  {{- include "lerian-common.serviceDiscovery.env" (dict
+        "context"     $
+        "enabled"     (eq (toString (dig "SD_ENABLED" "false" ($cv.extraEnvVars | default dict))) "true")
+        "name"        $cv.name
+        "port"        $cv.service.port
+        "namespace"   (include "global.namespace" $)
+        "ingressHost" (include "lerian-common.firstIngressHost" (dict "ingress" $cv.ingress))
+      ) | nindent 2 }}
+
+Inputs (dict):
+  context     (req)  root context ($) — used to read global.serviceDiscovery
+  enabled     (req)  bool — whether to emit the block at all
+  name        (req)  internal service DNS name (SD_INTERNAL_ADDRESS host)
+  port        (req)  internal service port
+  namespace   (req)  resolved namespace string
+  ingressHost (opt)  external host; when non-empty, emits SD_EXTERNAL_*
+                     (omit for consumer-only / internal-only instances)
+
+global.serviceDiscovery (all optional except address when enabled):
+  address, tls, tlsSkipVerify, workload, preferView, internalScheme, externalPort
+==============================================================================
+*/}}
+{{- define "lerian-common.serviceDiscovery.env" -}}
+{{- $sd := (.context.Values.global | default dict).serviceDiscovery | default dict -}}
+{{- /*
+  Derive ONLY when enabled AND global.serviceDiscovery.address is configured.
+  This keeps adoption backward-compatible: a chart carrying this helper but
+  deployed against a not-yet-migrated environment (SD_* still hand-set in
+  extraEnvVars, no global.serviceDiscovery) stays INERT — extraEnvVars drives
+  SD exactly as before, no duplicate keys, no render break. The environment
+  opts into derivation by setting global.serviceDiscovery + stripping the
+  per-app SD_* block down to just SD_ENABLED.
+*/ -}}
+{{- if and .enabled $sd.address -}}
+{{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
+   rendered by the component's own extraEnvVars passthrough. Emitting it again
+   would produce a duplicate key. This helper only adds the derived siblings. */ -}}
+SD_ADDRESS: {{ $sd.address | quote }}
+SD_TLS: {{ $sd.tls | default false | quote }}
+SD_TLS_SKIP_VERIFY: {{ $sd.tlsSkipVerify | default false | quote }}
+SD_WORKLOAD: {{ $sd.workload | default "" | quote }}
+SD_PREFER_VIEW: {{ $sd.preferView | default "external" | quote }}
+SD_INTERNAL_ADDRESS: {{ include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace) | quote }}
+SD_INTERNAL_PORT: {{ .port | quote }}
+SD_INTERNAL_SCHEME: {{ $sd.internalScheme | default "http" | quote }}
+{{- if .ingressHost }}
+SD_EXTERNAL_ADDRESS: {{ printf "https://%s" .ingressHost | quote }}
+SD_EXTERNAL_PORT: {{ $sd.externalPort | default 443 | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+lerian-common.firstIngressHost — the first ingress host, or "" when ingress is
+disabled/absent. Keeps the SD wiring a one-liner and consistent across charts.
+Inputs: ingress (the component's `.ingress` map).
+*/}}
+{{- define "lerian-common.firstIngressHost" -}}
+{{- $ing := .ingress | default dict -}}
+{{- if and $ing.enabled $ing.hosts -}}
+{{- (first $ing.hosts).host | default "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_serviceaccount.tpl
+++ b/charts/lerian-common/templates/_serviceaccount.tpl
@@ -1,0 +1,40 @@
+{{/*
+==============================================================================
+lerian-common — ServiceAccount.
+
+Identical across charts modulo naming/labels and the presence of a `namespace:`
+line. Naming and labels are passed ALREADY RENDERED by the chart's own helpers,
+so the output is byte-identical without unifying any contract. The caller owns
+the create/enable gate. `namespace` and `annotations` are emitted only when set.
+
+Usage (chart serviceaccount.yaml):
+  {{- if .Values.fees.serviceAccount.create -}}
+  {{- include "lerian-common.serviceAccount" (dict
+        "serviceAccount" .Values.fees.serviceAccount
+        "name" (include "plugin-fees.fullname" .)
+        "labels" (include "plugin-fees.labels" (dict "context" . "name" .Values.fees.name))
+      ) }}
+  {{- end }}
+
+Inputs (dict):
+  serviceAccount (req)  the component's `.serviceAccount` map (optional annotations)
+  name           (req)  metadata.name (already rendered)
+  labels         (req)  labels block already rendered (no leading indent)
+  namespace      (opt)  metadata.namespace (already rendered); line omitted when empty
+==============================================================================
+*/}}
+{{- define "lerian-common.serviceAccount" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
+  labels:
+    {{- .labels | nindent 4 }}
+  {{- with .serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/lerian-common/templates/_streaming.tpl
+++ b/charts/lerian-common/templates/_streaming.tpl
@@ -1,0 +1,112 @@
+{{/*
+==============================================================================
+lerian-common — Streaming env (lib-streaming / RedPanda contract).
+
+Streaming is becoming standard across all Lerian charts. This helper emits the
+env-wide streaming CONSTANTS (broker + SASL/TLS transport) into a ConfigMap
+`data` map from `global.streaming`, set once per environment. Per-app IDENTITY
+(STREAMING_CLIENT_ID, STREAMING_CLOUDEVENTS_SOURCE) stays in each component
+(extraEnvVars), same split as OTEL service identity. The SECRETS
+(STREAMING_SASL_PASSWORD, STREAMING_TLS_CA_CERT) are emitted into the chart's own
+Secret by the companion `lerian-common.streaming.secret` helper below (values are
+per-component; never in the ConfigMap).
+
+Like serviceDiscovery.env:
+  - it does NOT emit STREAMING_ENABLED (that is the app's knob, rendered by the
+    component's own extraEnvVars passthrough — emitting it here would duplicate);
+  - it is backward-compatible: derives ONLY when enabled AND
+    global.streaming.brokers is set, otherwise stays INERT so a not-yet-migrated
+    environment (STREAMING_* still hand-set in extraEnvVars) renders unchanged.
+
+Usage (in a component configmap.yaml, BEFORE the extraEnvVars passthrough):
+
+  {{- $cv := .Values.ledger -}}
+  {{- include "lerian-common.streaming.env" (dict
+        "context" $
+        "enabled" (eq (toString (dig "STREAMING_ENABLED" "false" ($cv.extraEnvVars | default dict))) "true")
+      ) | nindent 2 }}
+
+Inputs (dict):
+  context           (req)  root context ($) — reads global.streaming
+  enabled           (req)  bool — whether to emit the constants
+  clientId          (opt)  STREAMING_CLIENT_ID — emitted only when provided
+  cloudeventsSource (opt)  STREAMING_CLOUDEVENTS_SOURCE — emitted only when provided
+
+global.streaming (all optional except brokers, which gates emission):
+  brokers, tlsEnabled, saslMechanism, saslUsername
+==============================================================================
+*/}}
+{{- define "lerian-common.streaming.env" -}}
+{{- $s := (.context.Values.global | default dict).streaming | default dict -}}
+{{- if and .enabled $s.brokers -}}
+STREAMING_BROKERS: {{ $s.brokers | quote }}
+STREAMING_TLS_ENABLED: {{ $s.tlsEnabled | default false | quote }}
+STREAMING_SASL_MECHANISM: {{ $s.saslMechanism | default "" | quote }}
+STREAMING_SASL_USERNAME: {{ $s.saslUsername | default "" | quote }}
+{{- if hasKey . "clientId" }}
+STREAMING_CLIENT_ID: {{ .clientId | quote }}
+{{- end }}
+{{- if hasKey . "cloudeventsSource" }}
+STREAMING_CLOUDEVENTS_SOURCE: {{ .cloudeventsSource | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+------------------------------------------------------------------------------
+lerian-common.streaming.secret — the uniform streaming Secret keys.
+
+Companion to streaming.env: the .env helper emits the non-secret constants into
+the ConfigMap; this one emits the SECRET keys into the chart's own Secret. Key
+names are uniform across all charts (only the value differs per environment).
+
+Emits nothing (and never fails) unless BOTH: the feature is enabled AND the chart
+is not using an external Secret — the value lives outside the chart when
+useExistingSecret=true, so requiring it inline is wrong. When active:
+STREAMING_SASL_PASSWORD is required only when a SASL mechanism is configured (auth
+in use) — i.e. enabled AND saslMechanism; STREAMING_TLS_CA_CERT is always optional.
+For a required-but-empty key it fails with an actionable message (Bitnami-style),
+on install AND upgrade (these values are operator/Vault-provided, never generated).
+
+`mode` matches the chart's Secret form: "data" (b64enc) | "stringData". Output is
+`KEY: value` lines with no leading/trailing newline; the caller nindents under the
+matching `data:`/`stringData:` key:
+
+  # STREAMING SECRETS
+  {{- with (include "lerian-common.streaming.secret" (dict
+        "context" . "secrets" .Values.ledger.secrets
+        "secretName" (include "midaz.ledger.fullname" .)
+        "valuesPrefix" "ledger.secrets." "mode" "data"
+        "enabled" true "useExistingSecret" .Values.ledger.useExistingSecret
+        "saslMechanism" (dig "streaming" "saslMechanism" "" (.Values.global | default dict)))) }}
+  {{- . | nindent 2 }}
+  {{- end }}
+
+Inputs: context, secrets, secretName, valuesPrefix, mode,
+        enabled (bool — STREAMING_ENABLED),
+        useExistingSecret (bool — skip entirely when true),
+        saslMechanism (string — when non-empty, SASL_PASSWORD becomes required).
+------------------------------------------------------------------------------
+*/}}
+{{- define "lerian-common.streaming.secret" -}}
+{{- if and .enabled (not .useExistingSecret) -}}
+{{- $s := .secrets | default dict -}}
+{{- $b64 := eq (.mode | default "stringData") "data" -}}
+{{- $ns := .context.Release.Namespace -}}
+{{- $lines := list -}}
+{{- /* STREAMING_SASL_PASSWORD — required only when a SASL mechanism is set */ -}}
+{{- $sasl := index $s "STREAMING_SASL_PASSWORD" -}}
+{{- if and .saslMechanism (not $sasl) -}}
+{{- fail (printf "\n[lerian-common] Secret value required but empty: STREAMING_SASL_PASSWORD\n  set:     --set %sSTREAMING_SASL_PASSWORD=<value>   (or configure an existingSecret)\n  recover: kubectl get secret %s -n %s -o jsonpath=\"{.data.STREAMING_SASL_PASSWORD}\" | base64 -d\n" .valuesPrefix .secretName $ns) -}}
+{{- end -}}
+{{- if $sasl -}}
+{{- $lines = append $lines (printf "STREAMING_SASL_PASSWORD: %s" (ternary ($sasl | b64enc | quote) ($sasl | quote) $b64)) -}}
+{{- end -}}
+{{- /* STREAMING_TLS_CA_CERT — optional */ -}}
+{{- $ca := index $s "STREAMING_TLS_CA_CERT" -}}
+{{- if $ca -}}
+{{- $lines = append $lines (printf "STREAMING_TLS_CA_CERT: %s" (ternary ($ca | b64enc | quote) ($ca | quote) $b64)) -}}
+{{- end -}}
+{{- join "\n" $lines -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lerian-common/values.yaml
+++ b/charts/lerian-common/values.yaml
@@ -1,0 +1,41 @@
+# lerian-common is a LIBRARY chart: it renders nothing on its own and has no
+# values of its own. This file DOCUMENTS the shared `global.*` contract the
+# helpers read — the STANDARD template every environment fills in ONCE (at the
+# umbrella/GitOps layer). These are environment-specific (BYOC) and MUST NOT be
+# hardcoded in any product chart.
+#
+# All three domains follow the same pattern: env-wide infra constants live under
+# `global.*`, the per-app enable knob stays in the component `extraEnvVars`
+# (`SD_ENABLED` / `STREAMING_ENABLED`) or `configmap` (`MULTI_TENANT_ENABLED`),
+# and a component's own value overrides the global default. Every helper is
+# backward-compatible: with the `global.*` block absent it stays inert and the
+# component's existing values drive the output unchanged.
+
+global: {}
+  # -- Service Discovery (lib-service-discovery). Set once per environment.
+  # serviceDiscovery:
+  #   address: ""            # REQUIRED when SD_ENABLED=true (e.g. consul.<env>:443). No default.
+  #   tls: false             # SD_TLS
+  #   tlsSkipVerify: false   # SD_TLS_SKIP_VERIFY
+  #   workload: ""           # SD_WORKLOAD — per-env isolation key (provider+consumer must match)
+  #   preferView: external   # SD_PREFER_VIEW — internal|external (lib default: external)
+  #   internalScheme: http   # SD_INTERNAL_SCHEME
+  #   externalPort: 443      # SD_EXTERNAL_PORT (emitted only when a component has an ingress host)
+  #
+  # -- Streaming (lib-streaming / RedPanda). Set once per environment.
+  # streaming:
+  #   brokers: ""            # REQUIRED when STREAMING_ENABLED=true (e.g. redpanda.<env>:9092)
+  #   tlsEnabled: false      # STREAMING_TLS_ENABLED
+  #   saslMechanism: ""      # STREAMING_SASL_MECHANISM (e.g. SCRAM-SHA-256)
+  #   saslUsername: ""       # STREAMING_SASL_USERNAME
+  #   # NOTE: STREAMING_SASL_PASSWORD / STREAMING_TLS_CA_CERT are secrets — set them
+  #   # per component under `.secrets`, never here (they render into the Secret).
+  #
+  # -- Multi-tenant (lib-commons/multitenancy). The tenant-manager URL and its
+  #    Redis are environment infra, so they belong here too; a component's
+  #    configmap.MULTI_TENANT_* overrides these.
+  # multiTenant:
+  #   url: ""                # MULTI_TENANT_URL — tenant-manager base URL
+  #   redisHost: ""          # MULTI_TENANT_REDIS_HOST
+  #   redisPort: "6379"      # MULTI_TENANT_REDIS_PORT
+  #   redisTls: "false"      # MULTI_TENANT_REDIS_TLS


### PR DESCRIPTION
feat(common): add lerian-common library chart

New shared Helm library chart (type: library) consumed by productized charts.
Also brings the validate-helm-charts update + baseline that teach the chart-standard
gate about library charts (render-gate skips them; strict allows type: library).
Segregated from develop as its own PR to main.