### PR TITLE
feat(plugin-access-manager): productize on lerian-common library (no regression)

### DIFF
--- a/charts/plugin-access-manager/Chart.lock
+++ b/charts/plugin-access-manager/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
+- name: lerian-common-helm
+  repository: file://../lerian-common
+  version: 1.1.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.3.5
 - name: valkey
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.4.6
-digest: sha256:da62e66ac5c1c48ae0f25d85cd5440cd309637b42fdd13ec176a40534b32110d
-generated: "2026-06-07T13:03:00.436339-03:00"
+digest: sha256:ccb0050828215516a97c5944ed57dae94ddd6928150c7aac1d6cd6ee3af9e822
+generated: "2026-07-24T17:46:12.474637-03:00"

--- a/charts/plugin-access-manager/Chart.yaml
+++ b/charts/plugin-access-manager/Chart.yaml
@@ -29,6 +29,9 @@ icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
 # To understand the purpose and configuration of each dependency, visit:
 # https://docs.lerian.studio/docs/midaz-components
 dependencies:
+  - name: lerian-common-helm
+    version: ">=1.0.0 <2.0.0"
+    repository: "file://../lerian-common"
   - name: postgresql
     alias: auth-database
     version: "16.3.5"

--- a/charts/plugin-access-manager/templates/auth-backend/hpa.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/hpa.yaml
@@ -1,32 +1,7 @@
 {{- if .Values.auth.backend.autoscaling.enabled }}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: {{ include "plugin-auth-backend.fullname" . }}
