### PR TITLE
feat(common): add flat-passthrough env helpers to lerian-common

### DIFF
--- a/charts/lerian-common/README.md
+++ b/charts/lerian-common/README.md
@@ -11,6 +11,14 @@ via `include` by the product charts that declare it as a dependency.
   (set once per environment); the per-app enable knob stays in the component's
   `extraEnvVars`/`configmap`; a component value overrides the global default; and
   each helper stays **inert until `global.*` is set** (backward-compatible).
+- **Env contracts (flat-passthrough):** `lerian-common.serviceDiscovery.envFlat`,
+  `lerian-common.otel.envFlat`, `lerian-common.multiTenant.envFlat` — reproduce a
+  chart's EXISTING native env block **byte-for-byte** (same keys, defaults, quoting
+  and line order) with **no derivation** from `global.*`. The generic primitive
+  behind them is `lerian-common.env.flatBlock` (ordered `KEY: value` emitter,
+  `configmap.<KEY>` > `defaults.<KEY>` > `""`, presence-based). Each chart opts into
+  its own SUBSET + ORDER via `keys` and its per-key defaults via `defaults`; adoption
+  is a zero-diff refactor, before optionally migrating to the derivation helpers above.
 - **In-cluster host primitives:** `lerian-common.internalHost`, `lerian-common.internalURL`.
 - **Resource helpers:** `lerian-common.hpa`, `.service`, `.serviceAccount`, `.pdb`, `.ingress`.
 - **Deployment pod-spec fragments:** `lerian-common.scheduling`, `.imagePullSecrets`,

--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -131,6 +131,90 @@ Inputs: context, secrets, secretName, valuesPrefix, mode,
         useExistingSecret (bool — skip entirely when true).
 ------------------------------------------------------------------------------
 */}}
