### PR TITLE
feat(midaz): add PreSync migration Jobs for ledger and tracer

### DIFF
--- a/charts/midaz/templates/_helpers.tpl
+++ b/charts/midaz/templates/_helpers.tpl
@@ -126,6 +126,27 @@ Fail loud at render time so the operator fixes the configuration.
 {{- end }}
 
 {{/*
+Migration Job security contexts.
+Distroless nonroot images run as UID/GID 65532 (same as the app images).
+Used by the decoupled ledger/tracer migration PreSync Jobs.
+*/}}
+{{- define "midaz.migrations.securityContext.pod" -}}
+runAsNonRoot: true
+runAsUser: 65532
+runAsGroup: 65532
+seccompProfile:
+  type: RuntimeDefault
+{{- end }}
+
+{{- define "midaz.migrations.securityContext.container" -}}
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: true
+capabilities:
+  drop:
+    - ALL
+{{- end }}
+
+{{/*
 Create a default fully qualified app name for CRM.
 */}}
 {{- define "midaz-crm.fullname" -}}

--- a/charts/midaz/templates/ledger/deployment.yaml
+++ b/charts/midaz/templates/ledger/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "midaz-ledger.fullname" . }}
   labels:
     {{- include "midaz.labels" (dict "context" . "component" .Values.ledger.name "name" .Values.ledger.name ) | nindent 4 }}
+  annotations:
+    # Deploy the app after the migration Job (wave 1) has completed.
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   revisionHistoryLimit: {{ .Values.ledger.revisionHistoryLimit | default 10 }}
   strategy:

--- a/charts/midaz/templates/ledger/migrations-job.yaml
+++ b/charts/midaz/templates/ledger/migrations-job.yaml
@@ -11,9 +11,9 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  backoffLimit: {{ .Values.ledger.migrations.backoffLimit | default 3 }}
+  backoffLimit: {{ .Values.ledger.migrations.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.ledger.migrations.activeDeadlineSeconds | default 600 }}
-  ttlSecondsAfterFinished: {{ .Values.ledger.migrations.ttlSecondsAfterFinished | default 300 }}
+  ttlSecondsAfterFinished: {{ .Values.ledger.migrations.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/charts/midaz/templates/ledger/migrations-job.yaml
+++ b/charts/midaz/templates/ledger/migrations-job.yaml
@@ -9,7 +9,7 @@ metadata:
     # Run the schema migrations before the app Deployment on every sync.
     # Use a sync-wave (not a PreSync hook) so the Job runs in the normal sync
     # phase after Secrets/ConfigMaps (wave 0) and before the app Deployment.
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   backoffLimit: {{ .Values.ledger.migrations.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.ledger.migrations.activeDeadlineSeconds | default 600 }}

--- a/charts/midaz/templates/ledger/migrations-job.yaml
+++ b/charts/midaz/templates/ledger/migrations-job.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.ledger.enabled .Values.ledger.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "midaz-ledger.fullname" . }}-migrate
+  labels:
+    {{- include "midaz.labels" (dict "context" . "component" "ledger-migrations" "name" .Values.ledger.name) | nindent 4 }}
+  annotations:
+    # Run the schema migrations before the app Deployment on every sync.
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: {{ .Values.ledger.migrations.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.ledger.migrations.activeDeadlineSeconds | default 600 }}
+  ttlSecondsAfterFinished: {{ .Values.ledger.migrations.ttlSecondsAfterFinished | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "midaz.selectorLabels" (dict "context" . "component" "ledger-migrations" "name" .Values.ledger.name) | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      {{- with .Values.ledger.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- include "midaz.migrations.securityContext.pod" . | nindent 8 }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.ledger.migrations.image.repository }}:{{ .Values.ledger.migrations.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.ledger.migrations.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            {{- include "midaz.migrations.securityContext.container" . | nindent 12 }}
+          # Reuse the same DB configuration the ledger Deployment consumes:
+          # DB_ONBOARDING_* / DB_TRANSACTION_* (host, port, name, user, sslmode)
+          # come from the ledger ConfigMap; passwords are injected below.
+          envFrom:
+          - secretRef:
+              name: {{ if .Values.ledger.useExistingSecret }}{{ .Values.ledger.existingSecretName }}{{ else }}{{ include "midaz-ledger.fullname" . }}{{ end }}
+          - configMapRef:
+              name: {{ include "midaz-ledger.fullname" . }}
+          env:
+            {{/* PostgreSQL: single role `midaz` backs both onboarding and transaction;
+                 both module passwords map to Bitnami key `password`. Mirrors the ledger Deployment. */}}
+            {{- $pg := .Values.postgresql | default dict }}
+            {{- $pgAuth := $pg.auth | default dict }}
+            {{- if or (and (ne (toString $pg.enabled) "false") (not $pg.external)) $pgAuth.existingSecret }}
+            {{- include "midaz.infraSecretRef" (dict "context" $ "subchart" "postgresql" "key" "password" "envName" "DB_ONBOARDING_PASSWORD") | nindent 12 }}
+            {{- include "midaz.infraSecretRef" (dict "context" $ "subchart" "postgresql" "key" "password" "envName" "DB_TRANSACTION_PASSWORD") | nindent 12 }}
+            {{- else }}
+            {{- $secretName := ternary .Values.ledger.existingSecretName (include "midaz-ledger.fullname" .) .Values.ledger.useExistingSecret }}
+            {{- if .Values.ledger.secrets.DB_ONBOARDING_PASSWORD }}
+            - name: DB_ONBOARDING_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: DB_ONBOARDING_PASSWORD
+            {{- end }}
+            {{- if .Values.ledger.secrets.DB_TRANSACTION_PASSWORD }}
+            - name: DB_TRANSACTION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: DB_TRANSACTION_PASSWORD
+            {{- end }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.ledger.migrations.resources | nindent 12 }}
+      {{- with .Values.ledger.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ledger.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ledger.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/midaz/templates/ledger/migrations-job.yaml
+++ b/charts/midaz/templates/ledger/migrations-job.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "midaz.labels" (dict "context" . "component" "ledger-migrations" "name" .Values.ledger.name) | nindent 4 }}
   annotations:
     # Run the schema migrations before the app Deployment on every sync.
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    # Use a sync-wave (not a PreSync hook) so the Job runs in the normal sync
+    # phase after Secrets/ConfigMaps (wave 0) and before the app Deployment.
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   backoffLimit: {{ .Values.ledger.migrations.backoffLimit }}

--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -122,6 +122,36 @@ ledger:
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
     tag: "3.8.0"
+  # -- Decoupled schema migrations Job (ArgoCD PreSync hook).
+  #    Runs the midaz-ledger-migrations image before the app rollout to apply
+  #    the onboarding + transaction DB migrations. DB connection settings are
+  #    reused from ledger.configmap / ledger.secrets (same envFrom sources as
+  #    the ledger Deployment), so no extra DB config is required here.
+  migrations:
+    # -- Enable or disable the ledger migrations PreSync Job
+    enabled: true
+    image:
+      # -- Repository for the ledger migrations image
+      repository: ghcr.io/lerianstudio/midaz-ledger-migrations
+      # -- Image tag (populated by the release pipeline via gitops_yaml_key_mappings;
+      #    falls back to .Chart.AppVersion when empty)
+      tag: ""
+      # -- Image pull policy
+      pullPolicy: IfNotPresent
+    # -- Job backoffLimit (retries before the migration is marked failed)
+    backoffLimit: 3
+    # -- Hard time limit for the migration Job
+    activeDeadlineSeconds: 600
+    # -- Retain the finished Job for this many seconds before cleanup
+    ttlSecondsAfterFinished: 300
+    # -- Resource requests/limits for the migration Job
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 128Mi
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
   # -- Overrides the default generated name by Helm

--- a/charts/tracer/templates/_helpers.tpl
+++ b/charts/tracer/templates/_helpers.tpl
@@ -73,3 +73,24 @@ Allows overriding it for multi-namespace deployments in combined charts.
 {{- define "global.namespace" -}}
 {{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end }}
+
+{{/*
+Migration Job security contexts.
+Distroless nonroot images run as UID/GID 65532 (same as the app images).
+Used by the decoupled tracer migration PreSync Job.
+*/}}
+{{- define "tracer.migrations.securityContext.pod" -}}
+runAsNonRoot: true
+runAsUser: 65532
+runAsGroup: 65532
+seccompProfile:
+  type: RuntimeDefault
+{{- end }}
+
+{{- define "tracer.migrations.securityContext.container" -}}
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: true
+capabilities:
+  drop:
+    - ALL
+{{- end }}

--- a/charts/tracer/templates/deployment.yaml
+++ b/charts/tracer/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "global.namespace" . }}
   labels:
     {{- include "tracer.labels" (dict "context" . "component" .Values.tracer.name "name" .Values.tracer.name) | nindent 4 }}
