### PR TITLE
feat(plugin-br-pix-indirect-btg): add SWAGGER_ENABLED config key

### DIFF
--- a/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/configmap.yaml
@@ -78,6 +78,7 @@ data:
   MONGO_TLS: {{ .Values.pix.configmap.MONGO_TLS | default "false" | quote }}
 
   # SWAGGER
+  SWAGGER_ENABLED: {{ .Values.pix.configmap.SWAGGER_ENABLED | default "true" | quote }}
   SWAGGER_TITLE: {{ .Values.pix.configmap.SWAGGER_TITLE | default "Plugin BR Pix Indirect BTG" | quote }}
   SWAGGER_DESCRIPTION: {{ .Values.pix.configmap.SWAGGER_DESCRIPTION | default "Documentation Plugin PIX BTG" | quote }}
   SWAGGER_VERSION: {{ .Values.pix.image.tag | default .Chart.AppVersion | quote }}


### PR DESCRIPTION
feat(plugin-br-pix-indirect-btg): add SWAGGER_ENABLED config key

Segregated from develop as its own PR to main (chart change only; Chart.yaml
version left to the release pipeline; docs/CHANGELOG handled separately).