+{{/*
+==============================================================================
+lerian-common.multiTenant.envFlat — flat-passthrough MULTI_TENANT_* block.
+
+Reproduces the chart's EXISTING native multi-tenant env block byte-for-byte (no
+derivation, no `global.multiTenant`). Complements `lerian-common.multiTenant.env`
+(the derivation-model helper): this one is a faithful mirror of the per-chart
+block for charts adopting lerian-common with zero render diff.
+
+Always emits `MULTI_TENANT_ENABLED` first (the knob) — UNLIKE
+`lerian-common.multiTenant.env`, which leaves it inline. Then, ONLY when enabled
+(`MULTI_TENANT_ENABLED == "true"`), emits the gated subset the chart opts into
+via `keys`, in that order, with `flatBlock` precedence/quoting. The gate is
+computed from the resolved MULTI_TENANT_ENABLED using presence (hasKey) over the
+configmap, falling back to `enabledDefault`.
+
+The SECRET keys (MULTI_TENANT_SERVICE_API_KEY / MULTI_TENANT_REDIS_PASSWORD) are
+NOT emitted here — use the companion `lerian-common.multiTenant.secret`.
+
+Usage (component configmap.yaml — replaces the hand-written MT block):
+
+  # midaz-ledger (8 keys: ENABLED + 7 gated; SERVICE_NAME default "ledger"):
+  {{- include "lerian-common.multiTenant.envFlat" (dict
+        "configmap" .Values.ledger.configmap
+        "keys" (list "MULTI_TENANT_URL" "MULTI_TENANT_SERVICE_NAME"
+                     "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"
+                     "MULTI_TENANT_REDIS_HOST" "MULTI_TENANT_REDIS_PORT" "MULTI_TENANT_REDIS_TLS")
+        "defaults" (dict "MULTI_TENANT_SERVICE_NAME" "ledger")
+        "required" (dict
+          "MULTI_TENANT_URL" "ledger.configmap.MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true"
+          "MULTI_TENANT_REDIS_HOST" "ledger.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true"))
+    | nindent 2 }}
+
+  # plugin-fees (14 keys: ENABLED + 13 gated; all standard defaults):
+  {{- include "lerian-common.multiTenant.envFlat" (dict
+        "configmap" .Values.fees.configmap
+        "keys" (list "MULTI_TENANT_URL" "MULTI_TENANT_ALLOW_INSECURE_HTTP" "MULTI_TENANT_ENVIRONMENT"
+                     "MULTI_TENANT_MAX_TENANT_POOLS" "MULTI_TENANT_IDLE_TIMEOUT_SEC"
+                     "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC"
+                     "MULTI_TENANT_REDIS_HOST" "MULTI_TENANT_REDIS_PORT" "MULTI_TENANT_REDIS_TLS"
+                     "MULTI_TENANT_TIMEOUT" "MULTI_TENANT_CACHE_TTL_SEC" "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC")
+        "required" (dict
+          "MULTI_TENANT_URL" "fees.configmap.MULTI_TENANT_URL is required when MULTI_TENANT_ENABLED=true"
+          "MULTI_TENANT_REDIS_HOST" "fees.configmap.MULTI_TENANT_REDIS_HOST is required when MULTI_TENANT_ENABLED=true"))
+    | nindent 2 }}
+
+Inputs (dict):
+  configmap      (req)  the component's `.configmap` map (native override source)
+  keys           (req)  ordered gated subset (WITHOUT MULTI_TENANT_ENABLED)
+  enabledDefault (opt)  default for MULTI_TENANT_ENABLED (default "false")
+  defaults       (opt)  per-key default overrides (e.g. SERVICE_NAME "ledger");
+                        chart defaults win over the standard defaults baked here
+  required       (opt)  dict key->message; fail if the resolved value is empty
+==============================================================================
+*/}}
+{{- define "lerian-common.multiTenant.envFlat" -}}
+{{- $cm := .configmap | default dict -}}
+{{- $enabledVal := .enabledDefault | default "false" -}}
+{{- if hasKey $cm "MULTI_TENANT_ENABLED" -}}{{- $enabledVal = index $cm "MULTI_TENANT_ENABLED" -}}{{- end -}}
+{{- $std := dict
+      "MULTI_TENANT_URL" ""
+      "MULTI_TENANT_SERVICE_NAME" ""
+      "MULTI_TENANT_ALLOW_INSECURE_HTTP" "false"
+      "MULTI_TENANT_ENVIRONMENT" ""
+      "MULTI_TENANT_MAX_TENANT_POOLS" "100"
+      "MULTI_TENANT_IDLE_TIMEOUT_SEC" "300"
+      "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" "5"
+      "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC" "30"
+      "MULTI_TENANT_REDIS_HOST" ""
+      "MULTI_TENANT_REDIS_PORT" "6379"
+      "MULTI_TENANT_REDIS_TLS" "false"
+      "MULTI_TENANT_TIMEOUT" "30"
+      "MULTI_TENANT_CACHE_TTL_SEC" "120"
+      "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" "30" -}}
+{{- /* Overlay chart defaults with `set` (see envFlat helpers) so empty-string
+   overrides win over `$std`. */ -}}
+{{- $defaults := deepCopy $std -}}
+{{- range $k, $v := (.defaults | default dict) -}}{{- $_ := set $defaults $k $v -}}{{- end -}}
+MULTI_TENANT_ENABLED: {{ $enabledVal | quote }}
+{{- if eq (toString $enabledVal) "true" }}
+{{ include "lerian-common.env.flatBlock" (dict "configmap" $cm "keys" .keys "defaults" $defaults "required" (.required | default dict)) }}
+{{- end -}}
+{{- end -}}
+
 {{- define "lerian-common.multiTenant.secret" -}}
 {{- if and .enabled (not .useExistingSecret) -}}
 {{- $s := .secrets | default dict -}}

--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -205,13 +205,10 @@ Inputs (dict):
       "MULTI_TENANT_TIMEOUT" "30"
       "MULTI_TENANT_CACHE_TTL_SEC" "120"
       "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" "30" -}}
-{{- /* Overlay chart defaults with `set` (see envFlat helpers) so empty-string
-   overrides win over `$std`. */ -}}
-{{- $defaults := deepCopy $std -}}
-{{- range $k, $v := (.defaults | default dict) -}}{{- $_ := set $defaults $k $v -}}{{- end -}}
+{{- if kindIs "invalid" $enabledVal -}}{{- $enabledVal = "false" -}}{{- end -}}
 MULTI_TENANT_ENABLED: {{ $enabledVal | quote }}
 {{- if eq (toString $enabledVal) "true" }}
