### PR TITLE
docs(doc): add Lerian Common library section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,16 @@ For implementation and configuration details, see the [README](https://charts.le
 | :---: | :---: | :---: |
 | `1.1.0` | `1.0.0-beta.109` | `1.0.0-beta.109` |
 -----------------
+
+### Lerian Common (Library)
+
+Library chart consumed by other Lerian charts — renders nothing on its own.
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/lerian-common).
+
+#### Application Version Mapping
+
+| Chart Version |
+| :---: |
+| `1.0.0` |
+-----------------


### PR DESCRIPTION
The release pipeline runs `update-chart-version-readme` for every released chart and fails when the chart has no version-matrix section in `README.md`.

`lerian-common` is a **library chart** that never had a README section, so its first release on `main` (after #1707) aborted at the semantic-release `prepare` step:

```
WARNING: Could not find section for chart 'lerian-common'
ERROR: Could not find version matrix table in README.md
```

This adds a minimal `### Lerian Common (Library)` section with a `| Chart Version |` table so the pipeline can locate and update it. Verified locally: the updater now finds the section and exits 0 (idempotent).

After merge, re-run the failed release workflow so `lerian-common-helm:1.0.0` publishes.