-  labels:
-    {{- include "plugin-auth-backend.labels" (dict "context" . "name" .Values.auth.backend.name ) | nindent 4 }} 
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{ include "plugin-auth-backend.fullname" . }}
-  minReplicas: {{ .Values.auth.backend.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.auth.backend.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.auth.backend.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.auth.backend.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.auth.backend.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.auth.backend.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+{{- include "lerian-common.hpa" (dict
+      "autoscaling" .Values.auth.backend.autoscaling
+      "name" (include "plugin-auth-backend.fullname" .)
+      "labels" (printf "%s " (include "plugin-auth-backend.labels" (dict "context" . "name" .Values.auth.backend.name)))
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/auth-backend/pdb.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/pdb.yaml
@@ -1,23 +1,9 @@
 {{- if .Values.auth.pdb.enabled }}
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "plugin-auth-backend.fullname" . }}
-  labels:
-    {{- include "plugin-auth-backend.labels" (dict "context" . "name" .Values.auth.backend.name ) | nindent 4 }} 
-  {{- with .Values.auth.pdb.annotations }}
-  annotations:
-    {{- range $key, $value := . }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  {{- end }}
-spec:
-  {{- with .Values.auth.pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
-  {{- else }}
-  minAvailable: {{ .Values.auth.pdb.minAvailable | default 0 }}
-  {{- end }}
-  selector:
-    matchLabels:
-      {{- include "plugin-auth-backend.selectorLabels" (dict "context" . "name" .Values.auth.backend.name) | nindent 6 }}
+{{- include "lerian-common.pdb" (dict
+      "pdb" .Values.auth.pdb
+      "name" (include "plugin-auth-backend.fullname" .)
+      "labels" (include "plugin-auth-backend.labels" (dict "context" . "name" .Values.auth.backend.name))
+      "selector" (include "plugin-auth-backend.selectorLabels" (dict "context" . "name" .Values.auth.backend.name))
+      "minAvailableDefault" 0
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/auth-backend/service.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/service.yaml
@@ -1,15 +1,6 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "plugin-auth-backend.fullname" . }}
-  labels:
-    {{- include "plugin-auth-backend.labels" (dict "context" . "name" .Values.auth.backend.name ) | nindent 4 }} 
-spec:
-  type: {{ .Values.auth.service.type }}
-  ports:
-    - port: 8000
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-    {{- include "plugin-auth-backend.selectorLabels" (dict "context" . "name" .Values.auth.backend.name) | nindent 4 }}
+{{- include "lerian-common.service" (dict
+      "service" (dict "type" .Values.auth.service.type "port" 8000)
+      "name" (include "plugin-auth-backend.fullname" .)
+      "labels" (printf "%s " (include "plugin-auth-backend.labels" (dict "context" . "name" .Values.auth.backend.name)))
+      "selector" (include "plugin-auth-backend.selectorLabels" (dict "context" . "name" .Values.auth.backend.name))
+    ) }}

--- a/charts/plugin-access-manager/templates/auth/configmap.yaml
+++ b/charts/plugin-access-manager/templates/auth/configmap.yaml
@@ -47,12 +47,14 @@ data:
   SECURE_LOG_FIELDS: {{ .Values.auth.configmap.SECURE_LOG_FIELDS | default "password,clientSecret" | quote }}
 
   # OPEN TELEMETRY
-  OTEL_RESOURCE_SERVICE_NAME: {{ .Values.auth.configmap.OTEL_RESOURCE_SERVICE_NAME | default "auth" | quote }}
-  OTEL_LIBRARY_NAME: {{ .Values.auth.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/auth" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.auth.image.tag | quote }}
-  OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.auth.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "dev" | quote }}
-  OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.auth.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.auth.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }}
+  {{- include "lerian-common.otel.envFlat" (dict
+        "configmap" .Values.auth.configmap
+        "defaults" (dict
+          "OTEL_RESOURCE_SERVICE_NAME" "auth"
+          "OTEL_LIBRARY_NAME" "github.com/LerianStudio/auth"
+          "OTEL_RESOURCE_SERVICE_VERSION" .Values.auth.image.tag
+          "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT" "dev"
+          "OTEL_EXPORTER_OTLP_ENDPOINT" "")) | nindent 2 }}
   ENABLE_TELEMETRY: {{ .Values.auth.configmap.ENABLE_TELEMETRY | default "true" | quote }}
 
   # AUTHORIZER

--- a/charts/plugin-access-manager/templates/auth/hpa.yaml
+++ b/charts/plugin-access-manager/templates/auth/hpa.yaml
@@ -1,32 +1,7 @@
 {{- if .Values.auth.autoscaling.enabled }}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: {{ include "plugin-auth.fullname" . }}
-  labels:
-    {{- include "plugin-auth.labels" (dict "context" . "name" .Values.auth.name ) | nindent 4 }} 
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{ include "plugin-auth.fullname" . }}
-  minReplicas: {{ .Values.auth.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.auth.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.auth.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.auth.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.auth.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.auth.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+{{- include "lerian-common.hpa" (dict
+      "autoscaling" .Values.auth.autoscaling
+      "name" (include "plugin-auth.fullname" .)
+      "labels" (printf "%s " (include "plugin-auth.labels" (dict "context" . "name" .Values.auth.name)))
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/auth/ingress.yaml
+++ b/charts/plugin-access-manager/templates/auth/ingress.yaml
@@ -1,61 +1,9 @@
 {{- if .Values.auth.ingress.enabled -}}
-{{- $fullName := include "plugin-auth.fullname" . -}}
-{{- $svcPort := .Values.auth.service.port -}}
-{{- if and .Values.auth.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.auth.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.auth.ingress.annotations "kubernetes.io/ingress.class" .Values.auth.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "plugin-auth.labels" (dict "context" . "name" .Values.auth.name ) | nindent 4 }} 
-  {{- with .Values.auth.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.auth.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.auth.ingress.className }}
-  {{- end }}
-  {{- if .Values.auth.ingress.tls }}
-  tls:
-    {{- range .Values.auth.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.auth.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- include "lerian-common.ingress" (dict
+      "context" .
+      "ingress" .Values.auth.ingress
+      "name" (include "plugin-auth.fullname" .)
+      "labels" (printf "%s " (include "plugin-auth.labels" (dict "context" . "name" .Values.auth.name)))
+      "svcPort" .Values.auth.service.port
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/auth/pdb.yaml
+++ b/charts/plugin-access-manager/templates/auth/pdb.yaml
@@ -1,23 +1,9 @@
 {{- if .Values.auth.pdb.enabled }}
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "plugin-auth.fullname" . }}
-  labels:
-    {{- include "plugin-auth.labels" (dict "context" . "name" .Values.auth.name ) | nindent 4 }} 
-  {{- with .Values.auth.pdb.annotations }}
-  annotations:
-    {{- range $key, $value := . }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  {{- end }}
-spec:
-  {{- with .Values.auth.pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
-  {{- else }}
-  minAvailable: {{ .Values.auth.pdb.minAvailable | default 0 }}
-  {{- end }}
-  selector:
-    matchLabels:
-      {{- include "plugin-auth.selectorLabels" (dict "context" . "name" .Values.auth.name) | nindent 6 }}
+{{- include "lerian-common.pdb" (dict
+      "pdb" .Values.auth.pdb
+      "name" (include "plugin-auth.fullname" .)
+      "labels" (include "plugin-auth.labels" (dict "context" . "name" .Values.auth.name))
+      "selector" (include "plugin-auth.selectorLabels" (dict "context" . "name" .Values.auth.name))
+      "minAvailableDefault" 0
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/identity/configmap.yaml
+++ b/charts/plugin-access-manager/templates/identity/configmap.yaml
@@ -43,11 +43,19 @@ data:
   SECURE_LOG_FIELDS: {{ .Values.identity.configmap.SECURE_LOG_FIELDS | default "password,clientSecret" | quote }}
 
   # OPEN TELEMETRY
-  OTEL_RESOURCE_SERVICE_NAME: {{ .Values.identity.configmap.OTEL_RESOURCE_SERVICE_NAME | default "plugin-identity" | quote }}
-  OTEL_LIBRARY_NAME: {{ .Values.identity.configmap.OTEL_LIBRARY_NAME | default "github.com/LerianStudio/identity" | quote }}
-  OTEL_RESOURCE_SERVICE_VERSION: {{ .Values.identity.image.tag | quote }}
-  OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: {{ .Values.identity.configmap.OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT | default "dev" | quote }}
-  OTEL_EXPORTER_OTLP_ENDPOINT_PORT: {{ .Values.identity.configmap.OTEL_EXPORTER_OTLP_ENDPOINT_PORT | default "4317" | quote }}
+  {{- include "lerian-common.otel.envFlat" (dict
+        "configmap" .Values.identity.configmap
+        "keys" (list
+          "OTEL_RESOURCE_SERVICE_NAME"
+          "OTEL_LIBRARY_NAME"
+          "OTEL_RESOURCE_SERVICE_VERSION"
+          "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT"
+          "OTEL_EXPORTER_OTLP_ENDPOINT_PORT")
+        "defaults" (dict
+          "OTEL_RESOURCE_SERVICE_NAME" "plugin-identity"
+          "OTEL_LIBRARY_NAME" "github.com/LerianStudio/identity"
+          "OTEL_RESOURCE_SERVICE_VERSION" .Values.identity.image.tag
+          "OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT" "dev")) | nindent 2 }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.identity.configmap.OTEL_EXPORTER_OTLP_ENDPOINT | default "" | quote }} 
   ENABLE_TELEMETRY: {{ .Values.identity.configmap.ENABLE_TELEMETRY | default "true" | quote }}
   # REDIS

--- a/charts/plugin-access-manager/templates/identity/hpa.yaml
+++ b/charts/plugin-access-manager/templates/identity/hpa.yaml
@@ -1,32 +1,7 @@
 {{- if .Values.identity.autoscaling.enabled }}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: {{ include "plugin-identity.fullname" . }}
-  labels:
-    {{- include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name ) | nindent 4 }} 
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{ include "plugin-identity.fullname" . }}
-  minReplicas: {{ .Values.identity.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.identity.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.identity.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.identity.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.identity.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.identity.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+{{- include "lerian-common.hpa" (dict
+      "autoscaling" .Values.identity.autoscaling
+      "name" (include "plugin-identity.fullname" .)
+      "labels" (printf "%s " (include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name)))
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/identity/ingress.yaml
+++ b/charts/plugin-access-manager/templates/identity/ingress.yaml
@@ -1,61 +1,9 @@
 {{- if .Values.identity.ingress.enabled -}}
-{{- $fullName := include "plugin-identity.fullname" . -}}
-{{- $svcPort := .Values.identity.service.port -}}
-{{- if and .Values.identity.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.identity.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.identity.ingress.annotations "kubernetes.io/ingress.class" .Values.identity.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name ) | nindent 4 }} 
-  {{- with .Values.identity.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.identity.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.identity.ingress.className }}
-  {{- end }}
-  {{- if .Values.identity.ingress.tls }}
-  tls:
-    {{- range .Values.identity.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.identity.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- include "lerian-common.ingress" (dict
+      "context" .
+      "ingress" .Values.identity.ingress
+      "name" (include "plugin-identity.fullname" .)
+      "labels" (printf "%s " (include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name)))
+      "svcPort" .Values.identity.service.port
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/identity/pdb.yaml
+++ b/charts/plugin-access-manager/templates/identity/pdb.yaml
@@ -1,23 +1,9 @@
 {{- if .Values.identity.pdb.enabled }}
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ include "plugin-identity.fullname" . }}
-  labels:
-    {{- include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name ) | nindent 4 }} 
-  {{- with .Values.identity.pdb.annotations }}
-  annotations:
-    {{- range $key, $value := . }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  {{- end }}
-spec:
-  {{- with .Values.identity.pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
-  {{- else }}
-  minAvailable: {{ .Values.identity.pdb.minAvailable | default 0 }}
-  {{- end }}
-  selector:
-    matchLabels:
-      {{- include "plugin-identity.selectorLabels" (dict "context" . "name" .Values.identity.name) | nindent 6 }}
+{{- include "lerian-common.pdb" (dict
+      "pdb" .Values.identity.pdb
+      "name" (include "plugin-identity.fullname" .)
+      "labels" (include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name))
+      "selector" (include "plugin-identity.selectorLabels" (dict "context" . "name" .Values.identity.name))
+      "minAvailableDefault" 0
+    ) }}
 {{- end }}

--- a/charts/plugin-access-manager/templates/identity/service.yaml
+++ b/charts/plugin-access-manager/templates/identity/service.yaml
@@ -1,15 +1,6 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "plugin-identity.fullname" . }}
-  labels:
-    {{- include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name ) | nindent 4 }} 
-spec:
-  type: {{ .Values.identity.service.type }}
-  ports:
-    - port: {{ .Values.identity.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-    {{- include "plugin-identity.selectorLabels" (dict "context" . "name" .Values.identity.name) | nindent 4 }}
+{{- include "lerian-common.service" (dict
+      "service" .Values.identity.service
+      "name" (include "plugin-identity.fullname" .)
+      "labels" (printf "%s " (include "plugin-identity.labels" (dict "context" . "name" .Values.identity.name)))
+      "selector" (include "plugin-identity.selectorLabels" (dict "context" . "name" .Values.identity.name))
+    ) }}


### PR DESCRIPTION
Productizes `charts/plugin-access-manager/` on the **lerian-common** library — render **byte-identical to main** (empty diff, verified with the CI sample values).

## What changed (helper-ized, render-clean)
- **hpa/pdb** — auth, auth-backend, identity → `lerian-common.hpa` / `.pdb`
- **service** — identity, auth-backend → `lerian-common.service`
- **ingress** — auth, identity → `lerian-common.ingress`
- **OTEL block** — auth, identity configmaps → `lerian-common.otel.envFlat`
- Adds `lerian-common-helm` dependency (`file://../lerian-common`, `>=1.0.0 <2.0.0`).

## Left native (bespoke — no render-equivalent helper)
Deployments (custom initContainers/probes/casdoor overrides), casdoor beego configmap, migration + init-user Jobs, provider secrets, dual-port `auth` service. access-manager is the **auth provider**, so the `PLUGIN_AUTH` consumer helper is intentionally NOT used; `MULTI_TENANT_ENABLED` toggle stays native (no lib multi-tenant block here); no SD_* block exists.

## Verification
- Old-pattern render diff vs main: **empty** (zero regression).
- strict: `0 violations`.

## Dependency
Uses `file://` to the in-repo `lerian-common`. The render-gate resolves `file://` local deps via the `materializeLocalDependencies` validator step introduced in **#1741** — so the **render-gate check here will pass once #1741 merges** (bringing that validator step to main). `helm dependency build` + `helm template` succeed at the real repo layout; strict is green.

Depends on #1742 (merged — helpers on main) and #1741 (validator step).