-{{ include "lerian-common.env.flatBlock" (dict "configmap" $cm "keys" .keys "defaults" $defaults "required" (.required | default dict)) }}
+{{ include "lerian-common.env.flatBlock" (dict "configmap" $cm "keys" .keys "defaults" (.defaults | default dict) "stdDefaults" $std "required" (.required | default dict)) }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -206,9 +206,14 @@ Inputs (dict):
       "MULTI_TENANT_CACHE_TTL_SEC" "120"
       "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" "30" -}}
 {{- if kindIs "invalid" $enabledVal -}}{{- $enabledVal = "false" -}}{{- end -}}
+{{- /* Guard: only emit non-secret multi-tenant keys from the known contract
+   ($std). Rejects a caller passing MULTI_TENANT_ENABLED again (emitted above)
+   or a secret-only name into the ConfigMap. */ -}}
+{{- $safeKeys := list -}}
+{{- range $k := (.keys | default list) -}}{{- if hasKey $std $k -}}{{- $safeKeys = append $safeKeys $k -}}{{- end -}}{{- end -}}
 MULTI_TENANT_ENABLED: {{ $enabledVal | quote }}
 {{- if eq (toString $enabledVal) "true" }}
-{{ include "lerian-common.env.flatBlock" (dict "configmap" $cm "keys" .keys "defaults" (.defaults | default dict) "stdDefaults" $std "required" (.required | default dict)) }}
+{{ include "lerian-common.env.flatBlock" (dict "configmap" $cm "keys" $safeKeys "defaults" (.defaults | default dict) "stdDefaults" $std "required" (.required | default dict)) }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/lerian-common/templates/_otel.tpl
+++ b/charts/lerian-common/templates/_otel.tpl
@@ -130,11 +130,5 @@ Inputs (dict):
       "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT"
       "OTEL_EXPORTER_OTLP_ENDPOINT_PORT"
       "OTEL_EXPORTER_OTLP_ENDPOINT") -}}
-{{- /* Overlay chart-supplied defaults onto the standard set. Use `set` (not sprig
-   `merge`) so an explicit empty-string default from the chart wins (e.g.
-   plugin-fees OTEL_EXPORTER_OTLP_ENDPOINT "") — `merge` would treat an empty dst
-   value as absent and refill it from `$std`. */ -}}
-{{- $defaults := deepCopy $std -}}
-{{- range $k, $v := (.defaults | default dict) -}}{{- $_ := set $defaults $k $v -}}{{- end -}}
-{{- include "lerian-common.env.flatBlock" (dict "configmap" .configmap "keys" $keys "defaults" $defaults) -}}
+{{- include "lerian-common.env.flatBlock" (dict "configmap" .configmap "keys" $keys "defaults" (.defaults | default dict) "stdDefaults" $std) -}}
 {{- end -}}

--- a/charts/lerian-common/templates/_otel.tpl
+++ b/charts/lerian-common/templates/_otel.tpl
@@ -58,3 +58,83 @@ Inputs (dict):
   value: "k8s.pod.ip=$(POD_IP)"
 {{- end }}
 {{- end -}}
