### PR TITLE
chore(pipe): register new charts in CI meta + add Lender to README

### DIFF
--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -57,3 +57,11 @@ pipe:
 doc:
   - changed-files:
       - any-glob-to-any-file: README.md
+
+br-ccs:
+  - changed-files:
+      - any-glob-to-any-file: charts/br-ccs/**
+
+br-slc:
+  - changed-files:
+      - any-glob-to-any-file: charts/br-slc/**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,9 @@
 - [ ] Pipeline
 - [ ] Documentation
 - [ ] Fetcher
+- [ ] BR STA
+- [ ] BR CCS
+- [ ] BR SLC
 
 ## Checklist
 Please check each item after it's completed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,15 +23,22 @@
 ## Checklist
 Please check each item after it's completed.
 
-- [ ] I have tested these changes locally.
+- [ ] I have tested these changes locally (or cut an **Alpha Release** from my branch — see below).
 - [ ] I have updated the documentation accordingly.
 - [ ] I have added necessary comments to the code, especially in complex areas.
 - [ ] I have ensured that my changes adhere to the project's coding standards.
 - [ ] I have checked for any potential security issues.
 - [ ] I have ensured that all tests pass.
-- [ ] I have updated the version appropriately (if applicable).
+- [ ] This PR modifies **only one chart** (or is a single shared `pipe`/`doc` change).
+- [ ] I did **not** hand-edit `Chart.yaml` `version`, `CHANGELOG.md`, or the README version matrix (CI owns these).
 - [ ] I have confirmed this code is ready for review.
 
 ## Additional Notes
 [//]: # (Add any additional notes, context, or explanation that could be helpful for reviewers.)
-## Obs: Please, always remember to target your PR to develop branch instead of main.
+
+## Contribution rules (trunk-based)
+
+- 🎯 **Target `main`.** The `develop` branch is retired — do **not** target it.
+- 📦 **One chart per PR**, on a `feat/<chart>` branch. A change that touches N charts = N PRs. Shared meta (`.github/**`, root `README.md`) is its own `pipe`/`doc` PR.
+- 🧪 **Test before merge with an Alpha Release.** Actions → **Helm Alpha Release** → *Run workflow* against **your branch** → set `chart`. Publishes a disposable `ghcr.io/lerianstudio/alpha/<chart>` (TTL ~3 days). Works even for a chart that only exists on your branch.
+- 🏷️ **Version, CHANGELOG and README matrix are CI-owned.** semantic-release bumps them on merge based on your commit type (`feat`→minor, `fix`→patch, breaking→major). Never hand-bump.

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -24,6 +24,7 @@ jobs:
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
+        charts/br-sta
         charts/fetcher
         charts/lerian-notification
         charts/midaz

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -50,7 +50,11 @@ jobs:
             doc
             product-console
             fetcher
+            lender
             tracer
+            br-sta
+            br-ccs
+            br-slc
             new
             charts
             common

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ For implementation and configuration details, see the [README](https://charts.le
 | `3.1.0` | 3.0.2 | 3.0.2 |
 -----------------
 
+### Lender
+
+For more details, check out the [official documentation](https://docs.lerian.studio/en/lender).
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/lender).
+
+#### Application Version Mapping
+
+| Chart Version | Lender Version |
+| :---: | :---: |
+| `1.0.0-beta.1` | 1.0.0-beta.48 |
+-----------------
+
 ### Tracer
 
 For more details, check out the [official documentation](https://docs.lerian.studio/en/tracer).


### PR DESCRIPTION
chore(pipe): register new charts in CI meta + add Lender to README

Shared-meta counterpart of the per-chart segregation PRs (#1707-#1720):
- pr-title.yml: allow scopes br-ccs, br-slc, br-sta, lender
- labeler.yaml: label rules for br-ccs, br-slc
- pull_request_template.md: BR STA / BR CCS / BR SLC checklist items
- gptchangelog.yml: include charts/br-sta
- README.md: add the Lender section (version tables left untouched — those are
  release-pipeline managed; only the new-chart section is added here)

Kept out of the per-chart PRs to avoid cross-PR conflicts on shared files.