### PR TITLE
feat(otel-collector): expose rollouts-pod-template-hash on spanmetrics

### DIFF
--- a/charts/otel-collector-lerian/values.yaml
+++ b/charts/otel-collector-lerian/values.yaml
@@ -348,6 +348,15 @@ opentelemetry-collector:
             - k8s.pod.name
             - k8s.deployment.name
             - k8s.namespace.name
+          # Pod labels -> resource attributes. `rollouts-pod-template-hash` is the
+          # label Argo Rollouts stamps on each ReplicaSet's pods (canary vs stable).
+          # Exposing it lets progressive-delivery analysis (AnalysisTemplate) isolate
+          # the canary's RED metrics from the stable's. Empty for pods that are not
+          # managed by a Rollout.
+          labels:
+            - tag_name: rollouts_pod_template_hash
+              key: rollouts-pod-template-hash
+              from: pod
 
       # Adds the client ID for multi-tenancy, as requested.
       resource/add_client_id:
@@ -384,6 +393,12 @@ opentelemetry-collector:
           - name: http.route
           - name: http.status_code
           - name: http.response.status_code
+          # Argo Rollouts canary/stable pod-template hash (from the k8sattributes
+          # pod-label extraction above). Low cardinality: "" for non-Rollout pods,
+          # plus the stable + canary hashes only while a rollout is in progress.
+          # Enables canary-isolated RED analysis for progressive delivery.
+          - name: rollouts_pod_template_hash
+            default: ""
         aggregation_cardinality_limit: 50000
 
     exporters:


### PR DESCRIPTION
## Proposal (for o11y review)

Expose the **Argo Rollouts pod-template hash** on the spanmetrics so that
**progressive-delivery analysis can isolate a canary's RED metrics** from the
stable version. This is a prerequisite for automatic, metric-gated canary
promotion/rollback (Argo Rollouts `AnalysisTemplate`) across our services.

> Opening this for the **o11y team to analyze** the cardinality/dimension policy
> before we adopt it. Nothing else depends on it merging immediately.

## Problem

Our apps don't expose `/metrics`; RED signals come from the OTel **spanmetrics**
connector (`calls_total`, `duration_milliseconds_bucket`) shipped to Mimir. A
canary gate must compare **only the new version's** pods against thresholds —
otherwise, at low traffic weight, canary errors are diluted by the stable
version and the gate is blind.

Argo Rollouts distinguishes canary vs stable pods with the pod label
`rollouts-pod-template-hash`. Today the spanmetrics carry `k8s.pod.name`,
`k8s.namespace.name`, `k8s.deployment.name` — but **no pod labels**, so there is
no way to slice a series by canary vs stable. (Verified on benedita: the label
`rollouts_pod_template_hash` returns an empty value set in Mimir.)

## Change (2 additive edits, `otel-collector-lerian`)

1. **`k8sattributes.extract.labels`** — extract the pod label into a resource
   attribute:
   ```yaml
   labels:
     - tag_name: rollouts_pod_template_hash
       key: rollouts-pod-template-hash
       from: pod
   ```
2. **`spanmetrics.dimensions`** — add it as a dimension so it becomes a metric
   label:
   ```yaml
   - name: rollouts_pod_template_hash
     default: ""
   ```

Chart version: `4.2.0-beta.3` → `4.2.0-beta.4`.

## Cardinality (please sanity-check)

- New label is **empty (`""`) for every pod not managed by a Rollout** → one extra
  value cluster-wide for the vast majority of series.
- For an app under rollout it adds the **stable + canary hashes**, and **only
  while a rollout is in progress**; it collapses back to the stable hash after.
- The connector already carries the far-higher-cardinality `k8s.pod.name`, and
  `aggregation_cardinality_limit: 50000` is unchanged. Net impact is expected to
  be negligible, but flagging for your call on the dimension policy.

## Backward compatibility

Purely additive. Existing queries/dashboards are unaffected (the new label just
appears with value `""` on existing series). No pipeline/processor reordering.

## Validation

- `helm lint` → 0 failures.
- `helm template` renders the label in both places (k8sattributes `tag_name`
  `rollouts_pod_template_hash` + spanmetrics dimension `rollouts_pod_template_hash`).

## Questions for o11y

- OK to add this as a **default dimension** for all envs, or should it be **gated
  behind a values flag** (e.g. `spanmetrics.rolloutDimension: true`) so only
  clusters doing progressive delivery pay the (tiny) cardinality?
- Naming: `rollouts_pod_template_hash` vs a namespaced `k8s.pod.label.*` form?