+
+{{/*
+==============================================================================
+lerian-common.otel.envFlat — flat-passthrough OTEL block (no derivation).
+
+Reproduces the chart's EXISTING native OTEL env block byte-for-byte. Unlike
+`lerian-common.otel.env` (which DERIVES from `global.observability`), this is a
+faithful mirror of the per-chart block, driven only by per-chart inputs.
+
+Scope: the 6 OTEL keys every productized chart currently emits, in the shared
+order — OTEL_RESOURCE_SERVICE_NAME, OTEL_LIBRARY_NAME,
+OTEL_RESOURCE_SERVICE_VERSION, OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT,
+OTEL_EXPORTER_OTLP_ENDPOINT_PORT, OTEL_EXPORTER_OTLP_ENDPOINT.
+ENABLE_TELEMETRY is intentionally NOT emitted here — it stays inline in the
+component configmap as its own knob (same split as `lerian-common.otel.env`).
+
+The three OTEL identity values are chart-specific and NOT `configmap.<KEY>`
+driven in the native templates:
+  - OTEL_RESOURCE_SERVICE_NAME / OTEL_LIBRARY_NAME differ per component;
+  - OTEL_RESOURCE_SERVICE_VERSION is `image.tag | default .Chart.AppVersion`
+    (no configmap key at all);
+  - OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT keys off configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT
+    for midaz-ledger but off configmap.ENV_NAME for midaz-crm / plugin-fees.
+So the CHART resolves each of these and passes it as the per-key `defaults`
+entry (see uses). Because the corresponding key is absent from `.configmap`
+under real values, `flatBlock` emits the supplied default — byte-identical to
+the native render. See `lerian-common.env.flatBlock` for precedence/quoting.
+
+Usage (component configmap.yaml — replaces the hand-written OTEL block):
+
+  # midaz-ledger:
+  {{- include "lerian-common.otel.envFlat" (dict
+        "configmap" .Values.ledger.configmap
+        "defaults" (dict
+          "OTEL_RESOURCE_SERVICE_NAME" "ledger"
+          "OTEL_LIBRARY_NAME" "github.com/LerianStudio/midaz/v3/components/ledger"
+          "OTEL_RESOURCE_SERVICE_VERSION" (.Values.ledger.image.tag | default .Chart.AppVersion)
+          "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT" (.Values.ledger.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "production")))
+    | nindent 2 }}
+
+  # plugin-fees (endpoint default "" + deployment-env keyed off ENV_NAME):
+  {{- include "lerian-common.otel.envFlat" (dict
+        "configmap" .Values.fees.configmap
+        "defaults" (dict
+          "OTEL_RESOURCE_SERVICE_NAME" "plugin-fees"
+          "OTEL_LIBRARY_NAME" "github.com/LerianStudio/plugin-fees"
+          "OTEL_RESOURCE_SERVICE_VERSION" (.Values.fees.image.tag | default .Chart.AppVersion)
+          "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT" (.Values.fees.configmap.ENV_NAME | default "development")
+          "OTEL_EXPORTER_OTLP_ENDPOINT" "")) | nindent 2 }}
+
+Inputs (dict):
+  configmap (req)  the component's `.configmap` map (native override source)
+  keys      (opt)  ordered subset; defaults to the full 6-key block above
+  defaults  (opt)  per-key default overrides (identity values live here; chart
+                   defaults win over the standard defaults baked in here)
+==============================================================================
+*/}}
+{{- define "lerian-common.otel.envFlat" -}}
+{{- $std := dict
+      "OTEL_RESOURCE_SERVICE_NAME" ""
+      "OTEL_LIBRARY_NAME" ""
+      "OTEL_RESOURCE_SERVICE_VERSION" ""
+      "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT" "production"
+      "OTEL_EXPORTER_OTLP_ENDPOINT_PORT" "4317"
+      "OTEL_EXPORTER_OTLP_ENDPOINT" "midaz-grafana:4317" -}}
+{{- $keys := .keys | default (list
+      "OTEL_RESOURCE_SERVICE_NAME"
+      "OTEL_LIBRARY_NAME"
+      "OTEL_RESOURCE_SERVICE_VERSION"
+      "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT"
+      "OTEL_EXPORTER_OTLP_ENDPOINT_PORT"
+      "OTEL_EXPORTER_OTLP_ENDPOINT") -}}
+{{- /* Overlay chart-supplied defaults onto the standard set. Use `set` (not sprig
+   `merge`) so an explicit empty-string default from the chart wins (e.g.
+   plugin-fees OTEL_EXPORTER_OTLP_ENDPOINT "") — `merge` would treat an empty dst
+   value as absent and refill it from `$std`. */ -}}
+{{- $defaults := deepCopy $std -}}
+{{- range $k, $v := (.defaults | default dict) -}}{{- $_ := set $defaults $k $v -}}{{- end -}}
+{{- include "lerian-common.env.flatBlock" (dict "configmap" .configmap "keys" $keys "defaults" $defaults) -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -77,3 +77,133 @@ Inputs: ingress (the component's `.ingress` map).
 {{- (first $ing.hosts).host | default "" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+==============================================================================
+lerian-common.env.flatBlock — SHARED low-level ordered `KEY: value` emitter.
+
+The generic primitive behind every `*.envFlat` helper (serviceDiscovery / otel /
+multiTenant). It reproduces a chart's EXISTING hand-written env block
+byte-for-byte: same keys, same values, same defaults, same quoting AND same line
+order — without deriving anything. It just walks a caller-supplied ordered key
+list and, per key, emits the component's native override if present else the
+supplied default.
+
+This is the "flat-passthrough" counterpart to the derivation-model helpers
+(lerian-common.serviceDiscovery.env / .otel.env / .multiTenant.env). Those
+DERIVE values from `global.*`; this one does NOT — it is a faithful mirror of the
+per-chart block, so a productized chart can adopt lerian-common with zero render
+diff before (optionally) moving to derivation later.
+
+Precedence per key (presence-based, NOT sprig `default`):
+  configmap.<KEY> (hasKey)  >  defaults.<KEY> (hasKey)  >  ""
+Presence checks (hasKey) are used deliberately so an explicit `false`/empty in
+the component configmap is respected instead of silently falling through to the
+default (the sprig-`default` footgun this repo has already hit with booleans).
+
+NOTE: under the REAL product values these keys are absent from `.configmap`
+(they are hand-defaulted in the native template), so hasKey is false and the
+`defaults.<KEY>` value is emitted — identical to the native `X | default "y"`.
+The hasKey semantics only diverge from native when a key is explicitly set to an
+empty string in configmap, which the native templates never do.
+
+Output: `KEY: value` lines joined by "\n" with NO leading/trailing newline; the
+caller `| nindent N`s it under the ConfigMap `data:` map.
+
+Inputs (dict):
+  configmap (req)  the component's `.configmap` map (native override source)
+  keys      (req)  ordered list of env keys to emit (the subset + order)
+  defaults  (opt)  dict key->default value, used when configmap lacks the key
+  required  (opt)  dict key->error message; if the RESOLVED value is empty, fail
+                   with that message (mirrors native `required`)
+==============================================================================
+*/}}
+{{- define "lerian-common.env.flatBlock" -}}
+{{- $cm := .configmap | default dict -}}
+{{- $defaults := .defaults | default dict -}}
+{{- $required := .required | default dict -}}
+{{- $lines := list -}}
+{{- range $k := .keys -}}
+  {{- $v := "" -}}
+  {{- if hasKey $cm $k -}}
+    {{- $v = index $cm $k -}}
+  {{- else if hasKey $defaults $k -}}
+    {{- $v = index $defaults $k -}}
+  {{- end -}}
+  {{- if and (hasKey $required $k) (not $v) -}}
+    {{- fail (index $required $k) -}}
+  {{- end -}}
+  {{- $lines = append $lines (printf "%s: %s" $k ($v | quote)) -}}
+{{- end -}}
+{{- join "\n" $lines -}}
+{{- end -}}
+
+{{/*
+==============================================================================
+lerian-common.serviceDiscovery.envFlat — flat-passthrough SD_* block.
+
+Reproduces the chart's EXISTING native SD_* env block byte-for-byte (no
+derivation, no `global.serviceDiscovery`). It encodes the canonical SD contract:
+the known key set + each key's STANDARD default. A chart opts into the SUBSET and
+ORDER it currently emits via `keys`, and overrides any per-key default via
+`defaults` (e.g. plugin-fees' whitespace-padded SD_ADDRESS). See
+`lerian-common.env.flatBlock` (this file) for precedence/quoting semantics.
+
+Usage (component configmap.yaml — replaces the hand-written SD_* block):
+
+  # midaz-ledger / midaz-crm — full 17-key block, standard defaults:
+  {{- include "lerian-common.serviceDiscovery.envFlat" (dict
+        "configmap" .Values.ledger.configmap) | nindent 2 }}
+
+  # plugin-fees — 7-key subset with its padded defaults:
+  {{- include "lerian-common.serviceDiscovery.envFlat" (dict
+        "configmap" .Values.fees.configmap
+        "keys" (list "SD_ADDRESS" "SD_ENABLED" "SD_EXTERNAL_ADDRESS"
+                     "SD_EXTERNAL_PORT" "SD_TLS" "SD_TLS_SKIP_VERIFY" "SD_WORKLOAD")
+        "defaults" (dict
+          "SD_ADDRESS" "localhost:8500       "
+          "SD_EXTERNAL_ADDRESS" "            "
+          "SD_EXTERNAL_PORT" "               "
+          "SD_WORKLOAD" "                    ")) | nindent 2 }}
+
+Inputs (dict):
+  configmap (req)  the component's `.configmap` map (native override source)
+  keys      (opt)  ordered subset to emit; defaults to the full 17-key block in
+                   the canonical (alphabetical) order midaz emits
+  defaults  (opt)  per-key default overrides (chart-specific defaults win over
+                   the standard defaults baked in here)
+==============================================================================
+*/}}
+{{- define "lerian-common.serviceDiscovery.envFlat" -}}
+{{- $std := dict
+      "SD_ADDRESS" "localhost:8500"
+      "SD_ALLOW_STALE" ""
+      "SD_DIAL_TIMEOUT" ""
+      "SD_ENABLED" "false"
+      "SD_EXTERNAL_ADDRESS" ""
+      "SD_EXTERNAL_PORT" ""
+      "SD_INTERNAL_ADDRESS" ""
+      "SD_INTERNAL_PORT" ""
+      "SD_INTERNAL_SCHEME" ""
+      "SD_PREFER_VIEW" ""
+      "SD_RESPONSE_HEADER_TIMEOUT" ""
+      "SD_SEED_TIMEOUT" ""
+      "SD_TLS" "false"
+      "SD_TLS_HANDSHAKE_TIMEOUT" ""
+      "SD_TLS_SKIP_VERIFY" "false"
+      "SD_WATCH_WAIT_TIME" ""
+      "SD_WORKLOAD" "" -}}
+{{- $keys := .keys | default (list
+      "SD_ADDRESS" "SD_ALLOW_STALE" "SD_DIAL_TIMEOUT" "SD_ENABLED"
+      "SD_EXTERNAL_ADDRESS" "SD_EXTERNAL_PORT" "SD_INTERNAL_ADDRESS"
+      "SD_INTERNAL_PORT" "SD_INTERNAL_SCHEME" "SD_PREFER_VIEW"
+      "SD_RESPONSE_HEADER_TIMEOUT" "SD_SEED_TIMEOUT" "SD_TLS"
+      "SD_TLS_HANDSHAKE_TIMEOUT" "SD_TLS_SKIP_VERIFY" "SD_WATCH_WAIT_TIME"
+      "SD_WORKLOAD") -}}
+{{- /* Overlay chart-supplied defaults onto the standard set. Use `set` (not sprig
+   `merge`) so an explicit empty-string default from the chart wins — `merge`
+   would treat an empty dst value as absent and refill it from `$std`. */ -}}
+{{- $defaults := deepCopy $std -}}
+{{- range $k, $v := (.defaults | default dict) -}}{{- $_ := set $defaults $k $v -}}{{- end -}}
+{{- include "lerian-common.env.flatBlock" (dict "configmap" .configmap "keys" $keys "defaults" $defaults) -}}
+{{- end -}}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -114,6 +114,8 @@ Inputs (dict):
   configmap (req)  the component's `.configmap` map (native override source)
   keys      (req)  ordered list of env keys to emit (the subset + order)
   defaults  (opt)  dict key->default value, used when configmap lacks the key
+  stdDefaults (opt) dict of standard/baked defaults; lowest precedence. Resolution
+                   order per key: configmap > defaults (caller) > stdDefaults > "".
   required  (opt)  dict key->error message; if the RESOLVED value is empty, fail
                    with that message (mirrors native `required`)
 ==============================================================================

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -121,15 +121,21 @@ Inputs (dict):
 {{- define "lerian-common.env.flatBlock" -}}
 {{- $cm := .configmap | default dict -}}
 {{- $defaults := .defaults | default dict -}}
+{{- $std := .stdDefaults | default dict -}}
 {{- $required := .required | default dict -}}
 {{- $lines := list -}}
 {{- range $k := .keys -}}
   {{- $v := "" -}}
+  {{- /* Precedence: native configmap key > caller default > standard default > "".
+     Presence-based (hasKey) so an explicit empty-string/false at any tier wins. */ -}}
   {{- if hasKey $cm $k -}}
     {{- $v = index $cm $k -}}
   {{- else if hasKey $defaults $k -}}
     {{- $v = index $defaults $k -}}
+  {{- else if hasKey $std $k -}}
+    {{- $v = index $std $k -}}
   {{- end -}}
+  {{- if kindIs "invalid" $v -}}{{- $v = "" -}}{{- end -}}
   {{- if and (hasKey $required $k) (not $v) -}}
     {{- fail (index $required $k) -}}
   {{- end -}}
@@ -200,10 +206,5 @@ Inputs (dict):
       "SD_RESPONSE_HEADER_TIMEOUT" "SD_SEED_TIMEOUT" "SD_TLS"
       "SD_TLS_HANDSHAKE_TIMEOUT" "SD_TLS_SKIP_VERIFY" "SD_WATCH_WAIT_TIME"
       "SD_WORKLOAD") -}}
