### PR TITLE
feat(common): default serviceDiscovery to internal view + tls-skip-verify

### DIFF
--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -53,9 +53,9 @@ global.serviceDiscovery (all optional except address when enabled):
    would produce a duplicate key. This helper only adds the derived siblings. */ -}}
 SD_ADDRESS: {{ $sd.address | quote }}
 SD_TLS: {{ $sd.tls | default false | quote }}
-SD_TLS_SKIP_VERIFY: {{ $sd.tlsSkipVerify | default false | quote }}
+SD_TLS_SKIP_VERIFY: {{ $sd.tlsSkipVerify | default true | quote }}
 SD_WORKLOAD: {{ $sd.workload | default "" | quote }}
-SD_PREFER_VIEW: {{ $sd.preferView | default "external" | quote }}
+SD_PREFER_VIEW: {{ $sd.preferView | default "internal" | quote }}
 SD_INTERNAL_ADDRESS: {{ include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace) | quote }}
 SD_INTERNAL_PORT: {{ .port | quote }}
 SD_INTERNAL_SCHEME: {{ $sd.internalScheme | default "http" | quote }}


### PR DESCRIPTION
Makes the platform-standard SD defaults the built-in defaults of `lerian-common.serviceDiscovery.env`, so environments do not have to set them in every `global.serviceDiscovery`:

- `SD_PREFER_VIEW`: `external` → **`internal`** (in-cluster consumers prefer the internal K8s DNS view)
- `SD_TLS_SKIP_VERIFY`: `false` → **`true`**

`SD_TLS` (false), `SD_INTERNAL_SCHEME` (http), `SD_EXTERNAL_PORT` (443) unchanged.

Only affects the fallback when `global.serviceDiscovery.<field>` is unset. Environments that set them explicitly (benedita dev-st sets both) are unchanged. `serviceDiscovery.env` has no merged consumer yet (midaz is the first), so no render regression.

Verified: with only `global.serviceDiscovery.address` set, the block now renders `SD_PREFER_VIEW: "internal"` + `SD_TLS_SKIP_VERIFY: "true"`. strict: 0 violations.