### PR TITLE
feat(plugin-access-manager): add auth-backend initDataFile + ALLOW_INSECURE_TLS

### DIFF
--- a/charts/plugin-access-manager/templates/auth-backend/configmap.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/configmap.yaml
@@ -20,3 +20,13 @@ data:
   quota: '{"organization": -1, "user": -1, "application": -1, "provider": -1}'
   logConfig: '{"filename": "logs/casdoor.log", "maxdays": 99999, "perm": "0770"}'
   initDataFile: {{ .Values.auth.backend.initDataFile | default "./init_data.json" | quote }}
+  # Allows the backend's outbox Postgres client to connect without a valid
+  # certificate. Same default and rationale as auth.configmap.ALLOW_INSECURE_TLS
+  # and identity.configmap.ALLOW_INSECURE_TLS. Casdoor ignores this key; only
+  # caradhras' outbox client reads it, and it fails closed without it.
+  ALLOW_INSECURE_TLS: {{ .Values.auth.backend.allowInsecureTLS | default "true" | quote }}
+
+  # Extra Env Vars
+  {{- with .Values.auth.backend.extraEnvVars }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/plugin-access-manager/templates/auth-backend/migrations.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/migrations.yaml
@@ -68,4 +68,36 @@ spec:
                 configMapKeyRef:
                   name: {{ include "plugin-auth.fullname" . }}
                   key: DB_SSLMODE
+            # POSTGRES_* mirrors of the DB_* vars above, mapped from the same
+            # ConfigMap/Secret keys. The caradhras migration runner
+            # (cmd/postgres-migrations) reads POSTGRES_HOST/PORT/USER/PASSWORD/DB/SSLMODE
+            # instead of Casdoor's DB_* contract; keeping both sets lets this single
+            # Job template run either migrations image via auth.backend.migrations.image,
+            # with no functional effect on casdoor-migrations (which ignores POSTGRES_*).
+            - name: POSTGRES_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_PORT
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_NAME
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_USER
+            {{- include "plugin-auth.dbPasswordEnv" (dict "context" $ "envName" "POSTGRES_PASSWORD") | nindent 12 }}
+            - name: POSTGRES_SSLMODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "plugin-auth.fullname" . }}
+                  key: DB_SSLMODE
       restartPolicy: OnFailure


### PR DESCRIPTION
feat(plugin-access-manager): add auth-backend initDataFile + ALLOW_INSECURE_TLS

Segregated from develop as its own PR to main (chart change only; Chart.yaml
version left to the release pipeline; docs/CHANGELOG handled separately).