-{{- /* Overlay chart-supplied defaults onto the standard set. Use `set` (not sprig
-   `merge`) so an explicit empty-string default from the chart wins — `merge`
-   would treat an empty dst value as absent and refill it from `$std`. */ -}}
-{{- $defaults := deepCopy $std -}}
-{{- range $k, $v := (.defaults | default dict) -}}{{- $_ := set $defaults $k $v -}}{{- end -}}
-{{- include "lerian-common.env.flatBlock" (dict "configmap" .configmap "keys" $keys "defaults" $defaults) -}}
+{{- include "lerian-common.env.flatBlock" (dict "configmap" .configmap "keys" $keys "defaults" (.defaults | default dict) "stdDefaults" $std) -}}
 {{- end -}}


### PR DESCRIPTION
Adds backward-compatible **flat-passthrough** env helpers to `lerian-common` so productized charts can reproduce their EXISTING native env blocks byte-for-byte — unblocking the configmap productization of midaz (and fees/others) without any render regression.

## New helpers (additive — existing derivation helpers untouched)
- **`lerian-common.env.flatBlock`** — shared ordered `KEY: value` primitive. Presence-based precedence per key: `configmap.<KEY>` > `defaults.<KEY>` > `""` (hasKey, not sprig `default`, so explicit `false`/empty is respected).
- **`lerian-common.serviceDiscovery.envFlat`** — full 17-key `SD_*` block (subset selectable via `keys`).
- **`lerian-common.otel.envFlat`** — 6-key OTEL block (does NOT emit `ENABLE_TELEMETRY`, same split as `otel.env`).
- **`lerian-common.multiTenant.envFlat`** — `MULTI_TENANT_ENABLED` + gated subset (emitted only when enabled).