+  annotations:
+    # Deploy the app after the migration Job (wave 1) has completed.
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   revisionHistoryLimit: {{ .Values.tracer.revisionHistoryLimit | default 10 }}
   strategy:

--- a/charts/tracer/templates/migrations-job.yaml
+++ b/charts/tracer/templates/migrations-job.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- include "tracer.labels" (dict "context" . "component" "tracer-migrations" "name" .Values.tracer.name) | nindent 4 }}
   annotations:
     # Run the schema migrations before the app Deployment on every sync.
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    # Use a sync-wave (not a PreSync hook) so the Job runs in the normal sync
+    # phase after Secrets/ConfigMaps (wave 0) and before the app Deployment.
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   backoffLimit: {{ .Values.tracer.migrations.backoffLimit }}

--- a/charts/tracer/templates/migrations-job.yaml
+++ b/charts/tracer/templates/migrations-job.yaml
@@ -12,9 +12,9 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  backoffLimit: {{ .Values.tracer.migrations.backoffLimit | default 3 }}
+  backoffLimit: {{ .Values.tracer.migrations.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.tracer.migrations.activeDeadlineSeconds | default 300 }}
-  ttlSecondsAfterFinished: {{ .Values.tracer.migrations.ttlSecondsAfterFinished | default 300 }}
+  ttlSecondsAfterFinished: {{ .Values.tracer.migrations.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/charts/tracer/templates/migrations-job.yaml
+++ b/charts/tracer/templates/migrations-job.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.tracer.enabled .Values.tracer.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "tracer.fullname" . }}-migrate
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    {{- include "tracer.labels" (dict "context" . "component" "tracer-migrations" "name" .Values.tracer.name) | nindent 4 }}
+  annotations:
+    # Run the schema migrations before the app Deployment on every sync.
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: {{ .Values.tracer.migrations.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.tracer.migrations.activeDeadlineSeconds | default 300 }}
+  ttlSecondsAfterFinished: {{ .Values.tracer.migrations.ttlSecondsAfterFinished | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tracer.selectorLabels" (dict "context" . "name" .Values.tracer.name) | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      {{- with .Values.tracer.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- include "tracer.migrations.securityContext.pod" . | nindent 8 }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.tracer.migrations.image.repository }}:{{ .Values.tracer.migrations.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.tracer.migrations.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            {{- include "tracer.migrations.securityContext.container" . | nindent 12 }}
+          # Reuse the same DB configuration the tracer Deployment consumes:
+          # DB_HOST / DB_PORT / DB_NAME / DB_USER / DB_SSL_MODE come from the
+          # tracer ConfigMap and DB_PASSWORD from the tracer Secret.
+          envFrom:
+          - secretRef:
+              name: {{ if .Values.tracer.useExistingSecret }}{{ .Values.tracer.existingSecretName }}{{ else }}{{ include "tracer.fullname" . }}{{ end }}
+          - configMapRef:
+              name: {{ include "tracer.fullname" . }}
+          resources:
+            {{- toYaml .Values.tracer.migrations.resources | nindent 12 }}
+      {{- with .Values.tracer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tracer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tracer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/tracer/templates/migrations-job.yaml
+++ b/charts/tracer/templates/migrations-job.yaml
@@ -10,7 +10,7 @@ metadata:
     # Run the schema migrations before the app Deployment on every sync.
     # Use a sync-wave (not a PreSync hook) so the Job runs in the normal sync
     # phase after Secrets/ConfigMaps (wave 0) and before the app Deployment.
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   backoffLimit: {{ .Values.tracer.migrations.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.tracer.migrations.activeDeadlineSeconds | default 300 }}

--- a/charts/tracer/values.yaml
+++ b/charts/tracer/values.yaml
@@ -61,6 +61,37 @@ tracer:
     # -- Image tag used for deployment
     tag: "1.0.0"
 
+  # -- Decoupled schema migrations Job (ArgoCD PreSync hook).
+  #    Runs the midaz-tracer-migrations image before the app rollout to apply
+  #    the tracer DB migrations. DB connection settings are reused from
+  #    tracer.configmap / tracer.secrets (same envFrom sources as the tracer
+  #    Deployment), so no extra DB config is required here.
+  migrations:
+    # -- Enable or disable the tracer migrations PreSync Job
+    enabled: true
+    image:
+      # -- Repository for the tracer migrations image
+      repository: ghcr.io/lerianstudio/midaz-tracer-migrations
+      # -- Image tag (populated by the release pipeline via gitops_yaml_key_mappings;
+      #    falls back to .Chart.AppVersion when empty)
+      tag: ""
+      # -- Image pull policy
+      pullPolicy: IfNotPresent
+    # -- Job backoffLimit (retries before the migration is marked failed)
+    backoffLimit: 3
+    # -- Hard time limit for the migration Job
+    activeDeadlineSeconds: 300
+    # -- Retain the finished Job for this many seconds before cleanup
+    ttlSecondsAfterFinished: 300
+    # -- Resource requests/limits for the migration Job
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 128Mi
+
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
 


### PR DESCRIPTION
Requested by: Ygohr

## Summary
Add PreSync ArgoCD/Helm hook Jobs for the decoupled `midaz-ledger-migrations` and `midaz-tracer-migrations` images.

These Jobs run before the app Deployments on every sync, applying DB schema migrations for Ledger (onboarding + transaction DBs) and Tracer (tracer DB). Each Job reuses the same `envFrom` ConfigMap + Secret sources the corresponding app Deployment already consumes, so DB connection settings are not duplicated.

## Changes
- `charts/midaz/templates/_helpers.tpl`: add `midaz.migrations.securityContext.pod` and `.container` helpers
- `charts/midaz/templates/ledger/migrations-job.yaml`: PreSync Job for ledger migrations (onboarding + transaction), passwords injected via the same infra-secret pattern as the ledger Deployment
- `charts/midaz/values.yaml`: add `ledger.migrations.*` (image, resources, job tuning)
- `charts/tracer/templates/_helpers.tpl`: add `tracer.migrations.securityContext.pod` and `.container` helpers
- `charts/tracer/templates/migrations-job.yaml`: PreSync Job for tracer migrations
- `charts/tracer/values.yaml`: add `tracer.migrations.*` (image, resources, job tuning)

## Security
- UID/GID 65532 (distroless nonroot, matches the app images)
- `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`
- `automountServiceAccountToken: false`
- DB passwords sourced via `secretKeyRef` only (never in plain env)

## Env contract
- Ledger: `DB_ONBOARDING_*` / `DB_TRANSACTION_*` (host, port, name, user, `SSLMODE`) from the ledger ConfigMap; `DB_ONBOARDING_PASSWORD` / `DB_TRANSACTION_PASSWORD` via secretKeyRef (single-sourced from the postgresql subchart when internal)
- Tracer: `DB_HOST/PORT/NAME/USER`, `DB_SSL_MODE` from the tracer ConfigMap; `DB_PASSWORD` from the tracer Secret
- `DB_*_SSLMODE` (ledger) vs `DB_SSL_MODE` (tracer) is the intentional asymmetry from the runner contract

## Notes
- Image tags default to `.Chart.AppVersion` and are populated by the Midaz release pipeline via `gitops_yaml_key_mappings` (`.ledger.migrations.image.tag`, `.tracer.migrations.image.tag`)
- `argocd.argoproj.io/sync-wave: "-1"` ensures migrations run before app Deployments
- Toggle per service via `ledger.migrations.enabled` / `tracer.migrations.enabled`

## Verification
- `helm lint` passes on both charts
- `helm template` renders both Jobs correctly (internal + external DB paths)