## Why flat-passthrough (vs the existing derivation helpers)
The current `*.env` helpers derive a subset of keys from `global.*` with opinionated defaults. Production charts emit a **different, larger, per-chart** key set with per-key defaults and a fixed order. Reproducing that exactly (zero regression) needs a passthrough model where the chart owns the keys/defaults and the helper encodes the contract + precedence. Both models now coexist.

## Proof: byte-equivalence (empty diff)
Rendered each chart’s CURRENT native block vs the helper invoked with that chart’s inputs:

| Case | native keys | helper keys | diff |
|------|:---:|:---:|:---:|
| midaz-ledger | 31 | 31 | **empty** ✅ |
| midaz-crm | 24 | 24 | **empty** ✅ |
| plugin-fees | 27 | 27 | **empty** ✅ |

(Exercised with `MULTI_TENANT_ENABLED=true`, non-empty configmap overrides, and fees’ whitespace-padded SD defaults / empty OTLP endpoint — all reproduced exactly.)

Serving **both midaz and fees** from the same helpers (different key subsets/defaults via inputs) is what proves these are generic, not chart-specific.

## Validation
- strict: `0 violations` · `helm lint`: 0 failed · library render-gate: skipped-library (helpers exercised via consumers).

## Follow-ups (separate PRs)
- midaz: helper-ize `ledger/crm` configmaps using these (the invocation dicts are worked out).
- Then fees / access-manager / reporter / pix-indirect productization.