### PR TITLE
feat(pipe): add version compatibility matrix automation (tracer pilot)

### DIFF
--- a/.github/scripts/generate-compatibility/annotation.go
+++ b/.github/scripts/generate-compatibility/annotation.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -36,14 +38,21 @@ type CompatAnnotation struct {
 // parseCompatAnnotation is the SECOND step of the two-step unmarshal: the caller
 // has already pulled the annotation string out of Chart.yaml.annotations; here
 // we unmarshal that embedded YAML document. An empty/whitespace-only string
-// means "no annotation declared" and returns (nil, nil). Broken YAML returns an
-// error so the caller can emit a V1 WARN and continue (never aborts).
+// means "no annotation declared" and returns (nil, nil).
+//
+// KnownFields(true) makes unknown/typo top-level keys (e.g. "testedWih",
+// "require") a parse error instead of being silently dropped — otherwise a typo
+// would erase the declaration without warning. The caller surfaces the error as
+// a V1 WARN and continues (never aborts). An empty document yields io.EOF from
+// Decode, which we treat as "nothing declared" (empty ann, no error).
 func parseCompatAnnotation(raw string) (*CompatAnnotation, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
 	}
 	var ann CompatAnnotation
-	if err := yaml.Unmarshal([]byte(raw), &ann); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&ann); err != nil && err != io.EOF {
 		return nil, err
 	}
 	return &ann, nil

--- a/.github/scripts/generate-compatibility/annotation.go
+++ b/.github/scripts/generate-compatibility/annotation.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"gopkg.in/yaml.v3"
+)
+
+// compatAnnotationKey is the reverse-DNS annotation carrying compatibility data.
+// It follows the precedent of lerian.studio/chart-type
+// (validate-helm-charts/main.go:21).
+const compatAnnotationKey = "lerian.studio/compatibility"
+
+// chartTypeAnnotationKey is the pre-existing annotation every chart carries.
+// It decides whether a missing cross-compatibility declaration is worth an INFO
+// reminder: single-service charts are standalone and are NOT expected to declare
+// compatibility, so their absence is silent.
+const chartTypeAnnotationKey = "lerian.studio/chart-type"
+
+const (
+	chartTypeSingleService     = "single-service"
+	chartTypeMultiComponent    = "multi-component"
+	chartTypeDependencyWrapper = "dependency-wrapper"
+)
+
+// CompatAnnotation is the parsed representation of the embedded YAML in the
+// lerian.studio/compatibility annotation (data-model §A.1). Both maps are
+// optional in v1; a wholly absent annotation is represented by a nil pointer.
+type CompatAnnotation struct {
+	Requires   map[string]string `yaml:"requires"`
+	TestedWith map[string]string `yaml:"testedWith"`
+}
+
+// parseCompatAnnotation is the SECOND step of the two-step unmarshal: the caller
+// has already pulled the annotation string out of Chart.yaml.annotations; here
+// we unmarshal that embedded YAML document. An empty/whitespace-only string
+// means "no annotation declared" and returns (nil, nil). Broken YAML returns an
+// error so the caller can emit a V1 WARN and continue (never aborts).
+func parseCompatAnnotation(raw string) (*CompatAnnotation, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var ann CompatAnnotation
+	if err := yaml.Unmarshal([]byte(raw), &ann); err != nil {
+		return nil, err
+	}
+	return &ann, nil
+}
+
+// validateCompat applies rules V3–V6 (api-design §I.3) without ever failing.
+// V1 (valid YAML) and V2 (unknown keys) are handled by parseCompatAnnotation
+// and the typed struct respectively. knownProducts is the set of chart names
+// present in the repo, used for the V3 existence check.
+//
+// chartType (lerian.studio/chart-type) gates the V6 reminder for a MISSING
+// cross-compatibility declaration:
+//   - single-service        → standalone; no reminder (cross-compat N/A).
+//   - multi-component /
+//     dependency-wrapper     → INFO reminder when nothing is declared.
+//   - "" (missing)           → treated as multi-component (conservative) PLUS a
+//     WARN that the chart-type annotation is absent.
+//
+// A DECLARED compatibility is always validated (V3/V4/V5) regardless of type.
+func validateCompat(chart, chartType string, ann *CompatAnnotation, knownProducts map[string]bool) []Warning {
+	var out []Warning
+
+	if chartType == "" {
+		// chart-type should always be present; flag its absence and fall through
+		// as if multi-component (the stricter branch that still reminds on V6).
+		out = append(out, Warning{SevWarn, chart, "CT", "lerian.studio/chart-type annotation is missing; treating as multi-component"})
+		chartType = chartTypeMultiComponent
+	}
+
+	if ann == nil || (len(ann.Requires) == 0 && len(ann.TestedWith) == 0) {
+		// Nothing declared. Single-service charts are standalone and are not
+		// expected to declare cross-compatibility, so stay silent for them.
+		if chartType == chartTypeSingleService {
+			return out
+		}
+		// multi-component / dependency-wrapper: soft, non-blocking reminder.
+		out = append(out, Warning{
+			Severity: SevInfo,
+			Chart:    chart,
+			Rule:     "V6",
+			Detail:   "no compatibility declared (testedWith expected in v1)",
+		})
+		return out
+	}
+
+	// V3 + V4: requires.
+	for product, rng := range ann.Requires {
+		if !knownProducts[product] {
+			out = append(out, Warning{SevWarn, chart, "V3", fmt.Sprintf("requires[%s] — unknown chart", product)})
+		}
+		if _, err := semver.NewConstraint(rng); err != nil {
+			out = append(out, Warning{SevWarn, chart, "V4", fmt.Sprintf("requires[%s] — invalid semver range %q", product, rng)})
+		}
+	}
+
+	// V3 + V5: testedWith.
+	for product, ver := range ann.TestedWith {
+		if !knownProducts[product] {
+			out = append(out, Warning{SevWarn, chart, "V3", fmt.Sprintf("testedWith[%s] — unknown chart", product)})
+		}
+		if _, err := semver.NewVersion(ver); err != nil {
+			out = append(out, Warning{SevWarn, chart, "V5", fmt.Sprintf("testedWith[%s] — not an exact version %q", product, ver)})
+		}
+	}
+
+	return out
+}

--- a/.github/scripts/generate-compatibility/annotation_test.go
+++ b/.github/scripts/generate-compatibility/annotation_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCompatAnnotation(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		want      *CompatAnnotation
+		wantError bool
+	}{
+		{
+			name: "complete requires + testedWith",
+			raw: `requires:
+  midaz-helm: ">=8.4.0 <9.0.0"
+testedWith:
+  midaz-helm: "8.6.0"
+`,
+			want: &CompatAnnotation{
+				Requires:   map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"},
+				TestedWith: map[string]string{"midaz-helm": "8.6.0"},
+			},
+		},
+		{
+			name: "only testedWith (typical v1 post-backfill)",
+			raw: `testedWith:
+  midaz-helm: "8.6.0"
+`,
+			want: &CompatAnnotation{
+				TestedWith: map[string]string{"midaz-helm": "8.6.0"},
+			},
+		},
+		{
+			name: "empty string => nil (absent)",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name:      "broken embedded YAML => error (V1)",
+			raw:       "requires:\n  midaz-helm \">=8.4.0\"\n", // missing colon
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCompatAnnotation(tt.raw)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("err = %v, wantError = %v", err, tt.wantError)
+			}
+			if tt.wantError {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/.github/scripts/generate-compatibility/annotation_test.go
+++ b/.github/scripts/generate-compatibility/annotation_test.go
@@ -43,6 +43,16 @@ testedWith:
 			raw:       "requires:\n  midaz-helm \">=8.4.0\"\n", // missing colon
 			wantError: true,
 		},
+		{
+			name:      "unknown top-level field (typo 'testedWih') => error, not silent",
+			raw:       "testedWih:\n  midaz-helm: \"8.6.0\"\n",
+			wantError: true,
+		},
+		{
+			name:      "unknown top-level field (typo 'require') => error, not silent",
+			raw:       "require:\n  midaz-helm: \">=8.4.0\"\n",
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/.github/scripts/generate-compatibility/builddoc_test.go
+++ b/.github/scripts/generate-compatibility/builddoc_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeTagLister returns canned tags (and optional dates) per dir.
+type fakeTagLister struct {
+	tags  map[string][]string
+	dates map[string]map[string]string // dir -> (tag -> YYYY-MM-DD)
+}
+
+func (f fakeTagLister) listTags(dir string) ([]string, error) {
+	return f.tags[dir], nil
+}
+
+func (f fakeTagLister) listTagDates(dir string) (map[string]string, error) {
+	if f.dates == nil {
+		return map[string]string{}, nil
+	}
+	return f.dates[dir], nil
+}
+
+func TestBuildDoc_Golden(t *testing.T) {
+	root := t.TempDir()
+
+	// midaz: N=8.6.0, tags cover 8.6..8.2.
+	writeChart(t, root, "midaz", `apiVersion: v2
+name: midaz-helm
+type: application
+version: 8.6.0
+appVersion: "3.7.8"
+`)
+	// plugin-fees: N=7.2.0, only its own tag; declares requires+testedWith.
+	writeChart(t, root, "plugin-fees", `apiVersion: v2
+name: plugin-fees-helm
+type: application
+version: 7.2.0
+appVersion: "3.3.0"
+annotations:
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: ">=8.4.0 <9.0.0"
+    testedWith:
+      midaz-helm: "8.6.0"
+`)
+
+	lister := fakeTagLister{
+		tags: map[string][]string{
+			"midaz": {
+				"midaz-v8.6.0", "midaz-v8.5.0", "midaz-v8.4.0",
+				"midaz-v8.3.0", "midaz-v8.2.0", "midaz-v8.6.0-beta.11",
+			},
+			"plugin-fees": {"plugin-fees-v7.2.0"},
+		},
+		dates: map[string]map[string]string{
+			"midaz": {
+				"midaz-v8.6.0": "2026-06-01", "midaz-v8.5.0": "2026-05-01",
+				"midaz-v8.4.0": "2026-04-01", "midaz-v8.3.0": "2026-03-01",
+				"midaz-v8.2.0": "2026-02-01",
+			},
+			"plugin-fees": {"plugin-fees-v7.2.0": "2026-06-15"},
+		},
+	}
+
+	doc, err := buildDoc(root, lister, io.Discard)
+	if err != nil {
+		t.Fatalf("buildDoc: %v", err)
+	}
+	doc.GeneratedFrom = "test" // pin the provenance field for a stable golden
+
+	got, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "golden_two_products.json")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("update golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (run with UPDATE_GOLDEN=1 first): %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("JSON mismatch.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/.github/scripts/generate-compatibility/chart.go
+++ b/.github/scripts/generate-compatibility/chart.go
@@ -1,0 +1,36 @@
+// Command generate-compatibility produces the per-product support-window matrix
+// (README blocks + docs/compatibility.json) for the charts in this repo.
+//
+// It mirrors the sibling tools in .github/scripts (generate-values-schemas,
+// update-readme-matrix): invoked with --root ../.., reads the repo state, and
+// writes deterministic artifacts. No network access beyond the git tags already
+// present in the checkout.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// chartDirectories returns the names (not full paths) of the immediate
+// subdirectories of <root>/charts, sorted ascending. Loose files under charts/
+// are ignored. Mirrors validate-helm-charts/main.go:292-307 but returns bare
+// names (the caller joins paths), copied here because Go forbids importing one
+// package main from another.
+func chartDirectories(root string) ([]string, error) {
+	chartsRoot := filepath.Join(root, "charts")
+	entries, err := os.ReadDir(chartsRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}

--- a/.github/scripts/generate-compatibility/chart_test.go
+++ b/.github/scripts/generate-compatibility/chart_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeTree cria uma árvore charts/<name> temporária e devolve o root.
+func writeTree(t *testing.T, chartDirs []string, extraFiles map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	// Always create the charts/ root so the "empty charts dir" case exercises an
+	// existing-but-empty directory (returns []), not a missing one (returns err,
+	// which TestChartDirectories_MissingRoot covers separately).
+	if err := os.MkdirAll(filepath.Join(root, "charts"), 0o755); err != nil {
+		t.Fatalf("mkdir charts: %v", err)
+	}
+	for _, d := range chartDirs {
+		if err := os.MkdirAll(filepath.Join(root, "charts", d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	for rel, content := range extraFiles {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+func TestChartDirectories(t *testing.T) {
+	tests := []struct {
+		name      string
+		dirs      []string
+		extra     map[string]string
+		want      []string
+		wantError bool
+	}{
+		{
+			name: "sorted ascending, dirs only",
+			dirs: []string{"midaz", "plugin-fees", "br-spi"},
+			want: []string{"br-spi", "midaz", "plugin-fees"},
+		},
+		{
+			name:  "ignores loose files in charts/",
+			dirs:  []string{"midaz"},
+			extra: map[string]string{"charts/README.md": "x"},
+			want:  []string{"midaz"},
+		},
+		{
+			name: "empty charts dir returns empty slice",
+			dirs: []string{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeTree(t, tt.dirs, tt.extra)
+			got, err := chartDirectories(root)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("err = %v, wantError = %v", err, tt.wantError)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChartDirectories_MissingRoot(t *testing.T) {
+	_, err := chartDirectories(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing charts dir, got nil")
+	}
+}

--- a/.github/scripts/generate-compatibility/check_test.go
+++ b/.github/scripts/generate-compatibility/check_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRun_Check(t *testing.T) {
+	t.Run("in-sync repo => ok, exit 0, no WARN", func(t *testing.T) {
+		root := seedRepo(t)
+		// First write so disk matches expectation.
+		var w1out, w1err bytes.Buffer
+		if code := run([]string{"--root", root, "--output", "docs/compatibility.json"}, &w1out, &w1err); code != 0 {
+			t.Fatalf("seed write exit=%d err=%s", code, w1err.String())
+		}
+		// Now check: should be clean.
+		var out, errb bytes.Buffer
+		code := run([]string{"--check", "--root", root}, &out, &errb)
+		if code != 0 {
+			t.Fatalf("check exit = %d, want 0. stderr=%s", code, errb.String())
+		}
+		if !strings.Contains(out.String(), "ok") {
+			t.Errorf("stdout should say ok, got %q", out.String())
+		}
+		if strings.Contains(errb.String(), "stale") {
+			t.Errorf("unexpected drift WARN: %s", errb.String())
+		}
+	})
+
+	t.Run("drift => WARN on stderr, still exit 0", func(t *testing.T) {
+		root := seedRepo(t)
+		// Do NOT write first: disk README has no COMPAT block => drift.
+		var out, errb bytes.Buffer
+		code := run([]string{"--check", "--root", root}, &out, &errb)
+		if code != 0 {
+			t.Fatalf("check exit = %d, want 0 (non-blocking v1). stderr=%s", code, errb.String())
+		}
+		if !strings.Contains(errb.String(), "stale") {
+			t.Errorf("expected drift WARN with 'stale', got stderr=%q", errb.String())
+		}
+	})
+}

--- a/.github/scripts/generate-compatibility/ensure_test.go
+++ b/.github/scripts/generate-compatibility/ensure_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnsureCompatBlock(t *testing.T) {
+	body := []string{"| Version | Support |", "| :---: | :---: |", "| `1.0.0` | 🟢 |"}
+
+	t.Run("existing markers => replace path", func(t *testing.T) {
+		doc := strings.Split("### X\n\n<!-- BEGIN COMPAT:x-helm -->\nOLD\n<!-- END COMPAT:x-helm -->", "\n")
+		out, err := ensureCompatBlock(doc, "x-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := strings.Join(out, "\n")
+		if strings.Contains(s, "OLD") || !strings.Contains(s, "1.0.0") {
+			t.Errorf("replace path failed:\n%s", s)
+		}
+	})
+
+	t.Run("existing table => replaced IN PLACE (no duplicate), prose+heading kept", func(t *testing.T) {
+		doc := strings.Split("### Matcher\n\nExisting prose.\n\n#### Application Version Mapping\n\n| Chart Version | Matcher Version |\n| :---: | :---: |\n| `3.0.0` | 1.0.0 |\n\n-----------------", "\n")
+		out, err := ensureCompatBlock(doc, "matcher-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := strings.Join(out, "\n")
+		// Prose, heading and trailing separator preserved.
+		if !strings.Contains(s, "Existing prose.") {
+			t.Error("prose lost")
+		}
+		if !strings.Contains(s, "#### Application Version Mapping") {
+			t.Error("mapping heading lost")
+		}
+		if !strings.Contains(s, "-----------------") {
+			t.Error("trailing separator lost")
+		}
+		// Markers + new body present.
+		if !strings.Contains(s, "<!-- BEGIN COMPAT:matcher-helm -->") || !strings.Contains(s, "1.0.0") {
+			t.Errorf("markers/body not present:\n%s", s)
+		}
+		// The OLD simple table must be GONE (replaced in place, not duplicated).
+		if strings.Contains(s, "| Chart Version | Matcher Version |") {
+			t.Errorf("old table still present (duplicate!):\n%s", s)
+		}
+		// Exactly one marker pair.
+		if strings.Count(s, "<!-- BEGIN COMPAT:matcher-helm -->") != 1 ||
+			strings.Count(s, "<!-- END COMPAT:matcher-helm -->") != 1 {
+			t.Errorf("markers duplicated:\n%s", s)
+		}
+		// Block sits where the table was: AFTER the mapping heading, BEFORE the separator.
+		beginIdx := indexOfLine(out, "<!-- BEGIN COMPAT:matcher-helm -->")
+		headingIdx := indexOfLine(out, "#### Application Version Mapping")
+		sepIdx := indexOfLine(out, "-----------------")
+		if !(headingIdx != -1 && beginIdx > headingIdx && beginIdx < sepIdx) {
+			t.Errorf("block not placed at table location (heading=%d begin=%d sep=%d)", headingIdx, beginIdx, sepIdx)
+		}
+	})
+
+	t.Run("in-place replace is idempotent (run 1 converts table, run 2 swaps body)", func(t *testing.T) {
+		doc := strings.Split("### Matcher\n\nprose\n\n#### Application Version Mapping\n\n| Chart Version | Matcher Version |\n| :---: | :---: |\n| `3.0.0` | 1.0.0 |\n\n-----------------", "\n")
+		once, err := ensureCompatBlock(doc, "matcher-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		twice, err := ensureCompatBlock(once, "matcher-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Join(once, "\n") != strings.Join(twice, "\n") {
+			t.Fatalf("in-place path not idempotent:\n--once--\n%s\n--twice--\n%s", strings.Join(once, "\n"), strings.Join(twice, "\n"))
+		}
+		// No duplicate markers after two runs.
+		s := strings.Join(twice, "\n")
+		if strings.Count(s, "<!-- BEGIN COMPAT:matcher-helm -->") != 1 {
+			t.Errorf("markers duplicated after 2 runs:\n%s", s)
+		}
+	})
+
+	t.Run("no section (ADR-5 br-spi) => create minimal section at end", func(t *testing.T) {
+		doc := strings.Split("# Charts\n\n### Midaz Helm Chart\n\nprose", "\n")
+		out, err := ensureCompatBlock(doc, "br-spi-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := strings.Join(out, "\n")
+		if !strings.Contains(s, "### Br Spi") {
+			t.Errorf("minimal section title not created:\n%s", s)
+		}
+		if !strings.Contains(s, "<!-- BEGIN COMPAT:br-spi-helm -->") {
+			t.Error("markers not created")
+		}
+		if !strings.Contains(s, "prose") || !strings.Contains(s, "### Midaz Helm Chart") {
+			t.Error("existing content disturbed")
+		}
+	})
+
+	t.Run("idempotent across all paths", func(t *testing.T) {
+		doc := strings.Split("# Charts\n\n### Midaz Helm Chart\n\nprose", "\n")
+		once, _ := ensureCompatBlock(doc, "br-spi-helm", body)
+		twice, _ := ensureCompatBlock(once, "br-spi-helm", body)
+		if strings.Join(once, "\n") != strings.Join(twice, "\n") {
+			t.Fatalf("not idempotent:\n--once--\n%s\n--twice--\n%s", strings.Join(once, "\n"), strings.Join(twice, "\n"))
+		}
+	})
+}
+
+func indexOfLine(lines []string, want string) int {
+	for i, l := range lines {
+		if strings.TrimSpace(l) == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/.github/scripts/generate-compatibility/json.go
+++ b/.github/scripts/generate-compatibility/json.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// CompatDoc is the root of docs/compatibility.json (data-model §B.1).
+type CompatDoc struct {
+	SchemaVersion int                `json:"schemaVersion"`
+	GeneratedFrom string             `json:"generatedFrom"`
+	Products      map[string]Product `json:"products"`
+}
+
+// Product is one chart's projection (data-model §B.2).
+//
+// AppVersion is the Chart.yaml appVersion, carried in-memory as informational
+// context; it is intentionally NOT serialized (json:"-"). Note the README N-row
+// app-version cells are resolved from values.yaml {component}.image.tag (shared
+// tableutil logic, multi-column), NOT from this single field.
+type Product struct {
+	Dir        string  `json:"dir"`
+	Current    string  `json:"current"`
+	AppVersion string  `json:"-"`
+	Cycles     []Cycle `json:"cycles,omitempty"`
+}
+
+// Cycle is one minor-cycle line (data-model §B.3). There is no tier field:
+// the badge/tier is presentation, derived at render time, never persisted.
+// Released is the ISO (YYYY-MM-DD) date of the cycle's latest tag; it is an
+// additive optional field (schemaVersion stays 1) and is omitted when unknown.
+type Cycle struct {
+	Cycle      string            `json:"cycle"`
+	Latest     string            `json:"latest"`
+	Released   string            `json:"released,omitempty"`
+	Supported  bool              `json:"supported"`
+	Requires   map[string]string `json:"requires,omitempty"`
+	TestedWith map[string]string `json:"testedWith,omitempty"`
+}
+
+// renderJSON marshals the document deterministically (Go's encoding/json sorts
+// map keys) with two-space indent and a trailing newline, matching the sibling
+// generate-values-schemas output style.
+func renderJSON(doc CompatDoc) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(doc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/.github/scripts/generate-compatibility/json_test.go
+++ b/.github/scripts/generate-compatibility/json_test.go
@@ -79,7 +79,10 @@ func TestRenderJSON_OmitsEmptyRequiresTestedWith(t *testing.T) {
 			"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}}},
 		},
 	}
-	out, _ := renderJSON(doc)
+	out, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
 	s := string(out)
 	if strings.Contains(s, `"requires"`) || strings.Contains(s, `"testedWith"`) {
 		t.Fatalf("empty maps must be omitted (omitempty)\n%s", s)

--- a/.github/scripts/generate-compatibility/json_test.go
+++ b/.github/scripts/generate-compatibility/json_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderJSON_DeterministicAndSchemaV1(t *testing.T) {
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "test",
+		Products: map[string]Product{
+			"plugin-fees-helm": {Dir: "plugin-fees", Current: "7.2.0"},
+			"midaz-helm":       {Dir: "midaz", Current: "8.6.0"},
+		},
+	}
+
+	out1, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+	out2, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON (2nd): %v", err)
+	}
+	if string(out1) != string(out2) {
+		t.Fatal("renderJSON not deterministic across runs")
+	}
+
+	s := string(out1)
+	if !strings.Contains(s, `"schemaVersion": 1`) {
+		t.Errorf("missing schemaVersion:1\n%s", s)
+	}
+	// Products must be emitted in sorted key order: midaz-helm before plugin-fees-helm.
+	iMidaz := strings.Index(s, "midaz-helm")
+	iFees := strings.Index(s, "plugin-fees-helm")
+	if iMidaz == -1 || iFees == -1 || iMidaz > iFees {
+		t.Errorf("products not in sorted order\n%s", s)
+	}
+	if !strings.HasSuffix(s, "\n") {
+		t.Error("output must end with a trailing newline")
+	}
+}
+
+func TestRenderJSON_NoTierField(t *testing.T) {
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "test",
+		Products: map[string]Product{
+			"midaz-helm": {
+				Dir:     "midaz",
+				Current: "8.6.0",
+				Cycles: []Cycle{
+					{Cycle: "8.6", Latest: "8.6.0", Supported: true},
+					{Cycle: "8.2", Latest: "8.2.0", Supported: false},
+				},
+			},
+		},
+	}
+	out, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, `"tier"`) {
+		t.Fatalf("JSON must NOT contain a tier field (presentation-only)\n%s", s)
+	}
+	for _, must := range []string{`"cycle": "8.6"`, `"latest": "8.6.0"`, `"supported": true`, `"supported": false`} {
+		if !strings.Contains(s, must) {
+			t.Errorf("missing %q\n%s", must, s)
+		}
+	}
+}
+
+func TestRenderJSON_OmitsEmptyRequiresTestedWith(t *testing.T) {
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		Products: map[string]Product{
+			"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}}},
+		},
+	}
+	out, _ := renderJSON(doc)
+	s := string(out)
+	if strings.Contains(s, `"requires"`) || strings.Contains(s, `"testedWith"`) {
+		t.Fatalf("empty maps must be omitted (omitempty)\n%s", s)
+	}
+}

--- a/.github/scripts/generate-compatibility/main.go
+++ b/.github/scripts/generate-compatibility/main.go
@@ -58,6 +58,15 @@ func run(args []string, stdout, stderr io.Writer) int {
 // runWrite writes the JSON and README (chart filter applies to README only; the
 // JSON is always regenerated in full for determinism — api-design §II.1).
 func runWrite(root, output, chart string, doc CompatDoc, stdout, stderr io.Writer) int {
+	// Validate --chart BEFORE writing anything: an unknown chart is a usage error
+	// (exit 2), and must not leave a JSON written with no README touched.
+	if chart != "" {
+		if _, ok := doc.Products[chart]; !ok {
+			fmt.Fprintf(stderr, "ERROR unknown chart %q\n", chart)
+			return 2
+		}
+	}
+
 	data, err := renderJSON(doc)
 	if err != nil {
 		fmt.Fprintf(stderr, "ERROR marshal compatibility.json: %v\n", err)

--- a/.github/scripts/generate-compatibility/main.go
+++ b/.github/scripts/generate-compatibility/main.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run parses flags and executes the requested mode, returning the process exit
+// code (api-design §II.2): 0 success (incl. WARN), 1 environment/usage error
+// (unreadable root), 2 conflicting flags. stdout carries the operation result;
+// stderr carries diagnostics.
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("generate-compatibility", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	write := fs.Bool("write", false, "Write mode (default when no mode given)")
+	check := fs.Bool("check", false, "Check mode: detect drift without writing")
+	root := fs.String("root", "../..", "Repository root containing charts/")
+	chart := fs.String("chart", "", "Restrict README update to a single chart (JSON always full)")
+	output := fs.String("output", "docs/compatibility.json", "JSON destination, relative to --root")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "ERROR invalid flags: %v\n", err)
+		return 2
+	}
+
+	// Mode selection + conflict check.
+	if *write && *check {
+		fmt.Fprintln(stderr, "ERROR --write and --check are mutually exclusive")
+		return 2
+	}
+
+	// Environment check: root must be a readable directory with charts/.
+	if info, err := os.Stat(filepath.Join(*root, "charts")); err != nil || !info.IsDir() {
+		fmt.Fprintf(stderr, "ERROR --root %q has no readable charts/ directory\n", *root)
+		return 1
+	}
+
+	doc, err := buildDoc(*root, gitTagLister{root: *root}, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR %v\n", err)
+		return 1
+	}
+
+	if *check {
+		return runCheck(*root, *output, doc, stdout, stderr)
+	}
+	return runWrite(*root, *output, *chart, doc, stdout, stderr)
+}
+
+// runWrite writes the JSON and README (chart filter applies to README only; the
+// JSON is always regenerated in full for determinism — api-design §II.1).
+func runWrite(root, output, chart string, doc CompatDoc, stdout, stderr io.Writer) int {
+	data, err := renderJSON(doc)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR marshal compatibility.json: %v\n", err)
+		return 1
+	}
+	if err := os.WriteFile(filepath.Join(root, output), data, 0o644); err != nil {
+		fmt.Fprintf(stderr, "ERROR write %s: %v\n", output, err)
+		return 1
+	}
+
+	readmeDoc := doc
+	if chart != "" {
+		readmeDoc = filterProduct(doc, chart)
+	}
+	if err := writeReadme(root, readmeDoc, stderr); err != nil {
+		fmt.Fprintf(stderr, "ERROR write README.md: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "wrote %s and README.md (%d products)\n", output, len(doc.Products))
+	return 0
+}
+
+// filterProduct returns a copy of doc containing only the named product, so a
+// --chart run touches just that README block.
+func filterProduct(doc CompatDoc, chart string) CompatDoc {
+	filtered := CompatDoc{SchemaVersion: doc.SchemaVersion, GeneratedFrom: doc.GeneratedFrom, Products: map[string]Product{}}
+	if p, ok := doc.Products[chart]; ok {
+		filtered.Products[chart] = p
+	}
+	return filtered
+}
+
+// runCheck compares the expected JSON + README against what is on disk without
+// writing. Drift is reported as WARN on stderr but never fails the build in v1
+// (ADR-4): exit stays 0. A clean repo prints "ok".
+func runCheck(root, output string, doc CompatDoc, stdout, stderr io.Writer) int {
+	drift := false
+
+	// JSON drift.
+	expectedJSON, err := renderJSON(doc)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR marshal compatibility.json: %v\n", err)
+		return 1
+	}
+	actualJSON, err := os.ReadFile(filepath.Join(root, output))
+	if err != nil || string(actualJSON) != string(expectedJSON) {
+		fmt.Fprintf(stderr, "WARN %s: compatibility JSON is stale\n", output)
+		drift = true
+	}
+
+	// README drift: render expected README from the current one and compare.
+	readmePath := filepath.Join(root, "README.md")
+	current, err := os.ReadFile(readmePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR read README.md: %v\n", err)
+		return 1
+	}
+	// Render with a discarded stderr: check only reports drift, not the
+	// app-version WARNs (those surface during --write).
+	expectedLines, err := renderReadmeLines(root, strings.Split(string(current), "\n"), doc, io.Discard)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR render README: %v\n", err)
+		return 1
+	}
+	if strings.Join(expectedLines, "\n") != string(current) {
+		fmt.Fprintln(stderr, "WARN README.md: compatibility block is stale")
+		drift = true
+	}
+
+	if drift {
+		fmt.Fprintln(stdout, "drift detected (non-blocking v1)")
+	} else {
+		fmt.Fprintln(stdout, "ok")
+	}
+	return 0
+}
+
+// buildDoc reads every chart under <root>/charts and assembles the document,
+// emitting WARN/INFO diagnostics to stderr. It never aborts on data problems
+// (ADR-4); only environment errors (unreadable charts/ dir) propagate.
+func buildDoc(root string, lister tagLister, stderr io.Writer) (CompatDoc, error) {
+	dirs, err := chartDirectories(root)
+	if err != nil {
+		return CompatDoc{}, fmt.Errorf("list charts: %w", err)
+	}
+
+	// First pass: read all states so we know the full set of known products
+	// before running the V3 existence check.
+	states := make([]ChartState, 0, len(dirs))
+	knownProducts := map[string]bool{}
+	for _, dir := range dirs {
+		state, err := readChartState(root, dir)
+		var badAnn *badAnnotationError
+		switch {
+		case errors.As(err, &badAnn):
+			fmt.Fprintln(stderr, Warning{SevWarn, badAnn.chart, "V1", err.Error()}.Line())
+		case err != nil:
+			fmt.Fprintf(stderr, "WARN %s: cannot read Chart.yaml — %v\n", dir, err)
+			continue
+		}
+		if state.Name == "" {
+			fmt.Fprintf(stderr, "WARN %s: Chart.yaml has no name; skipping\n", dir)
+			continue
+		}
+		states = append(states, state)
+		knownProducts[state.Name] = true
+	}
+
+	// Second pass: validate annotations, resolve windows, and build the document.
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "local",
+		Products:      map[string]Product{},
+	}
+	for _, state := range states {
+		emitWarnings(stderr, validateCompat(state.Name, state.ChartType, state.Compat, knownProducts))
+
+		rawTags, err := lister.listTags(state.Dir)
+		if err != nil {
+			// A tag-listing failure degrades to "no tags" (window = only N),
+			// never an abort (ADR-3): N is authoritative.
+			fmt.Fprintf(stderr, "WARN %s: cannot list tags — %v\n", state.Dir, err)
+			rawTags = nil
+		}
+		tagVers := parseTags(state.Dir, rawTags)
+
+		// Release dates come from the same tags (creatordate). A failure here is
+		// non-fatal: cycles simply carry no Released (ADR-3, additive field).
+		tagDates, err := lister.listTagDates(state.Dir)
+		if err != nil {
+			fmt.Fprintf(stderr, "WARN %s: cannot read tag dates — %v\n", state.Dir, err)
+			tagDates = nil
+		}
+		releaseDates := releaseDatesByVersion(state.Dir, tagDates)
+
+		cycles, ws := resolveWindow(state.Version, tagVers, releaseDates)
+		emitWarnings(stderr, tagChart(state.Name, ws))
+
+		// Attach declared requires/testedWith to the N cycle (index 0), the only
+		// cycle whose cross-compatibility we know from the current Chart.yaml.
+		if len(cycles) > 0 && state.Compat != nil {
+			if len(state.Compat.Requires) > 0 {
+				cycles[0].Requires = state.Compat.Requires
+			}
+			if len(state.Compat.TestedWith) > 0 {
+				cycles[0].TestedWith = state.Compat.TestedWith
+			}
+		}
+
+		doc.Products[state.Name] = Product{
+			Dir:        state.Dir,
+			Current:    state.Version,
+			AppVersion: state.AppVersion,
+			Cycles:     cycles,
+		}
+	}
+
+	return doc, nil
+}
+
+// tagChart rewrites the Chart field of window warnings (which carry the raw
+// version string) to the product name, for a consistent WARN/INFO contract.
+func tagChart(name string, ws []Warning) []Warning {
+	for i := range ws {
+		ws[i].Chart = name
+	}
+	return ws
+}

--- a/.github/scripts/generate-compatibility/markers.go
+++ b/.github/scripts/generate-compatibility/markers.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// beginMarker / endMarker build the HTML-comment sentinels for a chart's block.
+// Only content strictly between them is ever rewritten (terraform-docs pattern),
+// which keeps hand-written prose and irregular separators intact.
+func beginMarker(chart string) string { return "<!-- BEGIN COMPAT:" + chart + " -->" }
+func endMarker(chart string) string   { return "<!-- END COMPAT:" + chart + " -->" }
+
+// replaceCompatBlock replaces the lines between the BEGIN/END markers for the
+// given chart with blockBody, preserving everything outside the markers exactly.
+// Returns found=false (and the document unchanged) when the BEGIN marker is
+// absent, so the caller can decide to create a section instead. Returns an error
+// for a malformed document (END without BEGIN, or BEGIN without END).
+func replaceCompatBlock(lines []string, chart string, blockBody []string) ([]string, bool, error) {
+	begin, end := beginMarker(chart), endMarker(chart)
+
+	beginIdx, endIdx := -1, -1
+	for i, line := range lines {
+		switch strings.TrimSpace(line) {
+		case begin:
+			beginIdx = i
+		case end:
+			endIdx = i
+		}
+	}
+
+	if beginIdx == -1 && endIdx == -1 {
+		return lines, false, nil
+	}
+	if beginIdx == -1 || endIdx == -1 || endIdx < beginIdx {
+		return nil, false, fmt.Errorf("malformed COMPAT markers for %q (begin=%d end=%d)", chart, beginIdx, endIdx)
+	}
+
+	out := make([]string, 0, len(lines)-(endIdx-beginIdx)+len(blockBody)+2)
+	out = append(out, lines[:beginIdx+1]...) // keep everything up to & including BEGIN
+	out = append(out, blockBody...)          // fresh body
+	out = append(out, lines[endIdx:]...)     // END marker onward, unchanged
+	return out, true, nil
+}
+
+// sectionHeaderIndex returns the line index of the "### <Name>" header for a
+// chart, or -1 if the chart has no section (e.g. br-spi — ADR-5). It reuses the
+// exact name-normalization contract of tableutil.ParseTableForChart so section
+// matching stays consistent with the sibling README tooling: strip -helm,
+// hyphens -> spaces, lowercase.
+func sectionHeaderIndex(lines []string, chart string) int {
+	normalized := strings.ToLower(strings.TrimSuffix(chart, "-helm"))
+	normalized = strings.ReplaceAll(normalized, "-", " ")
+
+	for i, line := range lines {
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "### ") && strings.Contains(lower, normalized) {
+			return i
+		}
+	}
+	return -1
+}
+
+// appLabelsFor extracts ALL app-version column labels used in a chart's section
+// mapping table, i.e. every "<X>" of a header "| Chart Version | <X> Version |
+// [<Y> Version...] | ... |" (e.g. ["Tracer"] or ["Fees", "UI"]). Preserving
+// every column means the enriched COMPAT block never drops an existing app
+// column (multi-app charts like plugin-fees).
+//
+// It scans only within the chart's section (its "### " header to the next
+// "### "/"---" boundary). Crucially it reads the FIRST "| Chart Version |"
+// header it finds — which, after the first run, is the header INSIDE the COMPAT
+// block (the original table was replaced in place). To stay idempotent it stops
+// collecting labels at the generated "Support" column (and never treats
+// "Support"/"Requer ..." as app columns), so run 1 (original table) and run 2+
+// (generated block) yield the identical label set. Returns the fallback
+// (title-cased chart name) when no mapping header exists.
+func appLabelsFor(lines []string, chart string) []string {
+	fallback := []string{sectionTitle(chart)}
+
+	start := sectionHeaderIndex(lines, chart)
+	if start == -1 {
+		return fallback
+	}
+	for i := start + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		// Stop at the next section boundary.
+		if strings.HasPrefix(trimmed, "### ") || strings.HasPrefix(trimmed, "---") {
+			break
+		}
+		// Match a header row of the form "| Chart Version | <X> Version | ... |".
+		if strings.HasPrefix(trimmed, "| Chart Version |") {
+			if labels := appLabelsFromHeader(trimmed); len(labels) > 0 {
+				return labels
+			}
+		}
+	}
+	return fallback
+}
+
+// appLabelsFromHeader pulls the app-version labels out of a "| Chart Version |
+// ... |" header row. It reads every column after "Chart Version" and stops at
+// the first generated column ("Released" or "Support", whichever comes first),
+// so a previously generated block header (which appends Released, Support and
+// optional "Requer <target>" columns) yields exactly the same labels as the
+// original mapping table — the key to idempotency.
+func appLabelsFromHeader(headerRow string) []string {
+	cells := splitTableCells(headerRow)
+	var labels []string
+	for _, cell := range cells[1:] { // skip "Chart Version"
+		cell = strings.TrimSpace(cell)
+		if cell == "" {
+			continue
+		}
+		if cell == releasedHeader || cell == "Support" || strings.HasPrefix(cell, requiresHeaderPrefix+" ") {
+			break // generated columns are not app labels
+		}
+		// Prefer the "<X> Version" convention; keep verbatim otherwise so we
+		// never silently drop a column we don't recognize.
+		if label := strings.TrimSpace(strings.TrimSuffix(cell, " Version")); label != "" && label != cell {
+			labels = append(labels, label)
+		} else {
+			labels = append(labels, cell)
+		}
+	}
+	return labels
+}
+
+// mappingTableRange locates the existing app-mapping markdown table inside a
+// chart's section and returns [tableStart, tableEnd) line indices (tableEnd is
+// exclusive), or (-1,-1) when the section or table is absent. The table is the
+// run of lines starting at the "| Chart Version |" header and continuing while
+// lines are table rows ("| ... |") — i.e. header + alignment separator + data
+// rows. Scanning is confined to the chart's section (its "### " header to the
+// next "### "/"---" boundary) so we never touch another chart's table. This is
+// the in-place replacement target: the enriched COMPAT block takes the table's
+// place, leaving the "#### Application Version Mapping" heading, prose, links and
+// trailing "-----------------" separator untouched.
+func mappingTableRange(lines []string, chart string) (int, int) {
+	start := sectionHeaderIndex(lines, chart)
+	if start == -1 {
+		return -1, -1
+	}
+	for i := start + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "### ") || strings.HasPrefix(trimmed, "---") {
+			return -1, -1 // left the section without finding a table
+		}
+		if strings.HasPrefix(trimmed, "| Chart Version |") {
+			tableStart := i
+			end := i + 1
+			for end < len(lines) {
+				t := strings.TrimSpace(lines[end])
+				if strings.HasPrefix(t, "|") && strings.Count(t, "|") > 1 {
+					end++
+					continue
+				}
+				break
+			}
+			return tableStart, end
+		}
+	}
+	return -1, -1
+}
+
+// splitTableCells splits a markdown table row "| a | b | c |" into ["a","b","c"].
+func splitTableCells(row string) []string {
+	trimmed := strings.Trim(strings.TrimSpace(row), "|")
+	parts := strings.Split(trimmed, "|")
+	cells := make([]string, 0, len(parts))
+	for _, p := range parts {
+		cells = append(cells, strings.TrimSpace(p))
+	}
+	return cells
+}
+
+// sectionTitle renders the human title used when a chart has no README section
+// (ADR-5): strip -helm, hyphens -> spaces, Title Case. e.g. "br-spi-helm" ->
+// "Br Spi". Mirrors the tableutil normalization, then title-cases for display.
+func sectionTitle(chart string) string {
+	base := strings.TrimSuffix(chart, "-helm")
+	words := strings.Split(strings.ReplaceAll(base, "-", " "), " ")
+	for i, w := range words {
+		if w == "" {
+			continue
+		}
+		words[i] = strings.ToUpper(w[:1]) + w[1:]
+	}
+	return strings.Join(words, " ")
+}
+
+// ensureCompatBlock guarantees the chart's COMPAT block reflects blockBody,
+// choosing one of four paths (all idempotent):
+//  1. markers already present -> replace their contents (replaceCompatBlock);
+//  2. an app-mapping table exists in the section -> replace THAT table in place
+//     with markers+body, so the "#### Application Version Mapping" heading, prose
+//     and trailing separator stay put and no duplicate table is created;
+//  3. section header present but no table -> inject markers+body just after the
+//     "### ..." header (rare: a section that never had a mapping table);
+//  4. no section (ADR-5) -> append a minimal section (title + block) at the end.
+func ensureCompatBlock(lines []string, chart string, blockBody []string) ([]string, error) {
+	// Path 1: markers exist -> replace their contents.
+	replaced, found, err := replaceCompatBlock(lines, chart, blockBody)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return replaced, nil
+	}
+
+	block := wrapBlock(chart, blockBody)
+
+	// Path 2: an existing app-mapping table -> replace it in place. This is the
+	// common first-run path and the fix for the duplicate-table bug: the markers
+	// wrap the location the original table occupied.
+	if ts, te := mappingTableRange(lines, chart); ts != -1 {
+		out := make([]string, 0, len(lines)-(te-ts)+len(block))
+		out = append(out, lines[:ts]...) // up to (not including) the old table
+		out = append(out, block...)      // markers + enriched table
+		out = append(out, lines[te:]...) // everything after the old table
+		return out, nil
+	}
+
+	// Path 3: section exists but has no mapping table -> inject after the header.
+	if idx := sectionHeaderIndex(lines, chart); idx != -1 {
+		out := make([]string, 0, len(lines)+len(block)+1)
+		out = append(out, lines[:idx+1]...) // through the "### ..." header
+		out = append(out, "")               // blank line after header
+		out = append(out, block...)
+		out = append(out, lines[idx+1:]...)
+		return out, nil
+	}
+
+	// Path 4: no section -> minimal section at end (ADR-5).
+	out := make([]string, 0, len(lines)+len(block)+3)
+	out = append(out, lines...)
+	out = append(out, "", "### "+sectionTitle(chart), "")
+	out = append(out, block...)
+	return out, nil
+}
+
+// wrapBlock frames blockBody with the BEGIN/END markers for a chart.
+func wrapBlock(chart string, blockBody []string) []string {
+	out := make([]string, 0, len(blockBody)+2)
+	out = append(out, beginMarker(chart))
+	out = append(out, blockBody...)
+	out = append(out, endMarker(chart))
+	return out
+}

--- a/.github/scripts/generate-compatibility/markers.go
+++ b/.github/scripts/generate-compatibility/markers.go
@@ -20,17 +20,26 @@ func replaceCompatBlock(lines []string, chart string, blockBody []string) ([]str
 	begin, end := beginMarker(chart), endMarker(chart)
 
 	beginIdx, endIdx := -1, -1
+	beginCount, endCount := 0, 0
 	for i, line := range lines {
 		switch strings.TrimSpace(line) {
 		case begin:
 			beginIdx = i
+			beginCount++
 		case end:
 			endIdx = i
+			endCount++
 		}
 	}
 
 	if beginIdx == -1 && endIdx == -1 {
 		return lines, false, nil
+	}
+	// Duplicate markers leave an orphan block on rewrite (last-wins overwrites),
+	// silently corrupting the section. Require exactly one pair; anything else is
+	// malformed and must be surfaced as an error, not papered over.
+	if beginCount > 1 || endCount > 1 {
+		return nil, false, fmt.Errorf("duplicate COMPAT markers for %q (begin=%d end=%d)", chart, beginCount, endCount)
 	}
 	if beginIdx == -1 || endIdx == -1 || endIdx < beginIdx {
 		return nil, false, fmt.Errorf("malformed COMPAT markers for %q (begin=%d end=%d)", chart, beginIdx, endIdx)

--- a/.github/scripts/generate-compatibility/markers.go
+++ b/.github/scripts/generate-compatibility/markers.go
@@ -81,7 +81,7 @@ func sectionHeaderIndex(lines []string, chart string) int {
 // header it finds — which, after the first run, is the header INSIDE the COMPAT
 // block (the original table was replaced in place). To stay idempotent it stops
 // collecting labels at the generated "Support" column (and never treats
-// "Support"/"Requer ..." as app columns), so run 1 (original table) and run 2+
+// "Support"/"Requires ..." as app columns), so run 1 (original table) and run 2+
 // (generated block) yield the identical label set. Returns the fallback
 // (title-cased chart name) when no mapping header exists.
 func appLabelsFor(lines []string, chart string) []string {
@@ -111,8 +111,13 @@ func appLabelsFor(lines []string, chart string) []string {
 // ... |" header row. It reads every column after "Chart Version" and stops at
 // the first generated column ("Released" or "Support", whichever comes first),
 // so a previously generated block header (which appends Released, Support and
-// optional "Requer <target>" columns) yields exactly the same labels as the
+// optional "Requires <target>" columns) yields exactly the same labels as the
 // original mapping table — the key to idempotency.
+//
+// It also treats the legacy Portuguese "Requer <target>" column as a generated
+// sentinel: a README whose block was produced before the "Requer"->"Requires"
+// rename must migrate cleanly (in-place rewrite) without the stale "Requer"
+// header ever being mistaken for an app-version column.
 func appLabelsFromHeader(headerRow string) []string {
 	cells := splitTableCells(headerRow)
 	var labels []string
@@ -121,8 +126,10 @@ func appLabelsFromHeader(headerRow string) []string {
 		if cell == "" {
 			continue
 		}
-		if cell == releasedHeader || cell == "Support" || strings.HasPrefix(cell, requiresHeaderPrefix+" ") {
-			break // generated columns are not app labels
+		if cell == releasedHeader || cell == "Support" ||
+			strings.HasPrefix(cell, requiresHeaderPrefix+" ") ||
+			strings.HasPrefix(cell, legacyRequiresHeaderPrefix+" ") {
+			break // generated columns (incl. legacy "Requer") are not app labels
 		}
 		// Prefer the "<X> Version" convention; keep verbatim otherwise so we
 		// never silently drop a column we don't recognize.

--- a/.github/scripts/generate-compatibility/markers_test.go
+++ b/.github/scripts/generate-compatibility/markers_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func lns(s string) []string  { return strings.Split(s, "\n") }
+func str(ls []string) string { return strings.Join(ls, "\n") }
+
+func TestReplaceCompatBlock(t *testing.T) {
+	t.Run("replaces only between markers, prose untouched", func(t *testing.T) {
+		doc := lns(`### Midaz Helm Chart
+
+Intro prose that must survive.
+
+<!-- BEGIN COMPAT:midaz-helm -->
+OLD CONTENT
+<!-- END COMPAT:midaz-helm -->
+
+-----------------
+
+### Next Chart`)
+		body := []string{"| Version | Support |", "| :---: | :---: |", "| `8.6.0` | 🟢 |"}
+		out, found, err := replaceCompatBlock(doc, "midaz-helm", body)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !found {
+			t.Fatal("expected found=true")
+		}
+		s := str(out)
+		if !strings.Contains(s, "Intro prose that must survive.") {
+			t.Error("prose above block was lost")
+		}
+		if !strings.Contains(s, "-----------------") {
+			t.Error("separator below block was lost")
+		}
+		if !strings.Contains(s, "### Next Chart") {
+			t.Error("next section header was lost")
+		}
+		if strings.Contains(s, "OLD CONTENT") {
+			t.Error("old content not replaced")
+		}
+		if !strings.Contains(s, "8.6.0") {
+			t.Error("new body not inserted")
+		}
+		// Markers themselves must be preserved exactly once each.
+		if strings.Count(s, "<!-- BEGIN COMPAT:midaz-helm -->") != 1 ||
+			strings.Count(s, "<!-- END COMPAT:midaz-helm -->") != 1 {
+			t.Errorf("markers duplicated/lost:\n%s", s)
+		}
+	})
+
+	t.Run("idempotent: applying twice yields identical output", func(t *testing.T) {
+		doc := lns(`<!-- BEGIN COMPAT:x -->
+whatever
+<!-- END COMPAT:x -->`)
+		body := []string{"NEW"}
+		once, _, _ := replaceCompatBlock(doc, "x", body)
+		twice, _, _ := replaceCompatBlock(once, "x", body)
+		if str(once) != str(twice) {
+			t.Fatalf("not idempotent:\n--once--\n%s\n--twice--\n%s", str(once), str(twice))
+		}
+	})
+
+	t.Run("markers absent => found=false, doc unchanged", func(t *testing.T) {
+		doc := lns("### Some Chart\n\nno markers here")
+		out, found, err := replaceCompatBlock(doc, "some-chart", []string{"BODY"})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if found {
+			t.Fatal("expected found=false")
+		}
+		if str(out) != str(doc) {
+			t.Fatal("doc changed despite absent markers")
+		}
+	})
+
+	t.Run("only END marker => error (malformed)", func(t *testing.T) {
+		doc := lns("<!-- END COMPAT:x -->")
+		_, _, err := replaceCompatBlock(doc, "x", []string{"B"})
+		if err == nil {
+			t.Fatal("expected error for END-without-BEGIN")
+		}
+	})
+}

--- a/.github/scripts/generate-compatibility/markers_test.go
+++ b/.github/scripts/generate-compatibility/markers_test.go
@@ -85,4 +85,31 @@ whatever
 			t.Fatal("expected error for END-without-BEGIN")
 		}
 	})
+
+	t.Run("duplicate BEGIN markers => error (malformed)", func(t *testing.T) {
+		doc := lns("<!-- BEGIN COMPAT:x -->\nA\n<!-- END COMPAT:x -->\n<!-- BEGIN COMPAT:x -->\nB\n<!-- END COMPAT:x -->")
+		_, _, err := replaceCompatBlock(doc, "x", []string{"NEW"})
+		if err == nil {
+			t.Fatal("expected error for duplicate COMPAT markers")
+		}
+		if !strings.Contains(err.Error(), "duplicate") {
+			t.Errorf("error should mention 'duplicate', got: %v", err)
+		}
+	})
+
+	t.Run("duplicate END markers => error (malformed)", func(t *testing.T) {
+		doc := lns("<!-- BEGIN COMPAT:x -->\nA\n<!-- END COMPAT:x -->\n<!-- END COMPAT:x -->")
+		_, _, err := replaceCompatBlock(doc, "x", []string{"NEW"})
+		if err == nil {
+			t.Fatal("expected error for duplicate END markers")
+		}
+	})
+
+	t.Run("exactly one pair => ok", func(t *testing.T) {
+		doc := lns("<!-- BEGIN COMPAT:x -->\nOLD\n<!-- END COMPAT:x -->")
+		_, found, err := replaceCompatBlock(doc, "x", []string{"NEW"})
+		if err != nil || !found {
+			t.Fatalf("single pair should be ok, got found=%v err=%v", found, err)
+		}
+	})
 }

--- a/.github/scripts/generate-compatibility/markers_test.go
+++ b/.github/scripts/generate-compatibility/markers_test.go
@@ -113,3 +113,45 @@ whatever
 		}
 	})
 }
+
+func TestAppLabelsFromHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   []string
+	}{
+		{
+			name:   "original mapping table (no generated columns)",
+			header: "| Chart Version | Fees Version | UI Version |",
+			want:   []string{"Fees", "UI"},
+		},
+		{
+			name:   "generated header with Released+Support cuts before them",
+			header: "| Chart Version | Fees Version | UI Version | Released | Support | Requires midaz-helm |",
+			want:   []string{"Fees", "UI"},
+		},
+		{
+			name:   "LEGACY generated header with Requer cuts before it (migration)",
+			header: "| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |",
+			want:   []string{"Fees", "UI"},
+		},
+		{
+			name:   "malformed legacy header without Released/Support still ignores Requer",
+			header: "| Chart Version | Fees Version | Requer midaz-helm |",
+			want:   []string{"Fees"},
+		},
+		{
+			name:   "malformed header without Released/Support still ignores Requires",
+			header: "| Chart Version | Fees Version | Requires midaz-helm |",
+			want:   []string{"Fees"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appLabelsFromHeader(tt.header)
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/.github/scripts/generate-compatibility/render_readme.go
+++ b/.github/scripts/generate-compatibility/render_readme.go
@@ -20,8 +20,14 @@ var supportLabel = []string{
 // eolSupportLabel is the single summary cell for all end-of-life cycles.
 const eolSupportLabel = "🔴 EOL"
 
-// requiresHeaderPrefix labels the optional cross-compat column.
-const requiresHeaderPrefix = "Requer"
+// requiresHeaderPrefix labels the optional cross-compat column. English, to
+// match the other generated headers (Chart Version, Released, Support).
+const requiresHeaderPrefix = "Requires"
+
+// legacyRequiresHeaderPrefix is the pre-i18n-fix Portuguese label. Kept only as
+// a sentinel so appLabelsFromHeader ignores a legacy generated header during the
+// in-place migration to "Requires".
+const legacyRequiresHeaderPrefix = "Requer"
 
 // cellUnknown is the placeholder ("—") used wherever we do not have a confident
 // value: historical/EOL app versions, historical/EOL requires cells, and extra
@@ -34,7 +40,7 @@ const cellUnknown = "—"
 // column labels already present in the chart's README section (e.g. ["Tracer"]
 // or ["Fees", "UI"]) so the enriched table never drops an existing column:
 //
-//	| Chart Version | <App1> Version | [<AppN> Version...] | Support | [Requer <target>...] |
+//	| Chart Version | <App1> Version | [<AppN> Version...] | Support | [Requires <target>...] |
 //
 // Rows are one per cycle (ordered descending, index 0 = N), Support driven by
 // position (Full/Security/Extended), and a single collapsed EOL row that
@@ -45,7 +51,7 @@ const cellUnknown = "—"
 //     appVersions[label] (resolved from values.yaml {component}.image.tag by the
 //     shared tableutil extractor); a column with no resolved tag stays "—".
 //   - Historical/EOL app versions are "—".
-//   - The Requer column carries the declared range only on the N row; N-1..N-3
+//   - The Requires column carries the declared range only on the N row; N-1..N-3
 //     and EOL are "—" (in v1 the dev declares requires for the current version
 //     only; history is filled by E2E in v2).
 //
@@ -79,7 +85,7 @@ func renderCompatTable(p Product, appLabels []string, appVersions map[string]str
 	}
 	sort.Strings(targets)
 
-	// Header: Chart Version | <App> Version... | Released | Support | [Requer <target>...]
+	// Header: Chart Version | <App> Version... | Released | Support | [Requires <target>...]
 	headers := []string{"Chart Version"}
 	for _, lbl := range appLabels {
 		headers = append(headers, lbl+" Version")
@@ -107,7 +113,7 @@ func renderCompatTable(p Product, appLabels []string, appVersions map[string]str
 		return cells
 	}
 
-	// requiresCells builds the Requer cells for a row. Only the N row carries the
+	// requiresCells builds the Requires cells for a row. Only the N row carries the
 	// declared range; N-1..N-3 (and EOL) are "—".
 	requiresCells := func(c *Cycle) []string {
 		cells := make([]string, len(targets))

--- a/.github/scripts/generate-compatibility/render_readme.go
+++ b/.github/scripts/generate-compatibility/render_readme.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// supportLabel maps a supported cycle's position (0=N, 1=N-1, ...) to its rich
+// Support-column cell: badge + tier label + N-offset (data-model §1). The tier
+// is presentation only — it is derived here from position, never persisted in
+// the JSON. Positions >=4 are never supported (they collapse into the EOL row).
+var supportLabel = []string{
+	"🟢 Full (N)",
+	"🔵 Security (N-1)",
+	"🟡 Extended (N-2)",
+	"🟠 Extended (N-3)",
+}
+
+// eolSupportLabel is the single summary cell for all end-of-life cycles.
+const eolSupportLabel = "🔴 EOL"
+
+// requiresHeaderPrefix labels the optional cross-compat column.
+const requiresHeaderPrefix = "Requer"
+
+// cellUnknown is the placeholder ("—") used wherever we do not have a confident
+// value: historical/EOL app versions, historical/EOL requires cells, and extra
+// app columns even on the N row (we only know one app version — the Chart.yaml
+// appVersion — so extra columns are never invented).
+const cellUnknown = "—"
+
+// renderCompatTable produces the enriched "Application Version Mapping" table
+// for one product, wrapped later in COMPAT markers. It reuses ALL app-version
+// column labels already present in the chart's README section (e.g. ["Tracer"]
+// or ["Fees", "UI"]) so the enriched table never drops an existing column:
+//
+//	| Chart Version | <App1> Version | [<AppN> Version...] | Support | [Requer <target>...] |
+//
+// Rows are one per cycle (ordered descending, index 0 = N), Support driven by
+// position (Full/Security/Extended), and a single collapsed EOL row that
+// references only the ceiling of the dead range as "≤ <highest EOL latest>".
+//
+// Value policy (no invention):
+//   - Only the N row carries real app versions. Each app column is filled from
+//     appVersions[label] (resolved from values.yaml {component}.image.tag by the
+//     shared tableutil extractor); a column with no resolved tag stays "—".
+//   - Historical/EOL app versions are "—".
+//   - The Requer column carries the declared range only on the N row; N-1..N-3
+//     and EOL are "—" (in v1 the dev declares requires for the current version
+//     only; history is filled by E2E in v2).
+//
+// appVersions maps app LABEL (e.g. "Fees") to its resolved current tag.
+func renderCompatTable(p Product, appLabels []string, appVersions map[string]string) []string {
+	if len(appLabels) == 0 {
+		// Defensive: always render at least one app-version column.
+		appLabels = []string{sectionTitle("")}
+	}
+
+	// Split supported vs EOL, preserving descending order.
+	var supported, eol []Cycle
+	for _, c := range p.Cycles {
+		if c.Supported {
+			supported = append(supported, c)
+		} else {
+			eol = append(eol, c)
+		}
+	}
+
+	// Distinct requires targets across supported cycles (sorted for determinism).
+	requireTargets := map[string]bool{}
+	for _, c := range supported {
+		for target := range c.Requires {
+			requireTargets[target] = true
+		}
+	}
+	var targets []string
+	for target := range requireTargets {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+
+	// Header: Chart Version | <App> Version... | Released | Support | [Requer <target>...]
+	headers := []string{"Chart Version"}
+	for _, lbl := range appLabels {
+		headers = append(headers, lbl+" Version")
+	}
+	headers = append(headers, releasedHeader, "Support")
+	for _, tgt := range targets {
+		headers = append(headers, fmt.Sprintf("%s %s", requiresHeaderPrefix, tgt))
+	}
+
+	lines := []string{tableRow(headers), separator(len(headers))}
+
+	// appCells builds the app-version cells for a row. Only the N row carries
+	// real values, one per app column resolved from values.yaml; a column with
+	// no resolved tag (and every historical/EOL cell) stays "—".
+	appCells := func(isN bool) []string {
+		cells := make([]string, len(appLabels))
+		for i, lbl := range appLabels {
+			cells[i] = cellUnknown
+			if isN {
+				if tag, ok := appVersions[lbl]; ok && tag != "" {
+					cells[i] = tag
+				}
+			}
+		}
+		return cells
+	}
+
+	// requiresCells builds the Requer cells for a row. Only the N row carries the
+	// declared range; N-1..N-3 (and EOL) are "—".
+	requiresCells := func(c *Cycle) []string {
+		cells := make([]string, len(targets))
+		for i, tgt := range targets {
+			if c != nil {
+				if rng, ok := c.Requires[tgt]; ok && rng != "" {
+					cells[i] = rng
+					continue
+				}
+			}
+			cells[i] = cellUnknown
+		}
+		return cells
+	}
+
+	// Supported rows.
+	for i := range supported {
+		c := supported[i]
+		label := eolSupportLabel
+		if i < len(supportLabel) {
+			label = supportLabel[i]
+		}
+		isN := i == 0
+
+		row := []string{"`" + c.Latest + "`"}
+		row = append(row, appCells(isN)...)
+		row = append(row, releasedCell(c.Released), label)
+		if isN {
+			row = append(row, requiresCells(&c)...)
+		} else {
+			row = append(row, requiresCells(nil)...)
+		}
+		lines = append(lines, tableRow(row))
+	}
+
+	// Single collapsed EOL summary line: reference only the ceiling of the dead
+	// range ("≤ <highest EOL latest>"), never the full cycle list. eol[0] is the
+	// highest EOL cycle because cycles arrive ordered descending.
+	if len(eol) > 0 {
+		row := []string{"`≤ " + eol[0].Latest + "`"}
+		row = append(row, appCells(false)...)
+		// Released is "—" for the EOL row: it aggregates multiple versions.
+		row = append(row, cellUnknown, eolSupportLabel)
+		row = append(row, requiresCells(nil)...)
+		lines = append(lines, tableRow(row))
+	}
+
+	return lines
+}
+
+// releasedHeader is the column title for the release date (before Support).
+const releasedHeader = "Released"
+
+// releasedCell renders a cycle's release-date cell: the ISO date, or "—" when
+// unknown (e.g. a just-created N with no published tag yet).
+func releasedCell(date string) string {
+	if date == "" {
+		return cellUnknown
+	}
+	return date
+}
+
+func tableRow(cells []string) string {
+	return "| " + strings.Join(cells, " | ") + " |"
+}
+
+func separator(n int) string {
+	seps := make([]string, n)
+	for i := range seps {
+		seps[i] = ":---:"
+	}
+	return "| " + strings.Join(seps, " | ") + " |"
+}

--- a/.github/scripts/generate-compatibility/render_readme_test.go
+++ b/.github/scripts/generate-compatibility/render_readme_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func joined(lines []string) string { return strings.Join(lines, "\n") }
+
+func TestRenderCompatTable(t *testing.T) {
+	t.Run("single app col, Released before Support, EOL ceiling row", func(t *testing.T) {
+		p := Product{
+			Dir: "midaz", Current: "8.6.0",
+			Cycles: []Cycle{
+				{Cycle: "8.6", Latest: "8.6.0", Released: "2026-06-01", Supported: true},
+				{Cycle: "8.5", Latest: "8.5.0", Released: "2026-05-01", Supported: true},
+				{Cycle: "8.4", Latest: "8.4.0", Released: "2026-04-01", Supported: true},
+				{Cycle: "8.3", Latest: "8.3.0", Released: "2026-03-01", Supported: true},
+				{Cycle: "8.2", Latest: "8.2.0", Released: "2026-02-01", Supported: false},
+				{Cycle: "8.1", Latest: "8.1.0", Released: "2026-01-01", Supported: false},
+			},
+		}
+		out := joined(renderCompatTable(p, []string{"Midaz"}, map[string]string{"Midaz": "3.7.8"}))
+		for _, must := range []string{
+			"| Chart Version | Midaz Version | Released | Support |",
+			"| :---: | :---: | :---: | :---: |",
+			"| `8.6.0` | 3.7.8 | 2026-06-01 | 🟢 Full (N) |",
+			"| `8.5.0` | — | 2026-05-01 | 🔵 Security (N-1) |",
+			"| `8.4.0` | — | 2026-04-01 | 🟡 Extended (N-2) |",
+			"| `8.3.0` | — | 2026-03-01 | 🟠 Extended (N-3) |",
+		} {
+			if !strings.Contains(out, must) {
+				t.Errorf("missing %q in:\n%s", must, out)
+			}
+		}
+		// EOL row: ceiling reference, Released = — (aggregate).
+		if !strings.Contains(out, "| `≤ 8.2.0` | — | — | 🔴 EOL |") {
+			t.Errorf("expected EOL ceiling row with Released=— , got:\n%s", out)
+		}
+		if strings.Contains(out, "8.1") {
+			t.Errorf("EOL row must not list lower cycles (8.1 leaked):\n%s", out)
+		}
+		if strings.Count(out, "🔴") != 1 {
+			t.Errorf("expected exactly one EOL (🔴) line, got %d\n%s", strings.Count(out, "🔴"), out)
+		}
+	})
+
+	t.Run("multi app cols + Released + Requer coexist", func(t *testing.T) {
+		p := Product{
+			Dir: "plugin-fees", Current: "7.2.0",
+			Cycles: []Cycle{
+				{Cycle: "7.2", Latest: "7.2.0", Released: "2026-06-15", Supported: true,
+					Requires: map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"}},
+				{Cycle: "7.1", Latest: "7.1.0", Released: "2026-05-10", Supported: true},
+			},
+		}
+		out := joined(renderCompatTable(p, []string{"Fees", "UI"}, map[string]string{"Fees": "3.3.0", "UI": "3.0.0"}))
+		if !strings.Contains(out, "| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |") {
+			t.Errorf("multi-app + Released + Requer header wrong:\n%s", out)
+		}
+		// N row: both app cols filled, Released set, Requer = real range.
+		if !strings.Contains(out, "| `7.2.0` | 3.3.0 | 3.0.0 | 2026-06-15 | 🟢 Full (N) | >=8.4.0 <9.0.0 |") {
+			t.Errorf("N row wrong:\n%s", out)
+		}
+		// N-1 row: app cols —, Released set (its own tag date), Requer —.
+		if !strings.Contains(out, "| `7.1.0` | — | — | 2026-05-10 | 🔵 Security (N-1) | — |") {
+			t.Errorf("N-1 row wrong:\n%s", out)
+		}
+	})
+
+	t.Run("unknown release date => Released — ; unresolved app col => — even on N", func(t *testing.T) {
+		p := Product{
+			Dir: "plugin-fees", Current: "7.2.0",
+			Cycles: []Cycle{{Cycle: "7.2", Latest: "7.2.0", Supported: true}}, // no Released
+		}
+		out := joined(renderCompatTable(p, []string{"Fees", "UI"}, map[string]string{"Fees": "3.3.0"}))
+		if !strings.Contains(out, "| `7.2.0` | 3.3.0 | — | — | 🟢 Full (N) |") {
+			t.Errorf("expected UI=— and Released=— on N, got:\n%s", out)
+		}
+	})
+
+	t.Run("no requires => no Requer column (tracer pilot shape) with Released", func(t *testing.T) {
+		p := Product{
+			Dir: "tracer", Current: "2.1.0",
+			Cycles: []Cycle{
+				{Cycle: "2.1", Latest: "2.1.0", Released: "2026-06-18", Supported: true},
+				{Cycle: "2.0", Latest: "2.0.0", Released: "2026-06-09", Supported: true},
+				{Cycle: "1.0", Latest: "1.0.0", Released: "2026-01-30", Supported: true},
+			},
+		}
+		out := joined(renderCompatTable(p, []string{"Tracer"}, map[string]string{"Tracer": "1.0.0"}))
+		if strings.Contains(out, "Requer") {
+			t.Errorf("did not expect Requer column, got:\n%s", out)
+		}
+		if !strings.Contains(out, "| Chart Version | Tracer Version | Released | Support |") {
+			t.Errorf("expected Tracer header with Released, got:\n%s", out)
+		}
+		if !strings.Contains(out, "| `2.1.0` | 1.0.0 | 2026-06-18 | 🟢 Full (N) |") {
+			t.Errorf("expected N row, got:\n%s", out)
+		}
+		if !strings.Contains(out, "| `2.0.0` | — | 2026-06-09 | 🔵 Security (N-1) |") {
+			t.Errorf("expected N-1 row, got:\n%s", out)
+		}
+		if !strings.Contains(out, "| `1.0.0` | — | 2026-01-30 | 🟡 Extended (N-2) |") {
+			t.Errorf("expected N-2 row, got:\n%s", out)
+		}
+		if strings.Contains(out, "🔴") {
+			t.Errorf("all supported => no EOL line, got:\n%s", out)
+		}
+	})
+}

--- a/.github/scripts/generate-compatibility/render_readme_test.go
+++ b/.github/scripts/generate-compatibility/render_readme_test.go
@@ -45,7 +45,7 @@ func TestRenderCompatTable(t *testing.T) {
 		}
 	})
 
-	t.Run("multi app cols + Released + Requer coexist", func(t *testing.T) {
+	t.Run("multi app cols + Released + Requires coexist", func(t *testing.T) {
 		p := Product{
 			Dir: "plugin-fees", Current: "7.2.0",
 			Cycles: []Cycle{
@@ -55,14 +55,14 @@ func TestRenderCompatTable(t *testing.T) {
 			},
 		}
 		out := joined(renderCompatTable(p, []string{"Fees", "UI"}, map[string]string{"Fees": "3.3.0", "UI": "3.0.0"}))
-		if !strings.Contains(out, "| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |") {
-			t.Errorf("multi-app + Released + Requer header wrong:\n%s", out)
+		if !strings.Contains(out, "| Chart Version | Fees Version | UI Version | Released | Support | Requires midaz-helm |") {
+			t.Errorf("multi-app + Released + Requires header wrong:\n%s", out)
 		}
-		// N row: both app cols filled, Released set, Requer = real range.
+		// N row: both app cols filled, Released set, Requires = real range.
 		if !strings.Contains(out, "| `7.2.0` | 3.3.0 | 3.0.0 | 2026-06-15 | 🟢 Full (N) | >=8.4.0 <9.0.0 |") {
 			t.Errorf("N row wrong:\n%s", out)
 		}
-		// N-1 row: app cols —, Released set (its own tag date), Requer —.
+		// N-1 row: app cols —, Released set (its own tag date), Requires —.
 		if !strings.Contains(out, "| `7.1.0` | — | — | 2026-05-10 | 🔵 Security (N-1) | — |") {
 			t.Errorf("N-1 row wrong:\n%s", out)
 		}
@@ -79,7 +79,7 @@ func TestRenderCompatTable(t *testing.T) {
 		}
 	})
 
-	t.Run("no requires => no Requer column (tracer pilot shape) with Released", func(t *testing.T) {
+	t.Run("no requires => no Requires column (tracer pilot shape) with Released", func(t *testing.T) {
 		p := Product{
 			Dir: "tracer", Current: "2.1.0",
 			Cycles: []Cycle{
@@ -89,8 +89,8 @@ func TestRenderCompatTable(t *testing.T) {
 			},
 		}
 		out := joined(renderCompatTable(p, []string{"Tracer"}, map[string]string{"Tracer": "1.0.0"}))
-		if strings.Contains(out, "Requer") {
-			t.Errorf("did not expect Requer column, got:\n%s", out)
+		if strings.Contains(out, "Requires") {
+			t.Errorf("did not expect Requires column, got:\n%s", out)
 		}
 		if !strings.Contains(out, "| Chart Version | Tracer Version | Released | Support |") {
 			t.Errorf("expected Tracer header with Released, got:\n%s", out)

--- a/.github/scripts/generate-compatibility/resolve_test.go
+++ b/.github/scripts/generate-compatibility/resolve_test.go
@@ -180,11 +180,11 @@ func TestResolveWindow(t *testing.T) {
 		}
 	})
 
-	t.Run("only pre-release tags => INFO with pre-release message, window = only N", func(t *testing.T) {
+	t.Run("only pre-release tags => INFO (degraded), window = only N", func(t *testing.T) {
 		// N=2.0.0 but every tag is a pre-release: segregateStable filters them all,
 		// leaving only the forced N cycle. This is the same degraded state as "0
-		// tags" and must emit an INFO — with a message that says pre-release, not
-		// "no published tags".
+		// tags" and must emit an INFO — but NOT the "no published tags" message,
+		// because tags do exist.
 		cs, ws := resolveWindow("2.0.0", tagVers(t, "2.0.0-beta.1", "1.0.0-beta.2"), nil)
 		if len(cs) != 1 || cs[0].Cycle != "2.0" || cs[0].Latest != "2.0.0" || !cs[0].Supported {
 			t.Fatalf("expected single N cycle, got %+v", cs)
@@ -192,27 +192,32 @@ func TestResolveWindow(t *testing.T) {
 		if !hasINFO(ws) {
 			t.Fatalf("expected INFO for all-pre-release tags, got %+v", ws)
 		}
-		var infoMsg string
-		for _, w := range ws {
-			if w.Severity == SevInfo {
-				infoMsg = w.Detail
-			}
+		if strings.Contains(infoDetail(ws), "no published tags") {
+			t.Errorf("should NOT use 'no published tags' when tags exist, got %q", infoDetail(ws))
 		}
-		if !strings.Contains(infoMsg, "pre-release") {
-			t.Errorf("INFO message should mention pre-release, got %q", infoMsg)
+	})
+
+	t.Run("all STABLE tags above N => INFO (degraded), window = only N", func(t *testing.T) {
+		// N=8.6.0 but the only stable tags are 8.7.0 and 8.8.0 (both above N).
+		// byMinor has 2 entries, yet the "never exceed N" filter drops both, so the
+		// window is only the forced N cycle. The INFO MUST fire (regression of the
+		// same class as bug #8: counting cycles at the wrong moment).
+		cs, ws := resolveWindow("8.6.0", tagVers(t, "8.7.0", "8.8.0"), nil)
+		if len(cs) != 1 || cs[0].Cycle != "8.6" || cs[0].Latest != "8.6.0" || !cs[0].Supported {
+			t.Fatalf("expected single N cycle 8.6, got %+v", cs)
+		}
+		if !hasINFO(ws) {
+			t.Fatalf("expected INFO when all stable tags are above N, got %+v", ws)
+		}
+		if strings.Contains(infoDetail(ws), "no published tags") {
+			t.Errorf("should NOT use 'no published tags' when tags exist, got %q", infoDetail(ws))
 		}
 	})
 
 	t.Run("0 tags keeps the 'no published tags' message", func(t *testing.T) {
 		_, ws := resolveWindow("1.0.0", tagVers(t), nil)
-		var infoMsg string
-		for _, w := range ws {
-			if w.Severity == SevInfo {
-				infoMsg = w.Detail
-			}
-		}
-		if !strings.Contains(infoMsg, "no published tags") {
-			t.Errorf("expected 'no published tags' message, got %q", infoMsg)
+		if !strings.Contains(infoDetail(ws), "no published tags") {
+			t.Errorf("expected 'no published tags' message, got %q", infoDetail(ws))
 		}
 	})
 
@@ -281,6 +286,17 @@ func hasINFO(ws []Warning) bool {
 		}
 	}
 	return false
+}
+
+// infoDetail returns the Detail of the last INFO warning (or "" if none).
+func infoDetail(ws []Warning) string {
+	var d string
+	for _, w := range ws {
+		if w.Severity == SevInfo {
+			d = w.Detail
+		}
+	}
+	return d
 }
 
 func assertNoINFO(t *testing.T, ws []Warning) {

--- a/.github/scripts/generate-compatibility/resolve_test.go
+++ b/.github/scripts/generate-compatibility/resolve_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func tagVers(t *testing.T, ss ...string) []*semver.Version {
+	t.Helper()
+	out := make([]*semver.Version, 0, len(ss))
+	for _, s := range ss {
+		v, err := semver.NewVersion(s)
+		if err != nil {
+			t.Fatalf("bad version %q: %v", s, err)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// cyclePairs flattens []Cycle to a compact [cycle, latest, supported] view.
+func cyclePairs(cs []Cycle) []struct {
+	cycle     string
+	latest    string
+	supported bool
+} {
+	out := make([]struct {
+		cycle     string
+		latest    string
+		supported bool
+	}, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, struct {
+			cycle     string
+			latest    string
+			supported bool
+		}{c.Cycle, c.Latest, c.Supported})
+	}
+	return out
+}
+
+func TestResolveWindow(t *testing.T) {
+	t.Run("N=8.6.0 with 8.6..8.2 => top-4 supported, 8.2 unsupported", func(t *testing.T) {
+		cs, ws := resolveWindow("8.6.0", tagVers(t,
+			"8.6.0", "8.5.0", "8.4.0", "8.3.0", "8.2.0"), nil)
+		got := cyclePairs(cs)
+		want := [][3]string{
+			{"8.6", "8.6.0", "true"},
+			{"8.5", "8.5.0", "true"},
+			{"8.4", "8.4.0", "true"},
+			{"8.3", "8.3.0", "true"},
+			{"8.2", "8.2.0", "false"},
+		}
+		assertCycles(t, got, want)
+		assertNoINFO(t, ws)
+	})
+
+	t.Run("N authoritative: chart=8.6.0 but tags stale at 8.5 => N cycle still present & supported", func(t *testing.T) {
+		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.5.0", "8.4.0"), nil)
+		got := cyclePairs(cs)
+		// N=8.6 must appear as top cycle, supported, latest=8.6.0 (from Chart.yaml).
+		if got[0].cycle != "8.6" || got[0].supported != true || got[0].latest != "8.6.0" {
+			t.Fatalf("N cycle wrong: %+v", got[0])
+		}
+	})
+
+	t.Run("0 tags => only N cycle + INFO", func(t *testing.T) {
+		cs, ws := resolveWindow("1.0.0", tagVers(t), nil)
+		if len(cs) != 1 || cs[0].Cycle != "1.0" || !cs[0].Supported || cs[0].Latest != "1.0.0" {
+			t.Fatalf("expected single supported N cycle, got %+v", cs)
+		}
+		if !hasINFO(ws) {
+			t.Fatal("expected INFO warning for 0 tags")
+		}
+	})
+
+	t.Run("<4 minors => only existing", func(t *testing.T) {
+		cs, _ := resolveWindow("3.0.0", tagVers(t, "3.0.0", "2.9.0"), nil)
+		got := cyclePairs(cs)
+		want := [][3]string{
+			{"3.0", "3.0.0", "true"},
+			{"2.9", "2.9.0", "true"},
+		}
+		assertCycles(t, got, want)
+	})
+
+	t.Run("pre-release tag is ignored, does not create a cycle", func(t *testing.T) {
+		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.6.0-beta.11", "8.6.0", "8.5.0"), nil)
+		for _, c := range cs {
+			if c.Cycle == "8.6" && c.Latest != "8.6.0" {
+				t.Fatalf("pre-release leaked into cycle: %+v", c)
+			}
+		}
+		if len(cs) != 2 {
+			t.Fatalf("expected 2 cycles (8.6, 8.5), got %d: %+v", len(cs), cs)
+		}
+	})
+
+	t.Run("higher tag than N is dropped (never exceeds N)", func(t *testing.T) {
+		// A tag 8.7.0 exists but Chart.yaml says N=8.6.0: 8.7 must NOT appear.
+		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.7.0", "8.6.0", "8.5.0"), nil)
+		for _, c := range cs {
+			if c.Cycle == "8.7" {
+				t.Fatalf("cycle above N leaked in: %+v", cs)
+			}
+		}
+		if cs[0].Cycle != "8.6" {
+			t.Fatalf("top cycle should be N=8.6, got %q", cs[0].Cycle)
+		}
+	})
+
+	// Real pilot case: tracer N=2.1.0. Stable tags 1.0.0/2.0.0/2.1.0 plus many
+	// betas plus 2.2.0-beta.1 (a pre-release ABOVE N). Expect exactly the three
+	// stable minors, all supported (<4), no EOL, and no INFO (tags exist).
+	t.Run("tracer pilot: N=2.1.0, betas + 2.2.0-beta.1 above N discarded", func(t *testing.T) {
+		cs, ws := resolveWindow("2.1.0", tagVers(t,
+			"1.0.0", "1.0.0-beta.1",
+			"2.0.0", "2.0.0-beta.1", "2.0.0-beta.2", "2.0.0-beta.3",
+			"2.0.0-beta.4", "2.0.0-beta.5", "2.0.0-beta.6", "2.0.0-beta.7",
+			"2.1.0", "2.1.0-beta.1", "2.1.0-beta.2",
+			"2.2.0-beta.1"), nil)
+		got := cyclePairs(cs)
+		want := [][3]string{
+			{"2.1", "2.1.0", "true"},
+			{"2.0", "2.0.0", "true"},
+			{"1.0", "1.0.0", "true"},
+		}
+		assertCycles(t, got, want)
+		assertNoINFO(t, ws)
+	})
+
+	t.Run("release dates associate to each cycle by its latest version", func(t *testing.T) {
+		dates := map[string]string{
+			"2.1.0": "2026-06-18",
+			"2.0.0": "2026-06-09",
+			"1.0.0": "2026-01-30",
+			// 2.2.0-beta.1 date intentionally present but must be ignored (pre-release).
+			"2.2.0-beta.1": "2026-07-01",
+		}
+		cs, _ := resolveWindow("2.1.0", tagVers(t, "1.0.0", "2.0.0", "2.1.0", "2.2.0-beta.1"), dates)
+		want := map[string]string{"2.1": "2026-06-18", "2.0": "2026-06-09", "1.0": "2026-01-30"}
+		if len(cs) != 3 {
+			t.Fatalf("expected 3 cycles, got %d: %+v", len(cs), cs)
+		}
+		for _, c := range cs {
+			if c.Released != want[c.Cycle] {
+				t.Errorf("cycle %s Released = %q, want %q", c.Cycle, c.Released, want[c.Cycle])
+			}
+		}
+	})
+
+	t.Run("cycle with no known date has empty Released", func(t *testing.T) {
+		// N=5.0.0 with a tag but no date entry => Released stays "".
+		cs, _ := resolveWindow("5.0.0", tagVers(t, "5.0.0"), map[string]string{})
+		if len(cs) != 1 || cs[0].Released != "" {
+			t.Fatalf("expected empty Released, got %+v", cs)
+		}
+	})
+}
+
+func TestParseTagDates(t *testing.T) {
+	raw := "tracer-v2.1.0 2026-06-18\ntracer-v2.0.0 2026-06-09\n\ntracer-v1.0.0\nmalformed-line-no-space\n"
+	got := parseTagDates(raw)
+	if got["tracer-v2.1.0"] != "2026-06-18" || got["tracer-v2.0.0"] != "2026-06-09" {
+		t.Errorf("dates not parsed: %v", got)
+	}
+	// A tag with no date field is omitted.
+	if _, ok := got["tracer-v1.0.0"]; ok {
+		t.Errorf("expected tracer-v1.0.0 omitted (no date), got %v", got)
+	}
+}
+
+func TestReleaseDatesByVersion(t *testing.T) {
+	in := map[string]string{
+		"tracer-v2.1.0":       "2026-06-18",
+		"tracer-v2.2.0-beta.1": "2026-07-01",
+		"other-v1.0.0":         "2020-01-01", // wrong prefix, ignored
+		"tracer-vNOTSEMVER":    "2020-01-01", // unparseable, ignored
+	}
+	got := releaseDatesByVersion("tracer", in)
+	if got["2.1.0"] != "2026-06-18" {
+		t.Errorf("2.1.0 date = %q", got["2.1.0"])
+	}
+	if got["2.2.0-beta.1"] != "2026-07-01" {
+		t.Errorf("pre-release date should still map by version string: %v", got)
+	}
+	if _, ok := got["1.0.0"]; ok {
+		t.Errorf("other-dir tag leaked: %v", got)
+	}
+}
+
+func assertCycles(t *testing.T, got []struct {
+	cycle     string
+	latest    string
+	supported bool
+}, want [][3]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d cycles, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		sup := w[2] == "true"
+		if got[i].cycle != w[0] || got[i].latest != w[1] || got[i].supported != sup {
+			t.Errorf("cycle %d: got {%s %s %v}, want {%s %s %v}",
+				i, got[i].cycle, got[i].latest, got[i].supported, w[0], w[1], sup)
+		}
+	}
+}
+
+func hasINFO(ws []Warning) bool {
+	for _, w := range ws {
+		if w.Severity == SevInfo {
+			return true
+		}
+	}
+	return false
+}
+
+func assertNoINFO(t *testing.T, ws []Warning) {
+	t.Helper()
+	if hasINFO(ws) {
+		t.Errorf("unexpected INFO: %+v", ws)
+	}
+}

--- a/.github/scripts/generate-compatibility/resolve_test.go
+++ b/.github/scripts/generate-compatibility/resolve_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -97,6 +98,35 @@ func TestResolveWindow(t *testing.T) {
 		}
 	})
 
+	t.Run("patch ABOVE N in the same minor must NOT erase the N cycle", func(t *testing.T) {
+		// N=8.6.0 (nKey 8.6). A stray tag 8.6.1 (patch above N, same minor) must
+		// not hijack the 8.6 slot and then get dropped, which would delete the N
+		// cycle entirely. N is authoritative from Chart.yaml: the 8.6 cycle must
+		// exist with latest=8.6.0.
+		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.6.1", "8.6.0", "8.5.0"), nil)
+		var found *Cycle
+		for i := range cs {
+			if cs[i].Cycle == "8.6" {
+				found = &cs[i]
+			}
+		}
+		if found == nil {
+			t.Fatalf("N cycle 8.6 disappeared: %+v", cs)
+		}
+		if found.Latest != "8.6.0" || !found.Supported {
+			t.Fatalf("N cycle wrong (want latest=8.6.0 supported=true): %+v", *found)
+		}
+		if cs[0].Cycle != "8.6" {
+			t.Fatalf("top cycle should be N=8.6, got %q", cs[0].Cycle)
+		}
+		// 8.6.1 must never surface as its own cycle.
+		for _, c := range cs {
+			if c.Latest == "8.6.1" {
+				t.Fatalf("patch above N leaked as latest: %+v", cs)
+			}
+		}
+	})
+
 	t.Run("higher tag than N is dropped (never exceeds N)", func(t *testing.T) {
 		// A tag 8.7.0 exists but Chart.yaml says N=8.6.0: 8.7 must NOT appear.
 		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.7.0", "8.6.0", "8.5.0"), nil)
@@ -147,6 +177,42 @@ func TestResolveWindow(t *testing.T) {
 			if c.Released != want[c.Cycle] {
 				t.Errorf("cycle %s Released = %q, want %q", c.Cycle, c.Released, want[c.Cycle])
 			}
+		}
+	})
+
+	t.Run("only pre-release tags => INFO with pre-release message, window = only N", func(t *testing.T) {
+		// N=2.0.0 but every tag is a pre-release: segregateStable filters them all,
+		// leaving only the forced N cycle. This is the same degraded state as "0
+		// tags" and must emit an INFO — with a message that says pre-release, not
+		// "no published tags".
+		cs, ws := resolveWindow("2.0.0", tagVers(t, "2.0.0-beta.1", "1.0.0-beta.2"), nil)
+		if len(cs) != 1 || cs[0].Cycle != "2.0" || cs[0].Latest != "2.0.0" || !cs[0].Supported {
+			t.Fatalf("expected single N cycle, got %+v", cs)
+		}
+		if !hasINFO(ws) {
+			t.Fatalf("expected INFO for all-pre-release tags, got %+v", ws)
+		}
+		var infoMsg string
+		for _, w := range ws {
+			if w.Severity == SevInfo {
+				infoMsg = w.Detail
+			}
+		}
+		if !strings.Contains(infoMsg, "pre-release") {
+			t.Errorf("INFO message should mention pre-release, got %q", infoMsg)
+		}
+	})
+
+	t.Run("0 tags keeps the 'no published tags' message", func(t *testing.T) {
+		_, ws := resolveWindow("1.0.0", tagVers(t), nil)
+		var infoMsg string
+		for _, w := range ws {
+			if w.Severity == SevInfo {
+				infoMsg = w.Detail
+			}
+		}
+		if !strings.Contains(infoMsg, "no published tags") {
+			t.Errorf("expected 'no published tags' message, got %q", infoMsg)
 		}
 	})
 

--- a/.github/scripts/generate-compatibility/run_test.go
+++ b/.github/scripts/generate-compatibility/run_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// seedRepo builds a minimal repo (charts/ + README.md) for run() tests.
+func seedRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeChart(t, root, "matcher", `apiVersion: v2
+name: matcher-helm
+type: application
+version: 3.0.0
+`)
+	readme := "# Charts\n\n### Matcher\n\nprose\n"
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(readme), 0o644); err != nil {
+		t.Fatalf("seed readme: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	return root
+}
+
+func TestRun_ExitCodes(t *testing.T) {
+	t.Run("conflicting --write and --check => exit 2", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := run([]string{"--write", "--check"}, &out, &errb)
+		if code != 2 {
+			t.Fatalf("exit = %d, want 2. stderr=%s", code, errb.String())
+		}
+	})
+
+	t.Run("missing --root => exit 1", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := run([]string{"--root", "/no/such/dir/xyz"}, &out, &errb)
+		if code != 1 {
+			t.Fatalf("exit = %d, want 1. stderr=%s", code, errb.String())
+		}
+	})
+
+	t.Run("valid write => exit 0", func(t *testing.T) {
+		root := seedRepo(t)
+		var out, errb bytes.Buffer
+		code := run([]string{"--root", root, "--output", "docs/compatibility.json"}, &out, &errb)
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0. stderr=%s", code, errb.String())
+		}
+		if _, err := os.Stat(filepath.Join(root, "docs", "compatibility.json")); err != nil {
+			t.Fatalf("expected JSON written: %v", err)
+		}
+	})
+}

--- a/.github/scripts/generate-compatibility/run_test.go
+++ b/.github/scripts/generate-compatibility/run_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -52,6 +53,22 @@ func TestRun_ExitCodes(t *testing.T) {
 		}
 		if _, err := os.Stat(filepath.Join(root, "docs", "compatibility.json")); err != nil {
 			t.Fatalf("expected JSON written: %v", err)
+		}
+	})
+
+	t.Run("unknown --chart => exit 2, nothing written", func(t *testing.T) {
+		root := seedRepo(t)
+		var out, errb bytes.Buffer
+		code := run([]string{"--root", root, "--chart", "does-not-exist-helm", "--output", "docs/compatibility.json"}, &out, &errb)
+		if code != 2 {
+			t.Fatalf("exit = %d, want 2 (usage). stderr=%s", code, errb.String())
+		}
+		if !strings.Contains(errb.String(), "unknown chart") {
+			t.Errorf("stderr should mention unknown chart, got %q", errb.String())
+		}
+		// Neither the JSON nor the README must be written on a usage error.
+		if _, err := os.Stat(filepath.Join(root, "docs", "compatibility.json")); err == nil {
+			t.Error("JSON must NOT be written on unknown --chart")
 		}
 	})
 }

--- a/.github/scripts/generate-compatibility/run_test.go
+++ b/.github/scripts/generate-compatibility/run_test.go
@@ -58,6 +58,15 @@ func TestRun_ExitCodes(t *testing.T) {
 
 	t.Run("unknown --chart => exit 2, nothing written", func(t *testing.T) {
 		root := seedRepo(t)
+		// Snapshot the README before the run so we can prove it stays byte-identical
+		// (a future partial-write bug that touched README before validating --chart
+		// would be caught here).
+		readmePath := filepath.Join(root, "README.md")
+		before, err := os.ReadFile(readmePath)
+		if err != nil {
+			t.Fatalf("read README before: %v", err)
+		}
+
 		var out, errb bytes.Buffer
 		code := run([]string{"--root", root, "--chart", "does-not-exist-helm", "--output", "docs/compatibility.json"}, &out, &errb)
 		if code != 2 {
@@ -69,6 +78,13 @@ func TestRun_ExitCodes(t *testing.T) {
 		// Neither the JSON nor the README must be written on a usage error.
 		if _, err := os.Stat(filepath.Join(root, "docs", "compatibility.json")); err == nil {
 			t.Error("JSON must NOT be written on unknown --chart")
+		}
+		after, err := os.ReadFile(readmePath)
+		if err != nil {
+			t.Fatalf("read README after: %v", err)
+		}
+		if string(after) != string(before) {
+			t.Fatalf("README must NOT change on unknown --chart:\n--before--\n%s\n--after--\n%s", before, after)
 		}
 	})
 }

--- a/.github/scripts/generate-compatibility/section_test.go
+++ b/.github/scripts/generate-compatibility/section_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSectionHeaderIndex(t *testing.T) {
+	doc := strings.Split(`# Charts
+
+### Midaz Helm Chart
+
+prose
+
+### Plugin Fees Helm Chart
+
+prose
+
+### Matcher
+
+prose`, "\n")
+
+	tests := []struct {
+		chart string
+		want  int // line index of the "### ..." header, -1 if absent
+	}{
+		{"midaz-helm", 2},
+		{"plugin-fees-helm", 6},
+		{"matcher-helm", 10}, // normalizes to "matcher", matches "### Matcher"
+		{"br-spi-helm", -1},  // no section (ADR-5)
+	}
+	for _, tt := range tests {
+		t.Run(tt.chart, func(t *testing.T) {
+			got := sectionHeaderIndex(doc, tt.chart)
+			if got != tt.want {
+				t.Errorf("chart %q: got index %d, want %d", tt.chart, got, tt.want)
+			}
+		})
+	}
+}

--- a/.github/scripts/generate-compatibility/state.go
+++ b/.github/scripts/generate-compatibility/state.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ChartState is the normalized state read from one chart's Chart.yaml.
+// Version is N, the absolute authority for the support window (ADR-3):
+// it is NEVER derived from git tags.
+type ChartState struct {
+	Name       string // published chart name, e.g. "midaz-helm"
+	Dir        string // directory under charts/, e.g. "midaz" (tag prefix)
+	Version    string // N — from Chart.yaml.version
+	AppVersion string // informational (fills the N row's app-version cell)
+	ChartType  string // lerian.studio/chart-type: single-service | multi-component | dependency-wrapper
+	Compat     *CompatAnnotation
+}
+
+// chartYAML is the minimal shape we parse out of Chart.yaml.
+// Dependencies are not needed for the pilot; annotations carry compatibility.
+type chartYAML struct {
+	Name        string            `yaml:"name"`
+	Version     string            `yaml:"version"`
+	AppVersion  string            `yaml:"appVersion"`
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+// readChartState reads <root>/charts/<dir>/Chart.yaml and returns its
+// normalized state. Returns an error if the file is missing or unparseable.
+// A broken compatibility annotation is surfaced as a *badAnnotationError while
+// still returning a usable state (name/version), so buildDoc downgrades it to a
+// WARN and continues (ADR-4).
+func readChartState(root, dir string) (ChartState, error) {
+	path := filepath.Join(root, "charts", dir, "Chart.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ChartState{}, err
+	}
+
+	var c chartYAML
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return ChartState{}, err
+	}
+
+	chartType := c.Annotations[chartTypeAnnotationKey]
+
+	compat, err := parseCompatAnnotation(c.Annotations[compatAnnotationKey])
+	if err != nil {
+		// Broken embedded YAML (V1): surface as a tagged error so buildDoc can
+		// emit a WARN and continue. State is still usable (name/version known).
+		return ChartState{
+			Name:       c.Name,
+			Dir:        dir,
+			Version:    c.Version,
+			AppVersion: c.AppVersion,
+			ChartType:  chartType,
+		}, &badAnnotationError{chart: c.Name, err: err}
+	}
+
+	return ChartState{
+		Name:       c.Name,
+		Dir:        dir,
+		Version:    c.Version,
+		AppVersion: c.AppVersion,
+		ChartType:  chartType,
+		Compat:     compat,
+	}, nil
+}
+
+// badAnnotationError marks a Chart.yaml whose compatibility annotation is
+// unparseable (V1). The chart state is still returned; the caller downgrades
+// this to a WARN rather than aborting (ADR-4).
+type badAnnotationError struct {
+	chart string
+	err   error
+}
+
+func (e *badAnnotationError) Error() string {
+	return fmt.Sprintf("compatibility annotation is invalid YAML: %v", e.err)
+}

--- a/.github/scripts/generate-compatibility/state_test.go
+++ b/.github/scripts/generate-compatibility/state_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeChart(t *testing.T, root, dir, chartYAML string) {
+	t.Helper()
+	full := filepath.Join(root, "charts", dir)
+	if err := os.MkdirAll(full, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(full, "Chart.yaml"), []byte(chartYAML), 0o644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+}
+
+func TestReadChartState(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "midaz", `apiVersion: v2
+name: midaz-helm
+type: application
+version: 8.6.0
+appVersion: "3.7.8"
+`)
+
+	got, err := readChartState(root, "midaz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "midaz-helm" {
+		t.Errorf("Name = %q, want midaz-helm", got.Name)
+	}
+	if got.Dir != "midaz" {
+		t.Errorf("Dir = %q, want midaz", got.Dir)
+	}
+	if got.Version != "8.6.0" {
+		t.Errorf("Version = %q, want 8.6.0", got.Version)
+	}
+	if got.AppVersion != "3.7.8" {
+		t.Errorf("AppVersion = %q, want 3.7.8", got.AppVersion)
+	}
+}
+
+func TestReadChartState_MissingFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "charts", "empty"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := readChartState(root, "empty")
+	if err == nil {
+		t.Fatal("expected error for missing Chart.yaml, got nil")
+	}
+}
+
+func TestReadChartState_ParsesCompatAnnotation(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "plugin-fees", `apiVersion: v2
+name: plugin-fees-helm
+type: application
+version: 7.2.0
+appVersion: "3.3.0"
+annotations:
+  lerian.studio/chart-type: multi-component
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: ">=8.4.0 <9.0.0"
+    testedWith:
+      midaz-helm: "8.6.0"
+`)
+
+	got, err := readChartState(root, "plugin-fees")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Compat == nil {
+		t.Fatal("Compat is nil, want parsed annotation")
+	}
+	if got.Compat.Requires["midaz-helm"] != ">=8.4.0 <9.0.0" {
+		t.Errorf("Requires[midaz-helm] = %q", got.Compat.Requires["midaz-helm"])
+	}
+	if got.Compat.TestedWith["midaz-helm"] != "8.6.0" {
+		t.Errorf("TestedWith[midaz-helm] = %q", got.Compat.TestedWith["midaz-helm"])
+	}
+}
+
+func TestReadChartState_NoAnnotationIsNilCompat(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "matcher", `apiVersion: v2
+name: matcher-helm
+type: application
+version: 3.0.0
+`)
+	got, err := readChartState(root, "matcher")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Compat != nil {
+		t.Errorf("Compat = %+v, want nil", got.Compat)
+	}
+}

--- a/.github/scripts/generate-compatibility/tags.go
+++ b/.github/scripts/generate-compatibility/tags.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// tagLister abstracts the git tag lookup so tests can inject fixtures without
+// touching a real repo.
+type tagLister interface {
+	// listTags returns raw tag names matching the <dir>-v* glob for a chart dir.
+	listTags(dir string) ([]string, error)
+	// listTagDates returns a map of raw tag name -> release date (YYYY-MM-DD)
+	// for the <dir>-v* glob. The date is the tag's creatordate:short. Tags with
+	// no resolvable date are simply absent from the map.
+	listTagDates(dir string) (map[string]string, error)
+}
+
+// gitTagLister is the real implementation, backed by `git tag --list`.
+// It runs against the working tree at root.
+type gitTagLister struct {
+	root string
+}
+
+func (g gitTagLister) listTags(dir string) ([]string, error) {
+	cmd := exec.Command("git", "-C", g.root, "tag", "--list", dir+"-v*")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	tags := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if s := strings.TrimSpace(l); s != "" {
+			tags = append(tags, s)
+		}
+	}
+	return tags, nil
+}
+
+// listTagDates runs `git tag -l "<dir>-v*" --format='%(refname:short) %(creatordate:short)'`
+// and returns tag name -> ISO date (YYYY-MM-DD). creatordate:short is already
+// ISO-formatted. Lines without a date part are skipped.
+func (g gitTagLister) listTagDates(dir string) (map[string]string, error) {
+	cmd := exec.Command("git", "-C", g.root, "tag", "-l", dir+"-v*",
+		"--format=%(refname:short) %(creatordate:short)")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseTagDates(string(out)), nil
+}
+
+// parseTagDates turns the "<tag> <YYYY-MM-DD>" lines of `git tag --format` output
+// into a tag -> date map. Lines missing the date field are ignored. Kept as a
+// pure function so it is unit-testable without a git repo.
+func parseTagDates(raw string) map[string]string {
+	dates := map[string]string{}
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue // tag present but no date field
+		}
+		dates[fields[0]] = fields[1]
+	}
+	return dates
+}
+
+// parseTags filters raw tags to those of the form "<dir>-v<semver>", strips the
+// "<dir>-v" prefix, and parses each remainder with Masterminds/semver. Tags
+// whose remainder is not valid semver are dropped. Pre-releases are KEPT here;
+// segregation happens later (segregateStable). Output order mirrors input order.
+func parseTags(dir string, rawTags []string) []*semver.Version {
+	prefix := dir + "-v"
+	out := make([]*semver.Version, 0, len(rawTags))
+	for _, tag := range rawTags {
+		if !strings.HasPrefix(tag, prefix) {
+			continue
+		}
+		remainder := strings.TrimPrefix(tag, prefix)
+		v, err := semver.NewVersion(remainder)
+		if err != nil {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// releaseDatesByVersion maps a chart's tag dates (keyed by raw tag name) to a
+// map keyed by semver .String() of the version, so resolveWindow can look up a
+// cycle's release date by its latest version. Tags whose remainder is not valid
+// semver are ignored. e.g. {"tracer-v2.1.0": "2026-06-18"} -> {"2.1.0": "2026-06-18"}.
+func releaseDatesByVersion(dir string, tagDates map[string]string) map[string]string {
+	prefix := dir + "-v"
+	out := make(map[string]string, len(tagDates))
+	for tag, date := range tagDates {
+		if !strings.HasPrefix(tag, prefix) {
+			continue
+		}
+		remainder := strings.TrimPrefix(tag, prefix)
+		v, err := semver.NewVersion(remainder)
+		if err != nil {
+			continue
+		}
+		out[v.String()] = date
+	}
+	return out
+}

--- a/.github/scripts/generate-compatibility/tags_test.go
+++ b/.github/scripts/generate-compatibility/tags_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseTags(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		raw  []string
+		want []string // semver .String() values, order as returned
+	}{
+		{
+			name: "filters by dir prefix and strips it",
+			dir:  "midaz",
+			raw:  []string{"midaz-v8.6.0", "midaz-v8.5.0", "plugin-fees-v7.2.0"},
+			want: []string{"8.6.0", "8.5.0"},
+		},
+		{
+			name: "keeps semver pre-releases",
+			dir:  "midaz",
+			raw:  []string{"midaz-v8.6.0-beta.11", "midaz-v8.6.0"},
+			want: []string{"8.6.0-beta.11", "8.6.0"},
+		},
+		{
+			name: "drops tags whose suffix is not parseable semver",
+			dir:  "midaz",
+			raw:  []string{"midaz-vLATEST", "midaz-v8.6.0", "midaz-vnightly"},
+			want: []string{"8.6.0"},
+		},
+		{
+			name: "does not match a different dir that shares a prefix boundary",
+			dir:  "plugin-fees",
+			raw:  []string{"plugin-fees-v7.2.0", "plugin-fees-helm-v1.0.0"},
+			want: []string{"7.2.0"},
+		},
+		{
+			name: "empty input",
+			dir:  "br-spi",
+			raw:  []string{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTags(tt.dir, tt.raw)
+			gotStr := make([]string, 0, len(got))
+			for _, v := range got {
+				gotStr = append(gotStr, v.String())
+			}
+			if len(gotStr) != len(tt.want) {
+				t.Fatalf("got %v (len %d), want %v (len %d)", gotStr, len(gotStr), tt.want, len(tt.want))
+			}
+			for i := range tt.want {
+				if gotStr[i] != tt.want[i] {
+					t.Fatalf("index %d: got %q, want %q (full got %v)", i, gotStr[i], tt.want[i], gotStr)
+				}
+			}
+		})
+	}
+}

--- a/.github/scripts/generate-compatibility/testdata/golden_two_products.json
+++ b/.github/scripts/generate-compatibility/testdata/golden_two_products.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "generatedFrom": "test",
+  "products": {
+    "midaz-helm": {
+      "dir": "midaz",
+      "current": "8.6.0",
+      "cycles": [
+        {
+          "cycle": "8.6",
+          "latest": "8.6.0",
+          "released": "2026-06-01",
+          "supported": true
+        },
+        {
+          "cycle": "8.5",
+          "latest": "8.5.0",
+          "released": "2026-05-01",
+          "supported": true
+        },
+        {
+          "cycle": "8.4",
+          "latest": "8.4.0",
+          "released": "2026-04-01",
+          "supported": true
+        },
+        {
+          "cycle": "8.3",
+          "latest": "8.3.0",
+          "released": "2026-03-01",
+          "supported": true
+        },
+        {
+          "cycle": "8.2",
+          "latest": "8.2.0",
+          "released": "2026-02-01",
+          "supported": false
+        }
+      ]
+    },
+    "plugin-fees-helm": {
+      "dir": "plugin-fees",
+      "current": "7.2.0",
+      "cycles": [
+        {
+          "cycle": "7.2",
+          "latest": "7.2.0",
+          "released": "2026-06-15",
+          "supported": true,
+          "requires": {
+            "midaz-helm": ">=8.4.0 <9.0.0"
+          },
+          "testedWith": {
+            "midaz-helm": "8.6.0"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md
+++ b/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md
@@ -7,7 +7,7 @@ Fees prose.
 #### Application Version Mapping
 
 <!-- BEGIN COMPAT:plugin-fees-helm -->
-| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |
+| Chart Version | Fees Version | UI Version | Released | Support | Requires midaz-helm |
 | :---: | :---: | :---: | :---: | :---: | :---: |
 | `7.2.0` | 3.3.0 | — | — | 🟢 Full (N) | >=8.4.0 <9.0.0 |
 <!-- END COMPAT:plugin-fees-helm -->

--- a/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md
+++ b/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md
@@ -1,0 +1,31 @@
+# Charts
+
+### Plugin Fees Helm Chart
+
+Fees prose.
+
+#### Application Version Mapping
+
+<!-- BEGIN COMPAT:plugin-fees-helm -->
+| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |
+| :---: | :---: | :---: | :---: | :---: | :---: |
+| `7.2.0` | 3.3.0 | — | — | 🟢 Full (N) | >=8.4.0 <9.0.0 |
+<!-- END COMPAT:plugin-fees-helm -->
+
+-----------------
+
+### Matcher
+
+Matcher prose.
+
+#### Application Version Mapping
+
+<!-- BEGIN COMPAT:matcher-helm -->
+| Chart Version | Matcher Version | Released | Support |
+| :---: | :---: | :---: | :---: |
+| `3.0.0` | 1.0.0 | — | 🟢 Full (N) |
+<!-- END COMPAT:matcher-helm -->
+
+### Flowker
+
+Flowker prose.

--- a/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md
+++ b/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md
@@ -1,0 +1,27 @@
+# Charts
+
+### Plugin Fees Helm Chart
+
+Fees prose.
+
+#### Application Version Mapping
+
+| Chart Version | Fees Version | UI Version |
+| :---: | :---: | :---: |
+| `7.2.0` | 3.3.0 | `3.0.0` |
+
+-----------------
+
+### Matcher
+
+Matcher prose.
+
+#### Application Version Mapping
+
+| Chart Version | Matcher Version |
+| :---: | :---: |
+| `3.0.0` | 1.0.0 |
+
+### Flowker
+
+Flowker prose.

--- a/.github/scripts/generate-compatibility/warn.go
+++ b/.github/scripts/generate-compatibility/warn.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Severity is the stable, CI-parseable prefix (api-design §II.3).
+type Severity string
+
+const (
+	SevWarn Severity = "WARN"
+	SevInfo Severity = "INFO"
+)
+
+// Warning is one diagnostic tied to a chart and a validation rule.
+type Warning struct {
+	Severity Severity
+	Chart    string
+	Rule     string // e.g. "V3", "V4", "V6"
+	Detail   string
+}
+
+// Line renders the stable message contract: "WARN <chart>: <rule> — <detail>".
+func (w Warning) Line() string {
+	return fmt.Sprintf("%s %s: %s — %s", w.Severity, w.Chart, w.Rule, w.Detail)
+}
+
+// emitWarnings writes each warning as one line to stderr, sorted by chart then
+// rule for deterministic output. Returns the count of SevWarn (not INFO).
+func emitWarnings(stderr io.Writer, ws []Warning) int {
+	sorted := make([]Warning, len(ws))
+	copy(sorted, ws)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Chart != sorted[j].Chart {
+			return sorted[i].Chart < sorted[j].Chart
+		}
+		return sorted[i].Rule < sorted[j].Rule
+	})
+	warnCount := 0
+	for _, w := range sorted {
+		fmt.Fprintln(stderr, w.Line())
+		if w.Severity == SevWarn {
+			warnCount++
+		}
+	}
+	return warnCount
+}

--- a/.github/scripts/generate-compatibility/warn_test.go
+++ b/.github/scripts/generate-compatibility/warn_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"testing"
+)
+
+func rulesOf(ws []Warning) []string {
+	out := make([]string, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, w.Rule)
+	}
+	return out
+}
+
+func containsRule(ws []Warning, rule string) bool {
+	for _, r := range rulesOf(ws) {
+		if r == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateCompat(t *testing.T) {
+	known := map[string]bool{"midaz-helm": true, "plugin-fees-helm": true}
+
+	tests := []struct {
+		name      string
+		chartType string
+		ann       *CompatAnnotation
+		wantRules []string // rules that MUST be present
+		absent    []string // rules that must NOT be present
+	}{
+		{
+			name:      "single-service without compat => NO warnings (standalone)",
+			chartType: chartTypeSingleService,
+			ann:       nil,
+			absent:    []string{"V3", "V4", "V5", "V6", "CT"},
+		},
+		{
+			name:      "multi-component without compat => V6 INFO reminder",
+			chartType: chartTypeMultiComponent,
+			ann:       nil,
+			wantRules: []string{"V6"},
+		},
+		{
+			name:      "dependency-wrapper without compat => V6 INFO reminder",
+			chartType: chartTypeDependencyWrapper,
+			ann:       nil,
+			wantRules: []string{"V6"},
+		},
+		{
+			name:      "missing chart-type without compat => CT WARN + V6 INFO (conservative)",
+			chartType: "",
+			ann:       nil,
+			wantRules: []string{"CT", "V6"},
+		},
+		{
+			name:      "single-service WITH requires => still validates V3/V4, no V6",
+			chartType: chartTypeSingleService,
+			ann: &CompatAnnotation{
+				Requires: map[string]string{"midaz-ledger": "maior que 8"},
+			},
+			wantRules: []string{"V3", "V4"},
+			absent:    []string{"V6"},
+		},
+		{
+			name:      "valid complete (multi-component) => no warnings",
+			chartType: chartTypeMultiComponent,
+			ann: &CompatAnnotation{
+				Requires:   map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"},
+				TestedWith: map[string]string{"midaz-helm": "8.6.0"},
+			},
+			absent: []string{"V3", "V4", "V5", "V6", "CT"},
+		},
+		{
+			name:      "V3 unknown product in requires",
+			chartType: chartTypeMultiComponent,
+			ann: &CompatAnnotation{
+				Requires: map[string]string{"midaz-ledger": ">=8.0.0"},
+			},
+			wantRules: []string{"V3"},
+		},
+		{
+			name:      "V4 unparseable range",
+			chartType: chartTypeMultiComponent,
+			ann: &CompatAnnotation{
+				Requires: map[string]string{"midaz-helm": "maior que 8"},
+			},
+			wantRules: []string{"V4"},
+		},
+		{
+			name:      "V5 testedWith not an exact version",
+			chartType: chartTypeMultiComponent,
+			ann: &CompatAnnotation{
+				TestedWith: map[string]string{"midaz-helm": ">=8.6.0"},
+			},
+			wantRules: []string{"V5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateCompat("plugin-fees-helm", tt.chartType, tt.ann, known)
+			for _, r := range tt.wantRules {
+				if !containsRule(got, r) {
+					t.Errorf("expected rule %s in %v", r, rulesOf(got))
+				}
+			}
+			for _, r := range tt.absent {
+				if containsRule(got, r) {
+					t.Errorf("did not expect rule %s in %v", r, rulesOf(got))
+				}
+			}
+		})
+	}
+}

--- a/.github/scripts/generate-compatibility/window.go
+++ b/.github/scripts/generate-compatibility/window.go
@@ -69,11 +69,8 @@ func resolveWindow(chartVersion string, tagVersions []*semver.Version, releaseDa
 	}
 	nKey := minorKey(nVer)
 
-	// Group stable tag versions by minor cycle. stableCyclesFromTags is the count
-	// of real cycles the published tags contributed, BEFORE forcing N — used to
-	// detect the degraded "only pre-release tags" state below.
+	// Group stable tag versions by minor cycle.
 	byMinor := groupByMinor(segregateStable(tagVersions))
-	stableCyclesFromTags := len(byMinor)
 
 	// The N cycle is ALWAYS sourced from Chart.yaml (authority): N wins its own
 	// minor slot unconditionally. This is deliberate — if a stray tag with a
@@ -104,14 +101,25 @@ func resolveWindow(chartVersion string, tagVersions []*semver.Version, releaseDa
 		})
 	}
 
-	// Degraded window: the tags produced no stable cycle, so the window is only
-	// the forced N. Distinguish "no tags at all" from "only pre-release tags" so
-	// the diagnostic is accurate.
-	if stableCyclesFromTags == 0 {
+	// Degraded window: count the cycles that ACTUALLY entered the window besides
+	// the always-forced N cycle. This must be measured AFTER the "never exceed N"
+	// filter — counting byMinor earlier would miss the case where every stable
+	// tag is a cycle above N (all dropped by the filter), leaving only N but a
+	// non-zero pre-filter count (same class as bug #8: counting at the wrong
+	// moment). When nothing but N survived, the window is degraded → emit INFO.
+	nonNCycles := 0
+	for _, v := range latests {
+		if minorKey(v) != nKey {
+			nonNCycles++
+		}
+	}
+	if nonNCycles == 0 {
 		if len(tagVersions) == 0 {
 			warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "no published tags; window = only N (Chart.yaml)"})
 		} else {
-			warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "only pre-release tags; window = only N (Chart.yaml)"})
+			// Tags exist but none produced a usable cycle at or below N (all
+			// pre-release, or all above N). More precise than "only pre-release".
+			warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "no usable tags below N; window = only N (Chart.yaml)"})
 		}
 	}
 

--- a/.github/scripts/generate-compatibility/window.go
+++ b/.github/scripts/generate-compatibility/window.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// segregateStable drops every pre-release version (e.g. -beta.N, -HELM-N,
+// -rc.N). Per TRD §2, pre-releases never become their own support cycle; they
+// are removed before minors are computed. Input order is preserved for the
+// survivors.
+func segregateStable(vs []*semver.Version) []*semver.Version {
+	out := make([]*semver.Version, 0, len(vs))
+	for _, v := range vs {
+		if v.Prerelease() != "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// minorKey renders the "MAJOR.MINOR" cycle key for a version.
+func minorKey(v *semver.Version) string {
+	return fmt.Sprintf("%d.%d", v.Major(), v.Minor())
+}
+
+// groupByMinor buckets stable versions by their MAJOR.MINOR cycle, keeping the
+// highest patch in each bucket. The result is deterministic regardless of input
+// order because the winner is chosen by semver comparison, not by position.
+func groupByMinor(vs []*semver.Version) map[string]*semver.Version {
+	latest := map[string]*semver.Version{}
+	for _, v := range vs {
+		key := minorKey(v)
+		if cur, ok := latest[key]; !ok || v.GreaterThan(cur) {
+			latest[key] = v
+		}
+	}
+	return latest
+}
+
+// supportedWindowSize is the number of most-recent minor cycles that are marked
+// supported (N..N-3). Cycles below that are supported=false.
+const supportedWindowSize = 4
+
+// resolveWindow builds the ordered support-window cycles for one chart.
+//
+// N = chartVersion (from Chart.yaml) is authoritative: its cycle is always
+// present and supported, even when no matching tag exists (ADR-3, NFR-3). Tag
+// history supplies N-1..N-3. Cycles strictly above N are discarded (a stray
+// higher tag must never exceed the declared current version). The top
+// supportedWindowSize distinct minors are supported=true; the rest false.
+//
+// Degradation (FR-7): 0 tags => only the N cycle (+ an INFO); <4 minors => only
+// those that exist.
+//
+// releaseDates maps a version's semver .String() to its ISO release date
+// (YYYY-MM-DD, from the tag). Each cycle's Released is set from the date of its
+// latest version; a version with no known date leaves Released empty ("").
+func resolveWindow(chartVersion string, tagVersions []*semver.Version, releaseDates map[string]string) ([]Cycle, []Warning) {
+	var warnings []Warning
+
+	nVer, err := semver.NewVersion(chartVersion)
+	if err != nil {
+		// Chart.yaml version is unparseable: emit WARN, produce no cycles.
+		warnings = append(warnings, Warning{SevWarn, chartVersion, "N", fmt.Sprintf("Chart.yaml version %q is not valid semver", chartVersion)})
+		return nil, warnings
+	}
+	nKey := minorKey(nVer)
+
+	// Group stable tag versions by minor cycle.
+	byMinor := groupByMinor(segregateStable(tagVersions))
+
+	// Force the N cycle to exist, sourced from Chart.yaml (authority). If a tag
+	// for the N cycle also exists, keep the greater of the two as latest.
+	if existing, ok := byMinor[nKey]; !ok || nVer.GreaterThan(existing) {
+		byMinor[nKey] = nVer
+	}
+
+	// Collect the "latest" version of each minor, drop any cycle above N, then
+	// sort descending by that latest version.
+	latests := make([]*semver.Version, 0, len(byMinor))
+	for _, v := range byMinor {
+		if v.GreaterThan(nVer) {
+			continue // never exceed N
+		}
+		latests = append(latests, v)
+	}
+	sortSemverDesc(latests)
+
+	cycles := make([]Cycle, 0, len(latests))
+	for i, v := range latests {
+		cycles = append(cycles, Cycle{
+			Cycle:     minorKey(v),
+			Latest:    v.String(),
+			Released:  releaseDates[v.String()], // "" when the tag date is unknown
+			Supported: i < supportedWindowSize,
+		})
+	}
+
+	if len(tagVersions) == 0 {
+		warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "no published tags; window = only N (Chart.yaml)"})
+	}
+
+	return cycles, warnings
+}
+
+// sortSemverDesc performs a stable descending sort of semver versions in place.
+func sortSemverDesc(vs []*semver.Version) {
+	for i := 1; i < len(vs); i++ {
+		for j := i; j > 0 && vs[j].GreaterThan(vs[j-1]); j-- {
+			vs[j], vs[j-1] = vs[j-1], vs[j]
+		}
+	}
+}

--- a/.github/scripts/generate-compatibility/window.go
+++ b/.github/scripts/generate-compatibility/window.go
@@ -69,14 +69,19 @@ func resolveWindow(chartVersion string, tagVersions []*semver.Version, releaseDa
 	}
 	nKey := minorKey(nVer)
 
-	// Group stable tag versions by minor cycle.
+	// Group stable tag versions by minor cycle. stableCyclesFromTags is the count
+	// of real cycles the published tags contributed, BEFORE forcing N — used to
+	// detect the degraded "only pre-release tags" state below.
 	byMinor := groupByMinor(segregateStable(tagVersions))
+	stableCyclesFromTags := len(byMinor)
 
-	// Force the N cycle to exist, sourced from Chart.yaml (authority). If a tag
-	// for the N cycle also exists, keep the greater of the two as latest.
-	if existing, ok := byMinor[nKey]; !ok || nVer.GreaterThan(existing) {
-		byMinor[nKey] = nVer
-	}
+	// The N cycle is ALWAYS sourced from Chart.yaml (authority): N wins its own
+	// minor slot unconditionally. This is deliberate — if a stray tag with a
+	// patch ABOVE N in the same minor exists (e.g. N=8.6.0 with a tag 8.6.1),
+	// letting that tag occupy the 8.6 slot would then get it dropped by the
+	// "never exceed N" filter below, deleting the N cycle entirely. Overwriting
+	// with nVer keeps the N cycle present and correct (latest = the declared N).
+	byMinor[nKey] = nVer
 
 	// Collect the "latest" version of each minor, drop any cycle above N, then
 	// sort descending by that latest version.
@@ -99,8 +104,15 @@ func resolveWindow(chartVersion string, tagVersions []*semver.Version, releaseDa
 		})
 	}
 
-	if len(tagVersions) == 0 {
-		warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "no published tags; window = only N (Chart.yaml)"})
+	// Degraded window: the tags produced no stable cycle, so the window is only
+	// the forced N. Distinguish "no tags at all" from "only pre-release tags" so
+	// the diagnostic is accurate.
+	if stableCyclesFromTags == 0 {
+		if len(tagVersions) == 0 {
+			warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "no published tags; window = only N (Chart.yaml)"})
+		} else {
+			warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "only pre-release tags; window = only N (Chart.yaml)"})
+		}
 	}
 
 	return cycles, warnings

--- a/.github/scripts/generate-compatibility/window_test.go
+++ b/.github/scripts/generate-compatibility/window_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// mustVers parses a list of semver strings, failing the test on any error.
+func mustVers(t *testing.T, ss ...string) []*semver.Version {
+	t.Helper()
+	out := make([]*semver.Version, 0, len(ss))
+	for _, s := range ss {
+		v, err := semver.NewVersion(s)
+		if err != nil {
+			t.Fatalf("bad test version %q: %v", s, err)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func TestSegregateStable(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"drops beta", []string{"8.6.0", "8.6.0-beta.11", "8.5.0"}, []string{"8.6.0", "8.5.0"}},
+		{"drops HELM prerelease", []string{"1.0.0-HELM-94.1", "1.0.0"}, []string{"1.0.0"}},
+		{"all stable kept", []string{"3.2.0", "3.1.0"}, []string{"3.2.0", "3.1.0"}},
+		{"all prerelease => empty", []string{"2.0.0-rc.1", "2.0.0-beta.2"}, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := segregateStable(mustVers(t, tt.in...))
+			gotStr := make([]string, 0, len(got))
+			for _, v := range got {
+				gotStr = append(gotStr, v.String())
+			}
+			if len(gotStr) != len(tt.want) {
+				t.Fatalf("got %v, want %v", gotStr, tt.want)
+			}
+			for i := range tt.want {
+				if gotStr[i] != tt.want[i] {
+					t.Fatalf("index %d: got %q want %q", i, gotStr[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGroupByMinor(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want map[string]string // "MAJOR.MINOR" -> latest patch .String()
+	}{
+		{
+			name: "picks highest patch per minor",
+			in:   []string{"8.6.0", "8.6.2", "8.6.1", "8.5.0", "8.5.3"},
+			want: map[string]string{"8.6": "8.6.2", "8.5": "8.5.3"},
+		},
+		{
+			name: "single minor",
+			in:   []string{"3.0.0"},
+			want: map[string]string{"3.0": "3.0.0"},
+		},
+		{
+			name: "crosses majors",
+			in:   []string{"9.0.0", "8.9.0", "8.9.5"},
+			want: map[string]string{"9.0": "9.0.0", "8.9": "8.9.5"},
+		},
+		{
+			name: "empty",
+			in:   []string{},
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := groupByMinor(mustVers(t, tt.in...))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d cycles, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for cycle, wantLatest := range tt.want {
+				v, ok := got[cycle]
+				if !ok {
+					t.Fatalf("missing cycle %q in %v", cycle, got)
+				}
+				if v.String() != wantLatest {
+					t.Errorf("cycle %q: got latest %q, want %q", cycle, v.String(), wantLatest)
+				}
+			}
+		})
+	}
+}
+
+// TestGroupByMinor_OrderIndependent proves grouping does not depend on input
+// order (map iteration is random; the pick must be deterministic by value).
+func TestGroupByMinor_OrderIndependent(t *testing.T) {
+	forward := mustVers(t, "8.6.0", "8.6.1", "8.6.2")
+	rev := mustVers(t, "8.6.2", "8.6.1", "8.6.0")
+	// shuffle-ish: sort rev descending to differ from forward
+	sort.Sort(sort.Reverse(semver.Collection(rev)))
+	a := groupByMinor(forward)
+	b := groupByMinor(rev)
+	if a["8.6"].String() != b["8.6"].String() {
+		t.Fatalf("order-dependent: %q vs %q", a["8.6"], b["8.6"])
+	}
+	if a["8.6"].String() != "8.6.2" {
+		t.Fatalf("expected latest 8.6.2, got %q", a["8.6"])
+	}
+}

--- a/.github/scripts/generate-compatibility/write_readme.go
+++ b/.github/scripts/generate-compatibility/write_readme.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/LerianStudio/helm/.github/scripts/tableutil"
+)
+
+// sortedProductNames returns the product keys in stable ascending order.
+func sortedProductNames(doc CompatDoc) []string {
+	names := make([]string, 0, len(doc.Products))
+	for name := range doc.Products {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// resolveAppVersions resolves the current (N-row) app version for each app
+// column label of a chart, reading charts/<dir>/values.yaml via the shared
+// tableutil extractor (the same multi-column {component}.image.tag logic used by
+// update-chart-version-readme, with a root image.tag fallback). It returns a
+// map keyed by app LABEL (e.g. "Fees" -> "3.3.0") and a WARN per column whose
+// tag could not be resolved, mirroring the sister tool's "Could not find" note.
+// Only the current version is resolved; historical rows stay "—" (v1 reads the
+// current state only — decision, not derived from tags).
+func resolveAppVersions(root, dir string, appLabels []string) (map[string]string, []Warning) {
+	byLabel := map[string]string{}
+	if len(appLabels) == 0 {
+		return byLabel, nil
+	}
+
+	// tableutil keys on the full "<Label> Version" header; build those headers.
+	headers := make([]string, 0, len(appLabels))
+	labelOf := map[string]string{} // header -> label
+	for _, lbl := range appLabels {
+		h := lbl + " Version"
+		headers = append(headers, h)
+		labelOf[h] = lbl
+	}
+
+	valuesPath := filepath.Join(root, "charts", dir, "values.yaml")
+	res, err := tableutil.ExtractAppVersionsFromValues(valuesPath, headers)
+
+	var warnings []Warning
+	if err != nil {
+		warnings = append(warnings, Warning{SevWarn, dir, "APP", fmt.Sprintf("cannot read app versions: %v", err)})
+	}
+	for header, tag := range res.Found {
+		byLabel[labelOf[header]] = tag
+	}
+	for _, header := range res.Missing {
+		lbl := labelOf[header]
+		component := strings.ToLower(lbl)
+		warnings = append(warnings, Warning{SevWarn, dir, "APP", fmt.Sprintf("could not find %s.image.tag in values.yaml; %q left as —", component, header)})
+	}
+	return byLabel, warnings
+}
+
+// renderReadmeLines applies every product's COMPAT block to the given README
+// lines, in sorted product order, returning the resulting lines. It is the
+// single source of truth shared by writeReadme (mutates disk) and runCheck
+// (compares in memory), so both agree byte-for-byte. WARN/INFO diagnostics
+// (e.g. a missing app-version column) go to stderr.
+func renderReadmeLines(root string, lines []string, doc CompatDoc, stderr io.Writer) ([]string, error) {
+	var err error
+	for _, name := range sortedProductNames(doc) {
+		p := doc.Products[name]
+		// Reuse ALL app labels already present in this chart's README section
+		// (e.g. ["Tracer"] or ["Fees", "UI"]) so the enriched table never drops a
+		// column. Labels live outside the COMPAT markers, so they survive block
+		// replacement and stay stable across runs.
+		appLabels := appLabelsFor(lines, name)
+		// Resolve the current app version(s) from values.yaml (shared logic).
+		appVersions, ws := resolveAppVersions(root, p.Dir, appLabels)
+		emitWarnings(stderr, tagChart(name, ws))
+
+		body := renderCompatTable(p, appLabels, appVersions)
+		lines, err = ensureCompatBlock(lines, name, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return lines, nil
+}
+
+// writeReadme rewrites <root>/README.md so every product's COMPAT block matches
+// the document. Only content between (or newly wrapped in) markers changes;
+// prose, existing tables and irregular separators are preserved (risk #1
+// mitigation). For the pilot the caller passes a doc filtered to a single chart
+// (--chart tracer-helm), so only that block is touched.
+func writeReadme(root string, doc CompatDoc, stderr io.Writer) error {
+	readmePath := filepath.Join(root, "README.md")
+	data, err := os.ReadFile(readmePath)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+
+	lines, err = renderReadmeLines(root, lines, doc, stderr)
+	if err != nil {
+		return err
+	}
+
+	out := strings.Join(lines, "\n")
+	return os.WriteFile(readmePath, []byte(out), 0o644)
+}

--- a/.github/scripts/generate-compatibility/write_readme_test.go
+++ b/.github/scripts/generate-compatibility/write_readme_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedValues writes charts/<dir>/values.yaml so resolveAppVersions can resolve
+// the N-row app versions from {component}.image.tag (shared tableutil logic).
+func seedValues(t *testing.T, root, dir, body string) {
+	t.Helper()
+	full := filepath.Join(root, "charts", dir)
+	if err := os.MkdirAll(full, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(full, "values.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write values %s: %v", dir, err)
+	}
+}
+
+func TestWriteReadme_IrregularLayoutsGolden(t *testing.T) {
+	in, err := os.ReadFile(filepath.Join("testdata", "readme_irregular_in.md"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	root := t.TempDir()
+	readmePath := filepath.Join(root, "README.md")
+	if err := os.WriteFile(readmePath, in, 0o644); err != nil {
+		t.Fatalf("seed README: %v", err)
+	}
+	// fees.image.tag resolves the "Fees Version" column; there is deliberately no
+	// ui: section, so "UI Version" stays "—" (mirrors the real plugin-fees).
+	seedValues(t, root, "plugin-fees", "fees:\n  image:\n    tag: \"3.3.0\"\n")
+	seedValues(t, root, "matcher", "matcher:\n  image:\n    tag: \"1.0.0\"\n")
+
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		Products: map[string]Product{
+			"plugin-fees-helm": {Dir: "plugin-fees", Current: "7.2.0", Cycles: []Cycle{
+				{Cycle: "7.2", Latest: "7.2.0", Supported: true,
+					Requires: map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"}},
+			}},
+			"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{
+				{Cycle: "3.0", Latest: "3.0.0", Supported: true},
+			}},
+		},
+	}
+
+	if err := writeReadme(root, doc, io.Discard); err != nil {
+		t.Fatalf("writeReadme: %v", err)
+	}
+
+	got, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "readme_irregular_golden.md")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("update golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (run UPDATE_GOLDEN=1 first): %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("README mismatch.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+
+	// Structural invariants that must hold regardless of golden bytes:
+	s := string(got)
+	if !strings.Contains(s, "-----------------") {
+		t.Error("Plugin Fees separator was destroyed")
+	}
+	if !strings.Contains(s, "### Flowker") {
+		t.Error("Flowker section header lost")
+	}
+	// In-place replacement: the "#### Application Version Mapping" heading stays.
+	if strings.Count(s, "#### Application Version Mapping") != 2 {
+		t.Errorf("expected both mapping headings preserved, got %d:\n%s", strings.Count(s, "#### Application Version Mapping"), s)
+	}
+	// The ORIGINAL simple tables must be GONE (replaced in place, not duplicated).
+	if strings.Contains(s, "| Chart Version | Matcher Version |\n| :---: | :---: |") {
+		t.Errorf("Matcher original 2-col table still present (duplicate!):\n%s", s)
+	}
+	if strings.Contains(s, "| Chart Version | Fees Version | UI Version |\n| :---: | :---: | :---: |") {
+		t.Errorf("Fees original 3-col table still present (duplicate!):\n%s", s)
+	}
+	// Exactly one COMPAT block per chart.
+	if strings.Count(s, "<!-- BEGIN COMPAT:matcher-helm -->") != 1 ||
+		strings.Count(s, "<!-- BEGIN COMPAT:plugin-fees-helm -->") != 1 {
+		t.Errorf("duplicate COMPAT blocks:\n%s", s)
+	}
+	// Enriched blocks reuse the existing app label(s) and carry Released+Support.
+	// This test has no git tags in the temp root, so Released is "—".
+	if !strings.Contains(s, "| Chart Version | Matcher Version | Released | Support |") {
+		t.Errorf("Matcher COMPAT block missing rich header:\n%s", s)
+	}
+	if !strings.Contains(s, "| `3.0.0` | 1.0.0 | — | 🟢 Full (N) |") {
+		t.Errorf("Matcher N row wrong (resolved app version/released/support):\n%s", s)
+	}
+	// Multi-app fees: Fees Version resolved from values.yaml; UI Version has no
+	// values source so it stays "—" even on the N row (no invention).
+	if !strings.Contains(s, "| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |") {
+		t.Errorf("Plugin Fees COMPAT block missing multi-app rich header:\n%s", s)
+	}
+	if !strings.Contains(s, "| `7.2.0` | 3.3.0 | — | — | 🟢 Full (N) | >=8.4.0 <9.0.0 |") {
+		t.Errorf("Plugin Fees N row wrong (Fees=3.3.0, UI=—, Released=—):\n%s", s)
+	}
+}
+
+// TestWriteReadme_Idempotent proves running twice yields identical bytes.
+func TestWriteReadme_Idempotent(t *testing.T) {
+	in, _ := os.ReadFile(filepath.Join("testdata", "readme_irregular_in.md"))
+	root := t.TempDir()
+	readmePath := filepath.Join(root, "README.md")
+	_ = os.WriteFile(readmePath, in, 0o644)
+	seedValues(t, root, "matcher", "matcher:\n  image:\n    tag: \"1.0.0\"\n")
+
+	doc := CompatDoc{SchemaVersion: 1, Products: map[string]Product{
+		"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}}},
+	}}
+
+	_ = writeReadme(root, doc, io.Discard)
+	first, _ := os.ReadFile(readmePath)
+	_ = writeReadme(root, doc, io.Discard)
+	second, _ := os.ReadFile(readmePath)
+	if string(first) != string(second) {
+		t.Fatalf("writeReadme not idempotent:\n--first--\n%s\n--second--\n%s", first, second)
+	}
+}

--- a/.github/scripts/generate-compatibility/write_readme_test.go
+++ b/.github/scripts/generate-compatibility/write_readme_test.go
@@ -107,7 +107,7 @@ func TestWriteReadme_IrregularLayoutsGolden(t *testing.T) {
 	}
 	// Multi-app fees: Fees Version resolved from values.yaml; UI Version has no
 	// values source so it stays "—" even on the N row (no invention).
-	if !strings.Contains(s, "| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |") {
+	if !strings.Contains(s, "| Chart Version | Fees Version | UI Version | Released | Support | Requires midaz-helm |") {
 		t.Errorf("Plugin Fees COMPAT block missing multi-app rich header:\n%s", s)
 	}
 	if !strings.Contains(s, "| `7.2.0` | 3.3.0 | — | — | 🟢 Full (N) | >=8.4.0 <9.0.0 |") {
@@ -148,5 +148,83 @@ func TestWriteReadme_Idempotent(t *testing.T) {
 	}
 	if string(first) != string(second) {
 		t.Fatalf("writeReadme not idempotent:\n--first--\n%s\n--second--\n%s", first, second)
+	}
+}
+
+// TestWriteReadme_MigratesLegacyRequerLabel proves a README whose COMPAT block
+// was generated with the old Portuguese "Requer" label migrates cleanly to
+// "Requires" on the next run: in-place rewrite, one table, no leftover "Requer",
+// and the app columns are NOT inflated by the stale generated header.
+func TestWriteReadme_MigratesLegacyRequerLabel(t *testing.T) {
+	root := t.TempDir()
+	readmePath := filepath.Join(root, "README.md")
+	// Legacy README: the COMPAT block already carries the old "Requer" header.
+	legacy := `# Charts
+
+### Plugin Fees Helm Chart
+
+Fees prose.
+
+#### Application Version Mapping
+
+<!-- BEGIN COMPAT:plugin-fees-helm -->
+| Chart Version | Fees Version | UI Version | Released | Support | Requer midaz-helm |
+| :---: | :---: | :---: | :---: | :---: | :---: |
+| ` + "`7.2.0`" + ` | 3.3.0 | — | 2026-06-15 | 🟢 Full (N) | >=8.4.0 <9.0.0 |
+<!-- END COMPAT:plugin-fees-helm -->
+
+-----------------
+`
+	if err := os.WriteFile(readmePath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("seed legacy README: %v", err)
+	}
+	seedValues(t, root, "plugin-fees", "fees:\n  image:\n    tag: \"3.3.0\"\n")
+
+	doc := CompatDoc{SchemaVersion: 1, Products: map[string]Product{
+		"plugin-fees-helm": {Dir: "plugin-fees", Current: "7.2.0", Cycles: []Cycle{
+			{Cycle: "7.2", Latest: "7.2.0", Released: "2026-06-15", Supported: true,
+				Requires: map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"}},
+		}},
+	}}
+
+	if err := writeReadme(root, doc, io.Discard); err != nil {
+		t.Fatalf("writeReadme (migrate): %v", err)
+	}
+	got, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(got)
+
+	// New label present, old label gone.
+	if !strings.Contains(s, "| Chart Version | Fees Version | UI Version | Released | Support | Requires midaz-helm |") {
+		t.Errorf("migrated header wrong:\n%s", s)
+	}
+	if strings.Contains(s, "Requer ") || strings.Contains(s, "| Requer midaz-helm |") {
+		t.Errorf("legacy 'Requer' label leaked after migration:\n%s", s)
+	}
+	// App columns not inflated: exactly one COMPAT block, exactly two app cols
+	// (Fees, UI) — the stale generated columns must not have been read as apps.
+	if strings.Count(s, "<!-- BEGIN COMPAT:plugin-fees-helm -->") != 1 {
+		t.Errorf("expected exactly one block after migration:\n%s", s)
+	}
+	if !strings.Contains(s, "| `7.2.0` | 3.3.0 | — | 2026-06-15 | 🟢 Full (N) | >=8.4.0 <9.0.0 |") {
+		t.Errorf("migrated N row wrong (columns inflated?):\n%s", s)
+	}
+	// Prose + separator preserved.
+	if !strings.Contains(s, "Fees prose.") || !strings.Contains(s, "-----------------") {
+		t.Errorf("surrounding content disturbed:\n%s", s)
+	}
+
+	// And it is now idempotent under the new label.
+	if err := writeReadme(root, doc, io.Discard); err != nil {
+		t.Fatalf("writeReadme (second): %v", err)
+	}
+	again, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read again: %v", err)
+	}
+	if string(again) != s {
+		t.Fatalf("not idempotent after migration:\n--first--\n%s\n--second--\n%s", s, again)
 	}
 }

--- a/.github/scripts/generate-compatibility/write_readme_test.go
+++ b/.github/scripts/generate-compatibility/write_readme_test.go
@@ -117,20 +117,35 @@ func TestWriteReadme_IrregularLayoutsGolden(t *testing.T) {
 
 // TestWriteReadme_Idempotent proves running twice yields identical bytes.
 func TestWriteReadme_Idempotent(t *testing.T) {
-	in, _ := os.ReadFile(filepath.Join("testdata", "readme_irregular_in.md"))
+	in, err := os.ReadFile(filepath.Join("testdata", "readme_irregular_in.md"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
 	root := t.TempDir()
 	readmePath := filepath.Join(root, "README.md")
-	_ = os.WriteFile(readmePath, in, 0o644)
+	if err := os.WriteFile(readmePath, in, 0o644); err != nil {
+		t.Fatalf("seed README: %v", err)
+	}
 	seedValues(t, root, "matcher", "matcher:\n  image:\n    tag: \"1.0.0\"\n")
 
 	doc := CompatDoc{SchemaVersion: 1, Products: map[string]Product{
 		"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}}},
 	}}
 
-	_ = writeReadme(root, doc, io.Discard)
-	first, _ := os.ReadFile(readmePath)
-	_ = writeReadme(root, doc, io.Discard)
-	second, _ := os.ReadFile(readmePath)
+	if err := writeReadme(root, doc, io.Discard); err != nil {
+		t.Fatalf("writeReadme (first): %v", err)
+	}
+	first, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+	if err := writeReadme(root, doc, io.Discard); err != nil {
+		t.Fatalf("writeReadme (second): %v", err)
+	}
+	second, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read second: %v", err)
+	}
 	if string(first) != string(second) {
 		t.Fatalf("writeReadme not idempotent:\n--first--\n%s\n--second--\n%s", first, second)
 	}

--- a/.github/scripts/go.mod
+++ b/.github/scripts/go.mod
@@ -6,3 +6,5 @@ require (
 	golang.org/x/text v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/Masterminds/semver/v3 v3.2.1

--- a/.github/scripts/go.sum
+++ b/.github/scripts/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/.github/scripts/tableutil/appversions.go
+++ b/.github/scripts/tableutil/appversions.go
@@ -1,0 +1,121 @@
+package tableutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// versionSuffix is the trailing token in an app-version column header, e.g.
+// the " Version" of "Fees Version". "Chart Version" is excluded (it is the
+// chart version, not an app image tag).
+const versionSuffix = " Version"
+
+// AppVersionResult reports, per app-version column header, the image tag found
+// in a chart's values.yaml. Found maps header -> tag (e.g. "Fees Version" ->
+// "3.3.0"); Missing lists the headers whose {component}.image.tag could not be
+// resolved (the caller decides how to surface that — stdout log or stderr WARN).
+//
+// This is the shared, logging-neutral core reused by both
+// update-chart-version-readme and generate-compatibility so the multi-column
+// app-version extraction lives in exactly one place.
+type AppVersionResult struct {
+	Found   map[string]string
+	Missing []string
+}
+
+// ExtractAppVersionsFromValues reads valuesPath (a chart's values.yaml) and, for
+// each header ending in " Version" (except "Chart Version"), resolves the
+// component's image tag via {component}.image.tag (with a root image.tag
+// fallback for charts like product-console). The component key is the header
+// with " Version" stripped and lower-cased ("Fees Version" -> "fees").
+//
+// It never prints; on a read/parse failure it returns every eligible header in
+// Missing with a non-nil error, so callers can log consistently. Behaviour is
+// identical to the original update-chart-version-readme implementation.
+func ExtractAppVersionsFromValues(valuesPath string, headers []string) (AppVersionResult, error) {
+	res := AppVersionResult{Found: map[string]string{}}
+
+	eligible := func() []string {
+		var out []string
+		for _, h := range headers {
+			if strings.HasSuffix(h, versionSuffix) && h != "Chart Version" {
+				out = append(out, h)
+			}
+		}
+		return out
+	}
+
+	content, err := os.ReadFile(valuesPath)
+	if err != nil {
+		res.Missing = eligible()
+		return res, fmt.Errorf("read %s: %w", valuesPath, err)
+	}
+
+	var values map[string]interface{}
+	if err := yaml.Unmarshal(content, &values); err != nil {
+		res.Missing = eligible()
+		return res, fmt.Errorf("parse %s: %w", valuesPath, err)
+	}
+
+	for _, header := range headers {
+		if !strings.HasSuffix(header, versionSuffix) || header == "Chart Version" {
+			continue
+		}
+		componentKey := strings.ToLower(strings.TrimSuffix(header, versionSuffix))
+		if tag := GetImageTag(values, componentKey); tag != "" {
+			res.Found[header] = tag
+		} else {
+			res.Missing = append(res.Missing, header)
+		}
+	}
+
+	return res, nil
+}
+
+// GetImageTag extracts a component's image tag from a parsed values map, trying
+// {component}.image.tag first and falling back to a root-level image.tag (for
+// charts such as product-console whose values.yaml has image.tag at the root).
+// Returns "" when no tag is found.
+func GetImageTag(values map[string]interface{}, component string) string {
+	if componentSection, ok := values[component]; ok {
+		if componentMap, ok := componentSection.(map[string]interface{}); ok {
+			if tag := extractTagFromImageSection(componentMap); tag != "" {
+				return tag
+			}
+		}
+	}
+	// Fallback: root-level image.tag.
+	if tag := extractTagFromImageSection(values); tag != "" {
+		return tag
+	}
+	return ""
+}
+
+// extractTagFromImageSection returns the .tag of a map's "image" section,
+// coercing non-string scalars (int/float) to their string form. Returns ""
+// when the section, the image key, or the tag key is absent.
+func extractTagFromImageSection(section map[string]interface{}) string {
+	imageSection, ok := section["image"]
+	if !ok {
+		return ""
+	}
+	imageMap, ok := imageSection.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	tag, ok := imageMap["tag"]
+	if !ok {
+		return ""
+	}
+	switch v := tag.(type) {
+	case string:
+		return v
+	case int, float64:
+		return fmt.Sprintf("%v", v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/.github/scripts/tableutil/appversions_test.go
+++ b/.github/scripts/tableutil/appversions_test.go
@@ -1,0 +1,126 @@
+package tableutil
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func writeValues(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "values.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write values: %v", err)
+	}
+	return p
+}
+
+func TestExtractAppVersionsFromValues(t *testing.T) {
+	t.Run("multi-component: found + missing", func(t *testing.T) {
+		vals := `fees:
+  image:
+    tag: "3.3.0"
+mongodb:
+  enabled: true
+`
+		p := writeValues(t, vals)
+		res, err := ExtractAppVersionsFromValues(p, []string{"Chart Version", "Fees Version", "UI Version"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]string{"Fees Version": "3.3.0"}
+		if !reflect.DeepEqual(res.Found, want) {
+			t.Errorf("Found = %v, want %v", res.Found, want)
+		}
+		if !reflect.DeepEqual(res.Missing, []string{"UI Version"}) {
+			t.Errorf("Missing = %v, want [UI Version]", res.Missing)
+		}
+	})
+
+	t.Run("root-level image.tag fallback (product-console shape)", func(t *testing.T) {
+		vals := `image:
+  tag: "2.5.0"
+`
+		p := writeValues(t, vals)
+		res, err := ExtractAppVersionsFromValues(p, []string{"Chart Version", "Console Version"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.Found["Console Version"] != "2.5.0" {
+			t.Errorf("Console Version = %q, want 2.5.0 (root fallback)", res.Found["Console Version"])
+		}
+	})
+
+	t.Run("numeric tag coerced to string", func(t *testing.T) {
+		vals := `app:
+  image:
+    tag: 42
+`
+		p := writeValues(t, vals)
+		res, _ := ExtractAppVersionsFromValues(p, []string{"App Version"})
+		if res.Found["App Version"] != "42" {
+			t.Errorf("App Version = %q, want 42", res.Found["App Version"])
+		}
+	})
+
+	t.Run("missing file => all eligible headers missing + error", func(t *testing.T) {
+		res, err := ExtractAppVersionsFromValues(filepath.Join(t.TempDir(), "nope.yaml"), []string{"Chart Version", "Fees Version"})
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+		if !reflect.DeepEqual(res.Missing, []string{"Fees Version"}) {
+			t.Errorf("Missing = %v, want [Fees Version]", res.Missing)
+		}
+	})
+
+	t.Run("only Chart Version => nothing eligible", func(t *testing.T) {
+		p := writeValues(t, "fees:\n  image:\n    tag: \"1.0.0\"\n")
+		res, err := ExtractAppVersionsFromValues(p, []string{"Chart Version"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(res.Found) != 0 || len(res.Missing) != 0 {
+			t.Errorf("expected empty result, got Found=%v Missing=%v", res.Found, res.Missing)
+		}
+	})
+}
+
+func TestGetImageTag(t *testing.T) {
+	values := map[string]interface{}{
+		"fees": map[string]interface{}{
+			"image": map[string]interface{}{"tag": "3.3.0"},
+		},
+		"image": map[string]interface{}{"tag": "root-1.0.0"},
+	}
+	if got := GetImageTag(values, "fees"); got != "3.3.0" {
+		t.Errorf("fees tag = %q, want 3.3.0", got)
+	}
+	// Unknown component falls back to root image.tag.
+	if got := GetImageTag(values, "ui"); got != "root-1.0.0" {
+		t.Errorf("ui tag = %q, want root fallback root-1.0.0", got)
+	}
+	// No component and no root image => "".
+	if got := GetImageTag(map[string]interface{}{"x": 1}, "y"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestExtractAppVersions_DeterministicMissingOrder(t *testing.T) {
+	// Missing preserves header input order (stable diagnostics).
+	p := writeValues(t, "only:\n  image:\n    tag: \"1\"\n")
+	res, _ := ExtractAppVersionsFromValues(p, []string{"B Version", "A Version", "C Version"})
+	got := append([]string{}, res.Missing...)
+	want := []string{"B Version", "A Version", "C Version"}
+	if !reflect.DeepEqual(got, want) {
+		// guard against accidental sort
+		sort.Strings(want)
+		if reflect.DeepEqual(got, want) {
+			t.Errorf("Missing was sorted; expected input order, got %v", res.Missing)
+		} else {
+			t.Errorf("Missing = %v, want input order", res.Missing)
+		}
+	}
+}

--- a/.github/scripts/update-chart-version-readme/main.go
+++ b/.github/scripts/update-chart-version-readme/main.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/LerianStudio/helm/.github/scripts/tableutil"
-	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -100,98 +99,22 @@ func getChartDirectory(chartName string) string {
 }
 
 // extractAppVersionsFromValues reads values.yaml and extracts app versions
-// based on the table headers. For each "X Version" header, it looks for
-// the corresponding {x}.image.tag path in values.yaml
+// based on the table headers, delegating to the shared tableutil implementation
+// (kept as a thin wrapper so this tool preserves its stdout logging contract).
+// For each "X Version" header it resolves {x}.image.tag (root image.tag fallback).
 func extractAppVersionsFromValues(valuesPath string, headers []string) map[string]string {
-	versions := make(map[string]string)
-
-	content, err := os.ReadFile(valuesPath)
+	res, err := tableutil.ExtractAppVersionsFromValues(valuesPath, headers)
 	if err != nil {
-		fmt.Printf("WARNING: Could not read %s: %v\n", valuesPath, err)
-		return versions
+		fmt.Printf("WARNING: %v\n", err)
 	}
-
-	// Parse YAML into a generic map
-	var values map[string]interface{}
-	if err := yaml.Unmarshal(content, &values); err != nil {
-		fmt.Printf("WARNING: Could not parse %s: %v\n", valuesPath, err)
-		return versions
+	for header, tag := range res.Found {
+		fmt.Printf("Found %s = %s\n", header, tag)
 	}
-
-	// For each header that ends with " Version" (except "Chart Version"),
-	// derive the component name and look for {component}.image.tag
-	versionSuffix := " Version"
-	for _, header := range headers {
-		if !strings.HasSuffix(header, versionSuffix) || header == "Chart Version" {
-			continue
-		}
-
-		// Derive component name: "Auth Version" -> "auth"
-		componentName := strings.TrimSuffix(header, versionSuffix)
-		componentKey := strings.ToLower(componentName)
-
-		// Look for {component}.image.tag in values.yaml
-		tag := getImageTag(values, componentKey)
-		if tag != "" {
-			versions[header] = tag
-			fmt.Printf("Found %s = %s (from %s.image.tag)\n", header, tag, componentKey)
-		} else {
-			fmt.Printf("WARNING: Could not find %s.image.tag in values.yaml\n", componentKey)
-		}
+	for _, header := range res.Missing {
+		component := strings.ToLower(strings.TrimSuffix(header, " Version"))
+		fmt.Printf("WARNING: Could not find %s.image.tag in values.yaml\n", component)
 	}
-
-	return versions
-}
-
-// getImageTag extracts the image tag from a component's configuration
-// Looks for {component}.image.tag in the values map, with fallback to root image.tag
-func getImageTag(values map[string]interface{}, component string) string {
-	// First, try {component}.image.tag
-	if componentSection, ok := values[component]; ok {
-		if componentMap, ok := componentSection.(map[string]interface{}); ok {
-			if tag := extractTagFromImageSection(componentMap); tag != "" {
-				return tag
-			}
-		}
-	}
-
-	// Fallback: try image.tag directly at root level
-	// This handles charts where the values.yaml doesn't have a component section
-	// e.g., product-console where image.tag is at root instead of console.image.tag
-	if tag := extractTagFromImageSection(values); tag != "" {
-		fmt.Printf("  (found at root level image.tag)\n")
-		return tag
-	}
-
-	return ""
-}
-
-// extractTagFromImageSection extracts the tag from a map that contains an "image" section
-func extractTagFromImageSection(section map[string]interface{}) string {
-	imageSection, ok := section["image"]
-	if !ok {
-		return ""
-	}
-
-	imageMap, ok := imageSection.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	tag, ok := imageMap["tag"]
-	if !ok {
-		return ""
-	}
-
-	// Handle different tag types (string, number, etc.)
-	switch v := tag.(type) {
-	case string:
-		return v
-	case int, float64:
-		return fmt.Sprintf("%v", v)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
+	return res.Found
 }
 
 // updateAppVersions updates the rows with app versions extracted from values.yaml

--- a/.github/workflows/helm-chart-standard.yml
+++ b/.github/workflows/helm-chart-standard.yml
@@ -44,7 +44,10 @@ jobs:
 
       - name: Check compatibility matrix drift (non-blocking)
         working-directory: .github/scripts
-        run: go run ./generate-compatibility --root ../.. --check || true
+        # Drift is non-blocking by design: --check returns exit 0 on drift (ADR-4),
+        # exit 1/2 only on operational/usage errors (compile, module, FS). No
+        # `|| true` — that would also swallow those real failures.
+        run: go run ./generate-compatibility --root ../.. --check
 
       - name: Determine render scope
         id: render-scope

--- a/.github/workflows/helm-chart-standard.yml
+++ b/.github/workflows/helm-chart-standard.yml
@@ -8,6 +8,8 @@ on:
       - '.github/configs/helm-chart-standard-baseline.yaml'
       - '.github/configs/helm-render-values/**'
       - '.github/scripts/validate-helm-charts/**'
+      - '.github/scripts/generate-compatibility/**'
+      - '.github/scripts/tableutil/**'
       - '.github/workflows/helm-chart-standard.yml'
   workflow_dispatch:
   schedule:
@@ -39,6 +41,10 @@ jobs:
       - name: Validate chart standard
         working-directory: .github/scripts
         run: go run ./validate-helm-charts --root ../.. --strict
+
+      - name: Check compatibility matrix drift (non-blocking)
+        working-directory: .github/scripts
+        run: go run ./generate-compatibility --root ../.. --check || true
 
       - name: Determine render scope
         id: render-scope

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,10 @@ jobs:
       - name: Build scripts
         run: |
           cd .github/scripts
-          go build -o update-chart-version-readme-bin ./update-chart-version-readme
+          go build -o generate-compatibility-bin ./generate-compatibility
+
+      - name: Fetch tags for support window
+        run: git fetch --tags --force
 
       - name: Generate .releaserc file
         run: |
@@ -145,17 +148,19 @@ jobs:
 
           if [ "$CHART_NAME" == "plugin-access-manager" ] || [ "$CHART_NAME" == "otel-collector-lerian" ]; then
             PUSH_FILE="$CHART_NAME-\${nextRelease.version}.tgz"
+            COMPAT_CHART="$CHART_NAME"
           else
             PUSH_FILE="$CHART_NAME-helm-\${nextRelease.version}.tgz"
+            COMPAT_CHART="$CHART_NAME-helm"
           fi
 
           jq \
             --arg chartPath "$CHART_PATH" \
             --arg tagFormat "$CHART_NAME-v\${version}" \
             --arg successCmd "helm package $CHART_PATH && helm push $PUSH_FILE oci://ghcr.io/lerianstudio" \
-            --arg prepareCmd "./.github/scripts/update-chart-version-readme-bin --chart $CHART_NAME --version \${nextRelease.version}" \
+            --arg prepareCmd "./.github/scripts/generate-compatibility-bin --root . --chart $COMPAT_CHART --write" \
             '.plugins[2][1].chartPath = $chartPath |
-              .plugins[4][1].assets = [($chartPath + "/Chart.yaml"), "README.md"] |
+              .plugins[4][1].assets = [($chartPath + "/Chart.yaml"), "README.md", "docs/compatibility.json"] |
               .tagFormat = $tagFormat |
               .plugins[3][1].successCmd = $successCmd |
               .plugins[3][1].prepareCmd = $prepareCmd' \

--- a/README.md
+++ b/README.md
@@ -190,9 +190,13 @@ For implementation and configuration details, see the [README](https://charts.le
 
 #### Application Version Mapping
 
-| Chart Version | Tracer Version |
-| :---: | :---: |
-| `2.1.0` | 1.0.0 |
+<!-- BEGIN COMPAT:tracer-helm -->
+| Chart Version | Tracer Version | Released | Support |
+| :---: | :---: | :---: | :---: |
+| `2.1.0` | 1.0.0 | 2026-06-18 | 🟢 Full (N) |
+| `2.0.0` | — | 2026-06-09 | 🔵 Security (N-1) |
+| `1.0.0` | — | 2026-01-30 | 🟡 Extended (N-2) |
+<!-- END COMPAT:tracer-helm -->
 -----------------
 
 ### Otel Collector Lerian

--- a/docs/PROJECT_RULES.md
+++ b/docs/PROJECT_RULES.md
@@ -1,0 +1,23 @@
+# PROJECT_RULES — repo `LerianStudio/helm`
+
+> Regras específicas de tecnologia deste repositório. Ring Standards (coding patterns) valem por cima; este arquivo fixa **versões e escolhas locais**. Escopo atual: ferramental de build em `.github/scripts/` (não há serviço de produto neste repo).
+
+## Deployment model
+- **Build-time tooling** (CLIs Go executadas em GitHub Actions). Sem runtime de produção, banco, cache, fila, auth ou licenciamento neste repo.
+
+## Tech stack (ferramental `.github/scripts/`)
+| Categoria | Escolha | Versão | Constraint / Racional |
+|---|---|---|---|
+| Linguagem | Go | **1.21** | Piso duro (`go.mod`). Não subir sem bump coordenado de `setup-go`. |
+| Parse YAML | `gopkg.in/yaml.v3` | v3.0.1 | Já presente; padrão do módulo. |
+| SemVer | `github.com/Masterminds/semver/v3` | **v3.2.1** | Ranges + sort + grouping. **Capado em `<3.4`** enquanto Go=1.21 (v3.4+ sobem piso). Paridade com Helm 3.14.4. |
+| Lib interna | `tableutil` | — | Edição das tabelas do README. Reusar, não duplicar. |
+| Token CI | `actions/create-github-app-token` | @v1 | Manter pin do repo. |
+
+## Regras de dependência
+- Versões **explícitas** (sem `@latest`/ranges soltos). `go.sum` é o cache key de CI.
+- Não adotar `helm.sh/helm/v3` no ferramental (árvore transitiva pesada; tags `json:`).
+- Novas deps devem ser compatíveis com Go 1.21.
+
+## Licenças
+- Apenas permissivas (MIT/Apache-2.0/BSD). Sem GPL. Sem dependência comercial.

--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -1,0 +1,1361 @@
+{
+  "schemaVersion": 1,
+  "generatedFrom": "local",
+  "products": {
+    "br-sisbajud-helm": {
+      "dir": "br-sisbajud",
+      "current": "1.1.0",
+      "cycles": [
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2026-07-17",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.1",
+          "released": "2026-07-16",
+          "supported": true
+        }
+      ]
+    },
+    "br-spi-helm": {
+      "dir": "br-spi",
+      "current": "0.1.0-beta.1",
+      "cycles": [
+        {
+          "cycle": "0.1",
+          "latest": "0.1.0-beta.1",
+          "supported": true
+        }
+      ]
+    },
+    "fetcher-helm": {
+      "dir": "fetcher",
+      "current": "3.0.0",
+      "cycles": [
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.1",
+          "released": "2026-04-16",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.3",
+          "released": "2026-03-18",
+          "supported": true
+        },
+        {
+          "cycle": "1.3",
+          "latest": "1.3.0",
+          "released": "2026-03-05",
+          "supported": true
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.0",
+          "released": "2026-03-05",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2026-01-30",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-01-22",
+          "supported": false
+        }
+      ]
+    },
+    "flowker-helm": {
+      "dir": "flowker",
+      "current": "3.1.1",
+      "cycles": [
+        {
+          "cycle": "3.1",
+          "latest": "3.1.1",
+          "released": "2026-07-12",
+          "supported": true
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-04-16",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-02-06",
+          "supported": true
+        }
+      ]
+    },
+    "go-boilerplate-ddd-helm": {
+      "dir": "go-boilerplate-ddd",
+      "current": "2.2.0-beta.1",
+      "cycles": [
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0-beta.1",
+          "released": "2026-06-15",
+          "supported": true
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2026-06-12",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.1",
+          "released": "2026-05-25",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-04-28",
+          "supported": true
+        }
+      ]
+    },
+    "matcher-helm": {
+      "dir": "matcher",
+      "current": "3.0.0",
+      "cycles": [
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2026-04-16",
+          "supported": true
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.1",
+          "released": "2026-03-26",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.4",
+          "released": "2026-03-18",
+          "supported": true
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.0",
+          "released": "2026-02-27",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2026-01-30",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-01-28",
+          "supported": false
+        }
+      ]
+    },
+    "midaz-helm": {
+      "dir": "midaz",
+      "current": "8.6.0",
+      "cycles": [
+        {
+          "cycle": "8.6",
+          "latest": "8.6.0",
+          "released": "2026-07-17",
+          "supported": true
+        },
+        {
+          "cycle": "8.5",
+          "latest": "8.5.0",
+          "released": "2026-07-08",
+          "supported": true
+        },
+        {
+          "cycle": "8.4",
+          "latest": "8.4.0",
+          "released": "2026-06-23",
+          "supported": true
+        },
+        {
+          "cycle": "8.3",
+          "latest": "8.3.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "8.2",
+          "latest": "8.2.0",
+          "released": "2026-06-15",
+          "supported": false
+        },
+        {
+          "cycle": "8.1",
+          "latest": "8.1.1",
+          "released": "2026-06-09",
+          "supported": false
+        },
+        {
+          "cycle": "8.0",
+          "latest": "8.0.0",
+          "released": "2026-05-25",
+          "supported": false
+        },
+        {
+          "cycle": "7.0",
+          "latest": "7.0.0",
+          "released": "2026-05-14",
+          "supported": false
+        },
+        {
+          "cycle": "6.4",
+          "latest": "6.4.1",
+          "released": "2026-05-08",
+          "supported": false
+        },
+        {
+          "cycle": "6.3",
+          "latest": "6.3.0",
+          "released": "2026-04-27",
+          "supported": false
+        },
+        {
+          "cycle": "6.2",
+          "latest": "6.2.0",
+          "released": "2026-04-17",
+          "supported": false
+        },
+        {
+          "cycle": "6.1",
+          "latest": "6.1.0",
+          "released": "2026-04-16",
+          "supported": false
+        },
+        {
+          "cycle": "6.0",
+          "latest": "6.0.1",
+          "released": "2026-04-15",
+          "supported": false
+        },
+        {
+          "cycle": "5.7",
+          "latest": "5.7.0",
+          "released": "2026-03-10",
+          "supported": false
+        },
+        {
+          "cycle": "5.6",
+          "latest": "5.6.0",
+          "released": "2026-02-24",
+          "supported": false
+        },
+        {
+          "cycle": "5.5",
+          "latest": "5.5.1",
+          "released": "2026-02-03",
+          "supported": false
+        },
+        {
+          "cycle": "5.4",
+          "latest": "5.4.0",
+          "released": "2026-01-29",
+          "supported": false
+        },
+        {
+          "cycle": "5.3",
+          "latest": "5.3.0",
+          "released": "2026-01-19",
+          "supported": false
+        },
+        {
+          "cycle": "5.2",
+          "latest": "5.2.0",
+          "released": "2026-01-16",
+          "supported": false
+        },
+        {
+          "cycle": "5.1",
+          "latest": "5.1.2",
+          "released": "2026-01-15",
+          "supported": false
+        },
+        {
+          "cycle": "5.0",
+          "latest": "5.0.3",
+          "released": "2026-01-15",
+          "supported": false
+        },
+        {
+          "cycle": "4.5",
+          "latest": "4.5.1",
+          "released": "2026-02-19",
+          "supported": false
+        },
+        {
+          "cycle": "4.4",
+          "latest": "4.4.8",
+          "released": "2025-12-09",
+          "supported": false
+        },
+        {
+          "cycle": "4.3",
+          "latest": "4.3.10",
+          "released": "2026-02-18",
+          "supported": false
+        },
+        {
+          "cycle": "4.2",
+          "latest": "4.2.1",
+          "released": "2025-10-09",
+          "supported": false
+        },
+        {
+          "cycle": "4.1",
+          "latest": "4.1.0",
+          "released": "2025-10-07",
+          "supported": false
+        },
+        {
+          "cycle": "4.0",
+          "latest": "4.0.0",
+          "released": "2025-09-24",
+          "supported": false
+        },
+        {
+          "cycle": "3.3",
+          "latest": "3.3.0",
+          "released": "2025-09-23",
+          "supported": false
+        },
+        {
+          "cycle": "3.2",
+          "latest": "3.2.2",
+          "released": "2025-09-12",
+          "supported": false
+        },
+        {
+          "cycle": "3.1",
+          "latest": "3.1.0",
+          "released": "2025-08-19",
+          "supported": false
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.2",
+          "released": "2025-08-19",
+          "supported": false
+        },
+        {
+          "cycle": "2.7",
+          "latest": "2.7.0",
+          "released": "2025-08-05",
+          "supported": false
+        },
+        {
+          "cycle": "2.6",
+          "latest": "2.6.0",
+          "released": "2025-08-05",
+          "supported": false
+        },
+        {
+          "cycle": "2.5",
+          "latest": "2.5.0",
+          "released": "2025-06-20",
+          "supported": false
+        },
+        {
+          "cycle": "2.4",
+          "latest": "2.4.0",
+          "released": "2025-06-16",
+          "supported": false
+        },
+        {
+          "cycle": "2.3",
+          "latest": "2.3.1",
+          "released": "2025-06-10",
+          "supported": false
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2025-06-04",
+          "supported": false
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2025-06-03",
+          "supported": false
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2025-05-30",
+          "supported": false
+        },
+        {
+          "cycle": "1.63",
+          "latest": "1.63.0",
+          "released": "2025-05-16",
+          "supported": false
+        },
+        {
+          "cycle": "1.62",
+          "latest": "1.62.0",
+          "released": "2025-05-12",
+          "supported": false
+        },
+        {
+          "cycle": "1.61",
+          "latest": "1.61.0",
+          "released": "2025-05-07",
+          "supported": false
+        },
+        {
+          "cycle": "1.60",
+          "latest": "1.60.0",
+          "released": "2025-05-07",
+          "supported": false
+        },
+        {
+          "cycle": "1.59",
+          "latest": "1.59.1",
+          "released": "2025-04-22",
+          "supported": false
+        },
+        {
+          "cycle": "1.58",
+          "latest": "1.58.0",
+          "released": "2025-04-17",
+          "supported": false
+        },
+        {
+          "cycle": "1.57",
+          "latest": "1.57.1",
+          "released": "2025-04-16",
+          "supported": false
+        },
+        {
+          "cycle": "1.56",
+          "latest": "1.56.0",
+          "released": "2025-04-15",
+          "supported": false
+        },
+        {
+          "cycle": "1.55",
+          "latest": "1.55.0",
+          "released": "2025-04-15",
+          "supported": false
+        },
+        {
+          "cycle": "1.54",
+          "latest": "1.54.1",
+          "released": "2025-04-11",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2025-04-11",
+          "supported": false
+        }
+      ]
+    },
+    "notifications-helm": {
+      "dir": "notifications",
+      "current": "1.0.0-beta.4",
+      "cycles": [
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0-beta.4",
+          "released": "2026-06-18",
+          "supported": true
+        }
+      ]
+    },
+    "otel-collector-lerian": {
+      "dir": "otel-collector-lerian",
+      "current": "4.1.0",
+      "cycles": [
+        {
+          "cycle": "4.1",
+          "latest": "4.1.0",
+          "released": "2026-06-23",
+          "supported": true
+        },
+        {
+          "cycle": "4.0",
+          "latest": "4.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-04-27",
+          "supported": true
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.1",
+          "released": "2025-12-23",
+          "supported": true
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.1",
+          "released": "2025-12-08",
+          "supported": false
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2025-09-24",
+          "supported": false
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.0",
+          "released": "2025-09-23",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.2",
+          "released": "2025-09-12",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2025-08-19",
+          "supported": false
+        }
+      ]
+    },
+    "plugin-access-manager": {
+      "dir": "plugin-access-manager",
+      "current": "8.3.0",
+      "cycles": [
+        {
+          "cycle": "8.3",
+          "latest": "8.3.0",
+          "released": "2026-07-07",
+          "supported": true
+        },
+        {
+          "cycle": "8.2",
+          "latest": "8.2.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "8.1",
+          "latest": "8.1.0",
+          "released": "2026-06-09",
+          "supported": true
+        },
+        {
+          "cycle": "8.0",
+          "latest": "8.0.1",
+          "released": "2026-05-27",
+          "supported": true
+        },
+        {
+          "cycle": "7.0",
+          "latest": "7.0.0",
+          "released": "2026-05-19",
+          "supported": false
+        },
+        {
+          "cycle": "6.5",
+          "latest": "6.5.0",
+          "released": "2026-05-14",
+          "supported": false
+        },
+        {
+          "cycle": "6.4",
+          "latest": "6.4.1",
+          "released": "2026-04-29",
+          "supported": false
+        },
+        {
+          "cycle": "6.3",
+          "latest": "6.3.0",
+          "released": "2026-04-27",
+          "supported": false
+        },
+        {
+          "cycle": "6.2",
+          "latest": "6.2.0",
+          "released": "2026-04-16",
+          "supported": false
+        },
+        {
+          "cycle": "6.1",
+          "latest": "6.1.1",
+          "released": "2026-04-09",
+          "supported": false
+        },
+        {
+          "cycle": "6.0",
+          "latest": "6.0.0",
+          "released": "2026-03-11",
+          "supported": false
+        },
+        {
+          "cycle": "5.4",
+          "latest": "5.4.0",
+          "released": "2026-03-05",
+          "supported": false
+        },
+        {
+          "cycle": "5.3",
+          "latest": "5.3.0",
+          "released": "2026-03-03",
+          "supported": false
+        },
+        {
+          "cycle": "5.2",
+          "latest": "5.2.2",
+          "released": "2026-01-16",
+          "supported": false
+        },
+        {
+          "cycle": "5.1",
+          "latest": "5.1.0",
+          "released": "2026-01-15",
+          "supported": false
+        },
+        {
+          "cycle": "5.0",
+          "latest": "5.0.0",
+          "released": "2026-01-15",
+          "supported": false
+        },
+        {
+          "cycle": "4.2",
+          "latest": "4.2.2",
+          "released": "2026-01-07",
+          "supported": false
+        },
+        {
+          "cycle": "4.1",
+          "latest": "4.1.1",
+          "released": "2025-12-08",
+          "supported": false
+        },
+        {
+          "cycle": "4.0",
+          "latest": "4.0.0",
+          "released": "2025-09-24",
+          "supported": false
+        },
+        {
+          "cycle": "3.2",
+          "latest": "3.2.0",
+          "released": "2025-09-23",
+          "supported": false
+        },
+        {
+          "cycle": "3.1",
+          "latest": "3.1.3",
+          "released": "2025-09-12",
+          "supported": false
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.2",
+          "released": "2025-08-19",
+          "supported": false
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2025-06-24",
+          "supported": false
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2025-06-04",
+          "supported": false
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2025-06-02",
+          "supported": false
+        },
+        {
+          "cycle": "1.8",
+          "latest": "1.8.0",
+          "released": "2025-05-29",
+          "supported": false
+        },
+        {
+          "cycle": "1.7",
+          "latest": "1.7.0",
+          "released": "2025-05-07",
+          "supported": false
+        },
+        {
+          "cycle": "1.6",
+          "latest": "1.6.0",
+          "released": "2025-05-07",
+          "supported": false
+        },
+        {
+          "cycle": "1.5",
+          "latest": "1.5.0",
+          "released": "2025-04-22",
+          "supported": false
+        },
+        {
+          "cycle": "1.4",
+          "latest": "1.4.1",
+          "released": "2025-04-17",
+          "supported": false
+        },
+        {
+          "cycle": "1.3",
+          "latest": "1.3.1",
+          "released": "2025-04-16",
+          "supported": false
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.0",
+          "released": "2025-04-15",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2025-04-15",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.1",
+          "released": "2025-04-11",
+          "supported": false
+        }
+      ]
+    },
+    "plugin-bc-correios-helm": {
+      "dir": "plugin-bc-correios",
+      "current": "2.2.0",
+      "cycles": [
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2026-06-09",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-06-09",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.1",
+          "released": "2026-04-28",
+          "supported": true
+        }
+      ]
+    },
+    "plugin-br-bank-transfer-helm": {
+      "dir": "plugin-br-bank-transfer",
+      "current": "1.3.0",
+      "cycles": [
+        {
+          "cycle": "1.3",
+          "latest": "1.3.0",
+          "released": "2026-07-08",
+          "supported": true
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.1",
+          "released": "2026-06-24",
+          "supported": true
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.1",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-06-12",
+          "supported": true
+        }
+      ]
+    },
+    "plugin-br-payments-helm": {
+      "dir": "plugin-br-payments",
+      "current": "1.1.0-beta.3",
+      "cycles": [
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0-beta.3",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-05-21",
+          "supported": true
+        }
+      ]
+    },
+    "plugin-br-pix-direct-jd-helm": {
+      "dir": "plugin-br-pix-direct-jd",
+      "current": "3.0.0",
+      "cycles": [
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.11",
+          "released": "2026-05-14",
+          "supported": true
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2026-04-27",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-04-16",
+          "supported": true
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.6",
+          "released": "2025-12-10",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2025-10-31",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2025-10-07",
+          "supported": false
+        }
+      ]
+    },
+    "plugin-br-pix-indirect-btg-helm": {
+      "dir": "plugin-br-pix-indirect-btg",
+      "current": "3.5.0",
+      "cycles": [
+        {
+          "cycle": "3.5",
+          "latest": "3.5.0",
+          "released": "2026-07-17",
+          "supported": true
+        },
+        {
+          "cycle": "3.4",
+          "latest": "3.4.0",
+          "released": "2026-07-08",
+          "supported": true
+        },
+        {
+          "cycle": "3.3",
+          "latest": "3.3.1",
+          "released": "2026-06-24",
+          "supported": true
+        },
+        {
+          "cycle": "3.2",
+          "latest": "3.2.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "3.1",
+          "latest": "3.1.0",
+          "released": "2026-06-09",
+          "supported": false
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.1",
+          "released": "2026-05-23",
+          "supported": false
+        },
+        {
+          "cycle": "2.3",
+          "latest": "2.3.0",
+          "released": "2026-05-12",
+          "supported": false
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2026-04-16",
+          "supported": false
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.1",
+          "released": "2026-03-26",
+          "supported": false
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-03-11",
+          "supported": false
+        },
+        {
+          "cycle": "1.7",
+          "latest": "1.7.0",
+          "released": "2026-03-06",
+          "supported": false
+        },
+        {
+          "cycle": "1.6",
+          "latest": "1.6.0",
+          "released": "2026-03-03",
+          "supported": false
+        },
+        {
+          "cycle": "1.5",
+          "latest": "1.5.0",
+          "released": "2026-02-27",
+          "supported": false
+        },
+        {
+          "cycle": "1.4",
+          "latest": "1.4.0",
+          "released": "2026-02-20",
+          "supported": false
+        },
+        {
+          "cycle": "1.3",
+          "latest": "1.3.4",
+          "released": "2026-02-12",
+          "supported": false
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.1",
+          "released": "2026-01-29",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.1",
+          "released": "2026-01-26",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-01-21",
+          "supported": false
+        }
+      ]
+    },
+    "plugin-br-pix-switch-helm": {
+      "dir": "plugin-br-pix-switch",
+      "current": "2.0.0",
+      "cycles": [
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-04-27",
+          "supported": true
+        }
+      ]
+    },
+    "plugin-fees-helm": {
+      "dir": "plugin-fees",
+      "current": "7.2.0",
+      "cycles": [
+        {
+          "cycle": "7.2",
+          "latest": "7.2.0",
+          "released": "2026-07-17",
+          "supported": true
+        },
+        {
+          "cycle": "7.1",
+          "latest": "7.1.0",
+          "released": "2026-07-08",
+          "supported": true
+        },
+        {
+          "cycle": "7.0",
+          "latest": "7.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "6.0",
+          "latest": "6.0.0",
+          "released": "2026-05-14",
+          "supported": true
+        },
+        {
+          "cycle": "5.4",
+          "latest": "5.4.0",
+          "released": "2026-04-29",
+          "supported": false
+        },
+        {
+          "cycle": "5.3",
+          "latest": "5.3.0",
+          "released": "2026-04-27",
+          "supported": false
+        },
+        {
+          "cycle": "5.2",
+          "latest": "5.2.0",
+          "released": "2026-04-17",
+          "supported": false
+        },
+        {
+          "cycle": "5.1",
+          "latest": "5.1.0",
+          "released": "2026-04-17",
+          "supported": false
+        },
+        {
+          "cycle": "5.0",
+          "latest": "5.0.0",
+          "released": "2026-04-16",
+          "supported": false
+        },
+        {
+          "cycle": "4.1",
+          "latest": "4.1.2",
+          "released": "2026-02-19",
+          "supported": false
+        },
+        {
+          "cycle": "4.0",
+          "latest": "4.0.0",
+          "released": "2026-01-22",
+          "supported": false
+        },
+        {
+          "cycle": "3.5",
+          "latest": "3.5.1",
+          "released": "2025-12-30",
+          "supported": false
+        },
+        {
+          "cycle": "3.4",
+          "latest": "3.4.7",
+          "released": "2025-12-08",
+          "supported": false
+        },
+        {
+          "cycle": "3.3",
+          "latest": "3.3.0",
+          "released": "2025-10-31",
+          "supported": false
+        },
+        {
+          "cycle": "3.2",
+          "latest": "3.2.0",
+          "released": "2025-10-15",
+          "supported": false
+        },
+        {
+          "cycle": "3.1",
+          "latest": "3.1.1",
+          "released": "2025-10-14",
+          "supported": false
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2025-09-24",
+          "supported": false
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2025-09-23",
+          "supported": false
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.1",
+          "released": "2025-09-12",
+          "supported": false
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.2",
+          "released": "2025-08-19",
+          "supported": false
+        },
+        {
+          "cycle": "1.3",
+          "latest": "1.3.0",
+          "released": "2025-06-20",
+          "supported": false
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.0",
+          "released": "2025-06-10",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2025-05-16",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2025-05-07",
+          "supported": false
+        }
+      ]
+    },
+    "product-console-helm": {
+      "dir": "product-console",
+      "current": "3.2.0",
+      "cycles": [
+        {
+          "cycle": "3.2",
+          "latest": "3.2.0",
+          "released": "2026-07-20",
+          "supported": true
+        },
+        {
+          "cycle": "3.1",
+          "latest": "3.1.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-06-01",
+          "supported": true
+        },
+        {
+          "cycle": "2.3",
+          "latest": "2.3.0",
+          "released": "2026-04-27",
+          "supported": true
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2026-04-17",
+          "supported": false
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2026-04-16",
+          "supported": false
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.1",
+          "released": "2026-04-02",
+          "supported": false
+        },
+        {
+          "cycle": "1.3",
+          "latest": "1.3.0",
+          "released": "2026-03-11",
+          "supported": false
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.0",
+          "released": "2026-03-06",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2026-01-30",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-01-15",
+          "supported": false
+        }
+      ]
+    },
+    "reporter-helm": {
+      "dir": "reporter",
+      "current": "3.1.1",
+      "cycles": [
+        {
+          "cycle": "3.1",
+          "latest": "3.1.1",
+          "released": "2026-06-24",
+          "supported": true
+        },
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.2",
+          "latest": "2.2.0",
+          "released": "2026-04-27",
+          "supported": true
+        },
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2026-04-16",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-03-18",
+          "supported": false
+        },
+        {
+          "cycle": "1.2",
+          "latest": "1.2.1",
+          "released": "2026-03-11",
+          "supported": false
+        },
+        {
+          "cycle": "1.1",
+          "latest": "1.1.0",
+          "released": "2026-03-05",
+          "supported": false
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-02-06",
+          "supported": false
+        }
+      ]
+    },
+    "tracer-helm": {
+      "dir": "tracer",
+      "current": "2.1.0",
+      "cycles": [
+        {
+          "cycle": "2.1",
+          "latest": "2.1.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-06-09",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.0",
+          "released": "2026-01-30",
+          "supported": true
+        }
+      ]
+    },
+    "underwriter-helm": {
+      "dir": "underwriter",
+      "current": "3.0.0",
+      "cycles": [
+        {
+          "cycle": "3.0",
+          "latest": "3.0.0",
+          "released": "2026-06-18",
+          "supported": true
+        },
+        {
+          "cycle": "2.0",
+          "latest": "2.0.0",
+          "released": "2026-04-16",
+          "supported": true
+        },
+        {
+          "cycle": "1.0",
+          "latest": "1.0.1",
+          "released": "2026-02-19",
+          "supported": true
+        }
+      ]
+    }
+  }
+}

--- a/docs/pre-dev/helm-version-compatibility-matrix/BACKLOG.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/BACKLOG.md
@@ -1,0 +1,40 @@
+# Backlog — Fases Futuras (fora do v1)
+
+Itens conscientemente adiados para manter o v1 enxuto. Decisões registradas nesta sessão.
+
+## TODO-1 — Assistência para preencher `requires` (anti-erro manual)
+**Contexto:** editar a annotation `lerian.studio/compatibility` à mão é a peça mais frágil do desenho (erro de sintaxe YAML, range semver inválido, produto inexistente). No **v1 fica manual** (aceito para não inflar escopo/tempo). Duas abordagens aprovadas para depois:
+
+- **TODO-1a — Comando CLI que escreve a annotation.** Ex.: `generate-compatibility set-requires --chart plugin-fees --requires midaz-helm@">=8.4 <9"`. A ferramenta escreve o YAML formatado e **já validado** → dev nunca edita YAML cru. Mata erro de sintaxe.
+- **TODO-1b — Mapear no AGENT do Ring.** Dev pede em linguagem natural para a IA (agent Ring) e ela gera a annotation validada. **É a solução preferida do usuário.** Precisa: deixar essa capacidade mapeada/documentada no agent Ring apropriado (provável dev-sre / ou skill nova de "declarar compatibilidade de chart"). Não implementado no v1.
+
+**Nota:** `testedWith` NÃO precisa disso — é derivável do release (FR-8, backfill automático). O problema manual é só o `requires`.
+
+**Escopo do fardo (CORRIGIDO 2026-07-22 — estimativa anterior estava errada):** dependência entre produtos NÃO é medida pelas `dependencies:` do Chart.yaml (essas só listam INFRA: postgres/mongo/valkey). O sinal REAL está nos `values.yaml`, em variáveis de runtime tipo `MIDAZ_TRANSACTION_URL`, `PLUGIN_AUTH_ADDRESS` (URLs apontando pra outro produto Lerian). Medido assim: **~16 dos 21 charts referenciam outros produtos** (plugins BR Pix/bank-transfer/payments têm dezenas de refs; product-console 10; access-manager 7). Ou seja: **compat cruzada (#2) é a REGRA, não a exceção.** Consequência: mapear `requires` à mão em ~16 charts é inviável → **TODO-1b (IA/agent gera o requires) deixa de ser opcional e vira NECESSÁRIO para escala.** Ressalva: nem toda ref vira `requires` versionável (ex.: access-manager/auth é quase universal); refinar quais deps merecem entrar no `requires` é parte do TODO-1.
+O eixo #1 (suporte de versões) permanece 100% automático para TODOS — dev não mantém nada.
+
+## DECISÃO — `testedWith` REMOVIDO do v1 (2026-07-27)
+**Contexto:** `requires` (a REGRA: faixa semver que o produto exige) e `testedWith` (o FATO: versão exata testada junto) respondem perguntas diferentes. Mas `testedWith` DIGITADO À MÃO no v1 é fraco (dev só repete o topo da faixa → redundante com requires). Só tem valor quando é VERDADE OBSERVADA de um E2E. **Decisão do usuário:** v1 = annotation com SÓ `requires`; sem `testedWith` manual, sem backfill de testedWith (o FR-8 do PRD sai do v1). `testedWith` volta na v2, preenchido automaticamente pelo E2E (ver TODO-2). A ferramenta CONTINUA aceitando `testedWith` no schema/parser/JSON (omitempty; sem coluna se ausente) — validado: annotation só-requires funciona, JSON omite testedWith. Zero retrabalho pra v2.
+
+## TODO-2 — Preencher `requires`/`testedWith` a partir de teste E2E (v2)
+**Contexto:** DECISÃO — no **v1 o DESENVOLVEDOR determina o `requires`** (declara à mão na annotation da versão atual; só o N tem valor, N-1..N-3 mostram `—`). Na **v2**, preencher `requires` E `testedWith` AUTOMATICAMENTE a partir dos **testes automatizados E2E** (pipeline multi-produto **em desenvolvimento**): o que roda verde com os produtos juntos vira a verdade declarada — observada, não digitada. Casa com o TODO-1b (agent/IA) como as duas frentes de tirar o fardo manual do dev. Depende do E2E existir. Fora do v1.
+
+## TODO-3 — Campos do `compatibility.json` a definir com o time do Console
+**Contexto:** o time do product-console ainda **não foi consultado** sobre o que vai consumir. O JSON v1 é **mínimo e estável** (`schemaVersion`, `products{current, cycles{cycle, latest, supported, requires?, testedWith?}}`). Campos extras que o console pedir (ex.: label legível, custo, badge) entram como **aditivos** (não incrementam `schemaVersion`, não quebram). Conversar com o console antes de enriquecer.
+
+## TODO-4 — Promover checks de WARN para gate bloqueante
+**Contexto:** v1 é não-bloqueante (tudo WARN, exit 0). Quando a adoção estabilizar, promover V1–V5 (annotation) e o drift-check a **ERRO** (exit 1). É mudança de comportamento → major da feature, anunciada.
+
+## RISCO-A — VERIFICADO E DESCARTADO ✅ (2026-07-23)
+**Contexto:** `charts/*/Chart.yaml` é atualizado via `app-sync.yml` → shared-workflow externo `helm-update-chart.yml@v1.36.8`. Medo: reescrever o Chart.yaml e apagar a annotation `lerian.studio/compatibility`.
+**Verificação:** li o shared-workflow (clone em `/home/gauchito/lerian/github-actions-shared-workflows`). Ele faz UMA edição cirúrgica no Chart.yaml — `yq -i '.appVersion = "..."'` (linha 383, mikefarah/yq v4) — e só isso; o resto é `values.yaml` ({comp}.image.tag) e templates. **NÃO toca annotations/version/dependencies.**
+**Teste real:** rodei o EXATO comando (mikefarah/yq -i .appVersion) no Chart.yaml do fees COM a annotation → diff mostrou APENAS a linha appVersion mudada; a annotation compatibility (bloco YAML multi-linha) ficou byte-idêntica, formatação inclusa. **A annotation sobrevive ao app-sync.** Nenhuma ação necessária.
+
+## TODO-6 — Visibilidade dos WARN no CI (decidir na T-8)
+**Contexto:** a ferramenta emite WARN em stderr (ex.: coluna de app cuja `{comp}.image.tag` não existe no values → `—` + WARN; annotation malformada; drift). Hoje isso vai só pro log. **Decisão do usuário: manter `—` + WARN (não propagar dado fantasma).** Mas "onde o humano vê o WARN" fica pra T-8 (integração CI): (a) só stderr no log do Actions [fraco, some em job verde]; (b) anotação no PR [médio, autor vê]; (c) resumo agregado / comentário no PR [forte]. Recomendação: decidir (b)/(c) na T-8. No piloto (tracer, 1 coluna que resolve) NÃO há WARN.
+
+**Achado relevante (2026-07-23):** o README atual do plugin-fees mostra `UI Version: 3.0.0` que é HARDCODED manual — o `values.yaml` do fees NÃO tem seção `ui:` (só global/fees/mongodb/otel/aws), então `ui.image.tag` não existe. É dado fantasma (drift manual). A automação, ao pôr `—`+WARN, é mais honesta que o README atual. Investigar (fora do piloto) se a coluna UI ainda faz sentido no fees ou é resíduo.
+
+## TODO-5 — Datas de EOL por calendário
+**Contexto:** v1 classifica por posição (N-x), sem data de EOL concreta. Contrato prevê notificação de EOL com 6 meses de antecedência. Fase futura: calcular `eolDate` por ciclo (minor trimestral) e expor no JSON (campo aditivo) + notificação ativa.
+**DESTRAVADO parcialmente:** o v1 JÁ captura a data de LANÇAMENTO de cada versão (coluna "Released" no README + campo `released` no JSON, vindo de `git creatordate` da tag). Com released + cadência trimestral do contrato, dá pra derivar `eolDate` = released + N trimestres. A matéria-prima já existe; falta só o cálculo + exposição.

--- a/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
@@ -123,10 +123,10 @@ Ferramenta batch determinística. Duas operações mutuamente exclusivas, seleci
 | Código | Significado (v1) |
 |---|---|
 | 0 | Sucesso — inclui casos com WARN (dado malformado, produto inexistente, drift) |
-| 1 | Falha **operacional** apenas (não conteúdo): `--root` inexistente, sem permissão de escrita, flag inválida, README ilegível |
-| 2 | Uso incorreto (flags conflitantes, ex.: `--write` + `--check`) |
+| 1 | Falha **operacional** apenas (não conteúdo, não uso): `--root` inexistente, sem permissão de escrita, README ilegível |
+| 2 | **Uso incorreto**: flags conflitantes (`--write` + `--check`), flag inválida/malformada, `--chart` inexistente |
 
-> Princípio v1: **problema de dado do usuário = WARN + exit 0** (não trava CI). **Problema do ambiente/uso = exit ≠ 0**.
+> Princípio v1: **problema de dado do usuário = WARN + exit 0** (não trava CI). **Problema operacional = exit 1. Uso incorreto = exit 2.** (flag inválida é uso → exit 2, não 1.)
 
 ### II.3 Contrato de mensagens (stderr)
 Formato estável, uma linha por ocorrência, prefixo de severidade:

--- a/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
@@ -21,8 +21,9 @@
 ### I.2 Gramática (v1)
 ```
 compatibility   := requires? testedWith?
-requires        := "requires:"    mapping<productKey, semverRange>     # OPCIONAL no v1
-testedWith      := "testedWith:"  mapping<productKey, exactVersion>    # preenchido no v1
+requires        := "requires:"    mapping<productKey, semverRange>     # OPCIONAL no v1 (dev declara)
+testedWith      := "testedWith:"  mapping<productKey, exactVersion>    # ACEITO p/ forward-compat, mas NÃO usado no v1
+                                                                       # (removido do v1; volta na v2 via E2E — ver BACKLOG)
 productKey      := nome do chart-alvo tal como publicado (ex.: "midaz-helm", "plugin-access-manager")
 semverRange     := constraint Masterminds/semver  (ex.: ">=8.4.0 <9.0.0", "~8.4", "^8.4.0", "8.x || 9.x")
 exactVersion    := versão semver exata (ex.: "8.6.0", "1.2.1-beta.11")

--- a/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
@@ -16,7 +16,7 @@
 ### I.1 Localização e forma
 - Vive em `Chart.yaml` → `annotations["lerian.studio/compatibility"]`.
 - É uma **string** cujo conteúdo é um **documento YAML embutido** (block scalar `|`). Não é nesting YAML nativo (Helm exige annotations = `map[string]string`).
-- **Ausência é válida.** Chart sem a annotation → tratado como "sem compatibilidade declarada" (só janela de suporte derivada; sem coluna "Requer").
+- **Ausência é válida.** Chart sem a annotation → tratado como "sem compatibilidade declarada" (só janela de suporte derivada; sem coluna "Requires").
 
 ### I.2 Gramática (v1)
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/api-design.md
@@ -1,0 +1,181 @@
+# API / Contract Design — Matriz de Compatibilidade (v1)
+
+| | |
+|---|---|
+| gate | 4 — API/Contract Design |
+| date | 2026-07-22 |
+| confidence | 87 / 100 |
+| refs | [trd.md](trd.md) · [prd.md](prd.md) · [feature-map.md](feature-map.md) · [research.md](research.md) |
+
+> **Nota:** esta feature não expõe API HTTP. As duas interfaces são: **(I) o contrato declarativo da annotation** `lerian.studio/compatibility` (o que o **dev escreve**) e **(II) o contrato CLI** da ferramenta `generate-compatibility` (o que o **CI executa**). O `compatibility.json` (o que **cliente/ferramenta consomem**) é contrato de dados e vai no Gate 5 (Data Model). Todos os três são versionados.
+
+---
+
+## I. Contrato Declarativo — annotation `lerian.studio/compatibility`
+
+### I.1 Localização e forma
+- Vive em `Chart.yaml` → `annotations["lerian.studio/compatibility"]`.
+- É uma **string** cujo conteúdo é um **documento YAML embutido** (block scalar `|`). Não é nesting YAML nativo (Helm exige annotations = `map[string]string`).
+- **Ausência é válida.** Chart sem a annotation → tratado como "sem compatibilidade declarada" (só janela de suporte derivada; sem coluna "Requer").
+
+### I.2 Gramática (v1)
+```
+compatibility   := requires? testedWith?
+requires        := "requires:"    mapping<productKey, semverRange>     # OPCIONAL no v1
+testedWith      := "testedWith:"  mapping<productKey, exactVersion>    # preenchido no v1
+productKey      := nome do chart-alvo tal como publicado (ex.: "midaz-helm", "plugin-access-manager")
+semverRange     := constraint Masterminds/semver  (ex.: ">=8.4.0 <9.0.0", "~8.4", "^8.4.0", "8.x || 9.x")
+exactVersion    := versão semver exata (ex.: "8.6.0", "1.2.1-beta.11")
+```
+
+### I.3 Regras de validação
+| # | Regra | Severidade v1 |
+|---|---|---|
+| V1 | A string deve ser YAML válido | WARN (não bloqueia) |
+| V2 | Só as chaves `requires` e `testedWith` são reconhecidas; outras → ignoradas com aviso | WARN |
+| V3 | Cada `productKey` em `requires`/`testedWith` deve corresponder a um chart existente no repo | WARN |
+| V4 | Cada valor de `requires` deve ser um constraint semver Masterminds parseável | WARN |
+| V5 | Cada valor de `testedWith` deve ser versão semver exata | WARN |
+| V6 | `requires` pode ser omitido (v1); `testedWith` é esperado (mas ausência não bloqueia) | INFO |
+
+> **Fase futura:** V1–V5 podem ser promovidas a ERRO (bloqueante) quando o gate for ligado. No v1, **tudo é WARN/INFO e o processo continua** (ADR-4).
+
+### I.4 Exemplos
+
+**Válido — completo:**
+```yaml
+annotations:
+  lerian.studio/chart-type: multi-component
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: ">=8.4.0 <9.0.0"
+    testedWith:
+      midaz-helm: "8.6.0"
+```
+
+**Válido — só testedWith (o caso típico do v1 pós-backfill):**
+```yaml
+  lerian.studio/compatibility: |
+    testedWith:
+      midaz-helm: "8.6.0"
+```
+
+**Válido — ausente** (chart base, ex.: midaz; ou chart standalone, ex.: matcher): sem a annotation.
+
+**Inválido → WARN (V4, range não parseável), processo segue:**
+```yaml
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: "maior que 8"     # não é constraint semver
+```
+
+**Inválido → WARN (V3, produto inexistente):**
+```yaml
+  lerian.studio/compatibility: |
+    requires:
+      midaz-ledger: ">=8.0.0"       # não existe chart "midaz-ledger"
+```
+
+**Inválido → WARN (V1, YAML quebrado):**
+```yaml
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm ">=8.4.0"          # falta os dois-pontos
+```
+
+### I.5 Versionamento da annotation
+- v1 tem gramática fixa (`requires`/`testedWith`). Chaves novas futuras (ex.: `supportedSince`, `incompatibleWith`) entram como **aditivas e opcionais** — chaves desconhecidas são ignoradas com WARN (V2), garantindo compat retroativa.
+- Formalizada em `docs/helm-chart-standard.md` (subseção nova).
+
+---
+
+## II. Contrato CLI — `generate-compatibility`
+
+### II.1 Operações (modos)
+Ferramenta batch determinística. Duas operações mutuamente exclusivas, selecionadas por flag.
+
+#### Operação: WRITE (default)
+- **Propósito:** gerar/atualizar as saídas (bloco COMPAT no README de cada chart afetado + `docs/compatibility.json`).
+- **Idempotência:** rodar 2× sobre o mesmo estado → mesmos bytes. Reescreve integralmente o conteúdo entre markers; nunca faz append.
+
+| Parâmetro | Tipo | Obrig. | Default | Descrição |
+|---|---|---|---|---|
+| `--write` | flag | não | ligado | Modo escrita (implícito se nenhum modo dado) |
+| `--root` | caminho | não | `../..` | Raiz do repo (espelha as ferramentas irmãs) |
+| `--chart` | string | não | (todos) | Restringe a geração do README a um chart; o JSON é **sempre** regenerado por completo (determinismo) |
+| `--output` | caminho | não | `docs/compatibility.json` | Destino do artefato de máquina |
+
+**Saída (sucesso):** arquivos escritos no disco. `stdout`: resumo por chart (`updated`/`unchanged`/`created-section`). Exit **0**.
+
+#### Operação: CHECK (drift)
+- **Propósito:** detectar desatualização sem escrever. Gera em memória, compara com o disco.
+- **Uso:** PR-time em `helm-chart-standard.yml`.
+
+| Parâmetro | Tipo | Obrig. | Default | Descrição |
+|---|---|---|---|---|
+| `--check` | flag | sim (p/ este modo) | — | Modo verificação; não escreve nada |
+| `--root` | caminho | não | `../..` | idem |
+
+**Saída (v1):** se em dia → `stdout` "ok", exit **0**. Se drift → `stderr` `WARN: <chart> compatibility block is stale` **+ exit 0** (não bloqueia no v1). *(Fase futura: exit 1.)*
+
+### II.2 Contrato de exit codes
+| Código | Significado (v1) |
+|---|---|
+| 0 | Sucesso — inclui casos com WARN (dado malformado, produto inexistente, drift) |
+| 1 | Falha **operacional** apenas (não conteúdo): `--root` inexistente, sem permissão de escrita, flag inválida, README ilegível |
+| 2 | Uso incorreto (flags conflitantes, ex.: `--write` + `--check`) |
+
+> Princípio v1: **problema de dado do usuário = WARN + exit 0** (não trava CI). **Problema do ambiente/uso = exit ≠ 0**.
+
+### II.3 Contrato de mensagens (stderr)
+Formato estável, uma linha por ocorrência, prefixo de severidade:
+```
+WARN  <chart>: <regra> — <detalhe>        # ex.: WARN plugin-fees: V4 — requires[midaz-helm] range inválido ">2"
+INFO  <chart>: <detalhe>                   # ex.: INFO br-spi: nenhuma tag publicada; janela = só N (Chart.yaml)
+ERROR <detalhe>                            # só para exit 1/2
+```
+- Prefixos (`WARN`/`INFO`/`ERROR`) são contrato estável (parseáveis por CI/log).
+- `stdout` = resultado da operação (resumo write / "ok"|drift do check). `stderr` = diagnósticos. Separação estrita.
+
+### II.4 Comportamento determinístico (garantias)
+- Ordem de charts, de linhas de versão e de chaves no JSON é **estável** (ordenação definida, não depende de iteração de mapa).
+- Sem acesso de rede além das tags git já presentes no checkout.
+- `N` sempre de `Chart.yaml.version`; `N-1..N-3` das tags. Fetch incompleto → janela parcial + INFO, nunca erro (NFR-3, FR-7).
+
+### II.5 Versionamento do CLI
+- Flags v1 são um contrato aditivo: flags novas futuras não removem/renomeiam as existentes.
+- `--check` promover a bloqueante (exit 1) é **mudança de comportamento** reservada para uma major da feature, anunciada.
+
+---
+
+## III. Interações entre contratos (fluxo)
+```
+Dev escreve annotation (Contrato I)
+   └─► release/PR executa generate-compatibility (Contrato II)
+          ├─ WRITE → README (bloco entre markers) + docs/compatibility.json (Gate 5)
+          └─ CHECK → WARN de drift (exit 0 v1)
+                 └─► Cliente/ferramenta lê docs/compatibility.json (Contrato de dados — Gate 5)
+```
+
+---
+
+## IV. Testing Contracts
+- **Annotation (I):** casos por regra V1–V6 (válido completo, só testedWith, ausente, YAML quebrado, range inválido, produto inexistente, chave desconhecida) → asserção de severidade e exit 0.
+- **CLI (II):** `--write` idempotente (2× = mesmo byte); `--check` detecta drift e retorna exit 0 + WARN; flags conflitantes → exit 2; `--root` inválido → exit 1; `--chart X` só toca o bloco de X.
+- Contrato de mensagem: golden-file dos prefixos WARN/INFO.
+
+---
+
+## Gate 4 — Validação
+| Categoria | Status |
+|---|---|
+| Todas as interfaces com contrato (annotation + CLI; dados no Gate 5) | ✅ |
+| Operações com propósito claro e nomes consistentes (WRITE/CHECK) | ✅ |
+| Inputs tipados, obrigatórios vs opcionais explícitos | ✅ |
+| Erros identificados + severidade + exit codes | ✅ (WARN/INFO/ERROR + 0/1/2) |
+| Idempotência documentada | ✅ (II.1, II.4) |
+| Validação explícita (V1–V6) com exemplos válidos/inválidos | ✅ |
+| Versionamento dos contratos definido | ✅ (I.5, II.5) |
+| Backward-compat (aditivo; promoção a bloqueante = major) | ✅ |
+
+**Resultado: ✅ PASS → Gate 5 (Data Model)**

--- a/docs/pre-dev/helm-version-compatibility-matrix/data-model.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/data-model.md
@@ -1,0 +1,194 @@
+# Data Model — Matriz de Compatibilidade (v1)
+
+| | |
+|---|---|
+| gate | 5 — Data Model |
+| date | 2026-07-22 |
+| confidence | 89 / 100 |
+| refs | [api-design.md](api-design.md) · [trd.md](trd.md) · [prd.md](prd.md) · [research.md](research.md) |
+
+> **Nota:** não há banco de dados. As "entidades" são: **(A) structs internas** do gerador (transientes, em memória) e **(B) o documento `compatibility.json`** — a interface de dados **pública e versionada** que cliente/console consomem. Não há persistência mutável; o JSON é derivado, idempotente e regenerado por completo a cada execução. Sem lifecycle de update/delete: só "gerado".
+
+---
+
+## 0. DOIS EIXOS INDEPENDENTES (fundamento — decisão do usuário 2026-07-22)
+
+A feature tem **dois conceitos ortogonais** que NÃO devem ser confundidos:
+
+| Eixo | O que responde | Fonte | Vale pra | Coluna README |
+|---|---|---|---|---|
+| **#1 Suporte de versões** | "quais versões da PRÓPRIA app têm suporte" (N/N-1/N-2/N-3) | `version` + tags git | **TODOS os charts, sempre** | **Support** (sempre presente) |
+| **#2 Compatibilidade cruzada** | "com qual versão de OUTRO produto combina" | annotation `requires`/`testedWith` | só charts que dependem de outro | **Requer &lt;produto&gt;** (condicional) |
+
+- **#1 é universal e 100% automático** — dev não mantém nada; atualiza no release (version bump + tags).
+- **#2 é opcional e manual (v1)** — só multi-component com dependência real de produto Lerian. `requires` = conhecimento humano.
+
+**Regra de auto-avaliação (usa o `lerian.studio/chart-type` que JÁ existe em todos os 21 charts):**
+```
+chart-type == single-service   → standalone: NÃO espera #2. Sem coluna Requer. Script NÃO cobra (sem INFO).
+chart-type == multi-component
+   ou dependency-wrapper        → PODE ter #2. Se não declarar requires → INFO (lembrete suave, não bloqueia).
+```
+Reusa a etiqueta existente (9 single-service, 11 multi-component, 1 dependency-wrapper) — sem variável nova, intenção auditável, distingue "standalone de propósito" de "esqueceram".
+
+**Coluna do README renomeada:** "Status" → **"Support"** (decisão do usuário).
+
+---
+
+## 1. Vocabulário de Tier (APRESENTAÇÃO — derivado de posição, NÃO fica no JSON)
+
+**Decisão (usuário):** `tier` é conceito **interno/de apresentação**, derivável de posição (N-x). **NÃO é campo do `compatibility.json`.** O JSON é factual (`current` + `cycles` ordenados desc + `supported`); qualquer consumidor deriva o tier pelo **índice do ciclo** (0=N, 1=N-1, 2=N-2, 3=N-3, ≥4/`supported:false`=EOL). Evita dado redundante que pode divergir.
+
+Mapa de posição → apresentação (usado só pelo **renderer do README** e, se quiser, pelo console):
+
+| Posição | Nível (contrato LTS) | Custo | Badge (README) |
+|---|---|---|---|
+| N (índice 0) | Full Support | Incluído | 🟢 |
+| N-1 | Security | Incluído | 🔵 |
+| N-2 | Extended | +30% | 🟡 |
+| N-3 | Extended | +150% | 🟠 |
+| N-4+ / `supported:false` | Legacy / EOL | — | 🔴 |
+
+> `VersionRow.tier` (struct interna A.3) permanece como enum interno pra alimentar o render do README, mas **não é serializado** no JSON público.
+
+---
+
+## 2. Entidades internas (A) — em memória, owned pelo gerador
+
+### A.1 `CompatAnnotation` — o que o dev declarou
+- **Purpose:** representação parseada da annotation `lerian.studio/compatibility`.
+- **Owned by:** C-1 Chart Reader.
+- **Primary id:** nenhum (embutido no ChartState).
+
+| Atributo | Tipo | Obrig. | Constraints | Descrição |
+|---|---|---|---|---|
+| requires | Map&lt;ProductKey, SemverRange&gt; | não (v1) | cada range parseável (V4) | Dependência técnica declarada |
+| testedWith | Map&lt;ProductKey, ExactVersion&gt; | não | cada versão exata (V5) | Combinação testada em release |
+
+Ausência do objeto inteiro = válida (chart sem compatibilidade declarada).
+
+### A.2 `ChartState` — estado lido de um chart
+- **Owned by:** C-1. **Primary id:** `name`.
+
+| Atributo | Tipo | Obrig. | Constraints | Descrição |
+|---|---|---|---|---|
+| name | ProductKey | sim | único no repo | Nome publicado (ex.: `midaz-helm`) |
+| dir | String | sim | único | Diretório em `charts/` (ex.: `midaz`) — prefixo das tags |
+| version | Semver | sim | válido | **N (autoridade)** — de `Chart.yaml` |
+| appVersion | Semver | não | — | Versão do app (informativo) |
+| compat | CompatAnnotation | não | — | A.1 |
+| tags | List&lt;Semver&gt; | não | derivadas de `<dir>-v*` | Histórico p/ N-1..N-3 |
+
+> **Caso real verificado no repo (2026-07-22):** `midaz` tem `Chart.yaml.version=8.6.0` mas existe a tag `midaz-v8.7.0-beta.1` (**acima** de N e pre-release), além de `8.4.0-beta.{1,2,3}` e `8.5.0-beta.1`. Regras de C-2 confirmadas obrigatórias e viram **casos de teste (T-3)**: (a) **N = Chart.yaml, nunca a maior tag** — senão N sairia `8.7.0-beta`; (b) **descartar tags > N** ao montar N-1..N-3; (c) **segregar pre-releases** antes de agrupar por minor. Filtro `<dir>-v*` confirmado correto (formato real = `midaz-v8.6.0`).
+
+### A.3 `VersionRow` — uma linha da janela de suporte
+- **Owned by:** C-2 Support Window Resolver. **Relationship:** ChartState (1) ──< 1..4 >── VersionRow (janela) + até 1 linha-resumo EOL.
+
+| Atributo | Tipo | Obrig. | Constraints | Descrição |
+|---|---|---|---|---|
+| version | Semver | sim | — | Versão do chart naquele ciclo |
+| minorCycle | String | sim | `MAJOR.MINOR` | Ciclo (ex.: `8.6`) |
+| tier | TierEnum | sim | §1 | Nível de suporte |
+| isEOL | Boolean | sim | — | true → agrupado na linha-resumo |
+| requires | Map&lt;ProductKey, SemverRange&gt; | não | — | Copiado de compat p/ render "Requer" |
+
+**Regra de derivação (C-2):** segregar pre-releases → agrupar por `minorCycle` → ordenar desc → N = `version` do Chart.yaml, N-1..N-3 = 3 minors distintas imediatamente inferiores nas tags → resto = `eol` (colapsado em 1 linha-resumo). `<4` minors ⇒ menos linhas; `0` tags ⇒ só a linha N.
+
+---
+
+## 3. Entidade pública (B) — `compatibility.json` (contrato versionado)
+
+- **Purpose:** interface legível por máquina consumida por cliente/console/ferramentas (US-5).
+- **Owned by:** C-3b (gerador é a única autoridade de escrita; consumidores são read-only).
+- **Consistência:** derivado, eventual (regenerado no release). Fonte de verdade continua sendo Chart.yaml+tags; o JSON é **projeção**.
+
+### B.1 Documento raiz
+| Campo | Tipo | Obrig. | Descrição |
+|---|---|---|---|
+| schemaVersion | Integer | sim | Versão do contrato do documento. v1 = `1`. Monotônico, distinto de qualquer `$schema`. |
+| generatedFrom | String | sim | Referência de proveniência (ex.: commit/branch) — informativo |
+| products | Map&lt;ProductKey, Product&gt; | sim | Um por chart ativo |
+
+### B.2 `Product`
+| Campo | Tipo | Obrig. | Nullable | Descrição |
+|---|---|---|---|---|
+| dir | String | sim | não | Diretório do chart |
+| current | Semver | sim | não | N (= Chart.yaml.version) |
+| cycles | List&lt;Cycle&gt; | sim | não | Ordenada desc; até 4 sob suporte + ciclos EOL colapsados conforme render |
+
+### B.3 `Cycle` (linha por ciclo minor — modelo endoflife.date)
+| Campo | Tipo | Obrig. | Nullable | Descrição |
+|---|---|---|---|---|
+| cycle | String | sim | não | `MAJOR.MINOR` (ex.: `8.6`) |
+| latest | Semver | sim | não | Maior patch estável do ciclo |
+| supported | Boolean | sim | não | `false` ⟺ fora da janela N..N-3 (idioma bool endoflife.date). **Tier NÃO fica no JSON** — deriva-se de posição/`supported` (§1). |
+| requires | Map&lt;ProductKey, SemverRange&gt; | não | sim | Compatibilidade cruzada declarada (ausente no v1 se não declarada) |
+| testedWith | Map&lt;ProductKey, ExactVersion&gt; | não | sim | Preenchido no v1 (backfill) |
+
+> Ordem de `cycles` (desc) é o contrato: o consumidor lê posição para tier. Índice 0 = `current` = N.
+
+### B.4 Exemplo real (números do repo)
+```json
+{
+  "schemaVersion": 1,
+  "generatedFrom": "main@<commit>",
+  "products": {
+    "midaz-helm": {
+      "dir": "midaz",
+      "current": "8.6.0",
+      "cycles": [
+        { "cycle": "8.6", "latest": "8.6.0", "supported": true  },
+        { "cycle": "8.5", "latest": "8.5.0", "supported": true  },
+        { "cycle": "8.4", "latest": "8.4.0", "supported": true  },
+        { "cycle": "8.3", "latest": "8.3.0", "supported": true  },
+        { "cycle": "8.2", "latest": "8.2.0", "supported": false }
+      ]
+    },
+    "plugin-fees-helm": {
+      "dir": "plugin-fees",
+      "current": "7.2.0",
+      "cycles": [
+        { "cycle": "7.2", "latest": "7.2.0", "supported": true,
+          "requires":   { "midaz-helm": ">=8.4.0 <9.0.0" },
+          "testedWith": { "midaz-helm": "8.6.0" } }
+      ]
+    }
+  }
+}
+```
+*(Nota: `plugin-fees` só tem 1 ciclo aqui porque as tags de histórico não existem no clone atual — FR-7 degradação graciosa. O `requires` aparece porque foi declarado; no backfill v1 puro só `testedWith` estaria presente.)*
+
+---
+
+## 4. Custom Types
+| Tipo | Base | Formato | Exemplo |
+|---|---|---|---|
+| ProductKey | String | nome de chart publicado | `midaz-helm`, `plugin-access-manager` |
+| Semver | String | SemVer 2.0 | `8.6.0`, `1.2.1-beta.11` |
+| SemverRange | String | constraint Masterminds | `>=8.4.0 <9.0.0`, `~8.4`, `8.x \|\| 9.x` |
+| ExactVersion | Semver | — | `8.6.0` |
+| TierEnum | String | enum §1 (**interno**, não serializado no JSON) | `full` |
+
+---
+
+## 5. Migration / Versionamento do schema
+- **Aditivo não-quebra:** novos campos opcionais em `Product`/`Cycle` (ex.: `eolDate` numa fase futura) → **não** incrementam `schemaVersion`; consumidores antigos ignoram.
+- **Quebra:** remover/renomear campo, mudar semântica de `tier` → incrementa `schemaVersion` para `2`; consumidores validam e migram um passo.
+- v1 congela: `schemaVersion:1` com os campos acima.
+
+---
+
+## Gate 5 — Validação
+| Categoria | Status |
+|---|---|
+| Entidades modeladas (CompatAnnotation, ChartState, VersionRow, Product/Cycle) | ✅ |
+| Atributos tipados, obrig/opcional e nullability explícitos | ✅ |
+| Relacionamentos com cardinalidade (ChartState 1──<1..4 VersionRow) | ✅ |
+| Ownership único (C-1 lê, C-2 deriva, C-3b escreve; consumidor read-only) | ✅ |
+| Enum de tier canônico e fechado, com regra forward-compat | ✅ |
+| Constraints/validação (V4/V5, `supported`⟺`eol`) | ✅ |
+| Lifecycle (derivado/regenerado; sem update/delete mutável) | ✅ |
+| Versionamento do contrato de dados (schemaVersion aditivo vs quebra) | ✅ |
+| Exemplo real com números do repo | ✅ |
+
+**Resultado: ✅ PASS → Gate 6 (Dependency Map)** — PAUSA para validação da interface (conforme pedido).

--- a/docs/pre-dev/helm-version-compatibility-matrix/data-model.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/data-model.md
@@ -18,14 +18,14 @@ A feature tem **dois conceitos ortogonais** que NÃO devem ser confundidos:
 | Eixo | O que responde | Fonte | Vale pra | Coluna README |
 |---|---|---|---|---|
 | **#1 Suporte de versões** | "quais versões da PRÓPRIA app têm suporte" (N/N-1/N-2/N-3) | `version` + tags git | **TODOS os charts, sempre** | **Support** (sempre presente) |
-| **#2 Compatibilidade cruzada** | "com qual versão de OUTRO produto combina" | annotation `requires`/`testedWith` | só charts que dependem de outro | **Requer &lt;produto&gt;** (condicional) |
+| **#2 Compatibilidade cruzada** | "com qual versão de OUTRO produto combina" | annotation `requires`/`testedWith` | só charts que dependem de outro | **Requires &lt;produto&gt;** (condicional) |
 
 - **#1 é universal e 100% automático** — dev não mantém nada; atualiza no release (version bump + tags).
 - **#2 é opcional e manual (v1)** — só multi-component com dependência real de produto Lerian. `requires` = conhecimento humano.
 
 **Regra de auto-avaliação (usa o `lerian.studio/chart-type` que JÁ existe em todos os 21 charts):**
 ```
-chart-type == single-service   → standalone: NÃO espera #2. Sem coluna Requer. Script NÃO cobra (sem INFO).
+chart-type == single-service   → standalone: NÃO espera #2. Sem coluna Requires. Script NÃO cobra (sem INFO).
 chart-type == multi-component
    ou dependency-wrapper        → PODE ter #2. Se não declarar requires → INFO (lembrete suave, não bloqueia).
 ```
@@ -90,7 +90,7 @@ Ausência do objeto inteiro = válida (chart sem compatibilidade declarada).
 | minorCycle | String | sim | `MAJOR.MINOR` | Ciclo (ex.: `8.6`) |
 | tier | TierEnum | sim | §1 | Nível de suporte |
 | isEOL | Boolean | sim | — | true → agrupado na linha-resumo |
-| requires | Map&lt;ProductKey, SemverRange&gt; | não | — | Copiado de compat p/ render "Requer" |
+| requires | Map&lt;ProductKey, SemverRange&gt; | não | — | Copiado de compat p/ render "Requires" |
 
 **Regra de derivação (C-2):** segregar pre-releases → agrupar por `minorCycle` → ordenar desc → N = `version` do Chart.yaml, N-1..N-3 = 3 minors distintas imediatamente inferiores nas tags → resto = `eol` (colapsado em 1 linha-resumo). `<4` minors ⇒ menos linhas; `0` tags ⇒ só a linha N.
 

--- a/docs/pre-dev/helm-version-compatibility-matrix/dependency-map.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/dependency-map.md
@@ -1,0 +1,89 @@
+# Dependency Map — Matriz de Compatibilidade (v1)
+
+| | |
+|---|---|
+| gate | 6 — Dependency Map |
+| date | 2026-07-22 |
+| standards_loaded | golang.md, devops.md (Gate 3) |
+| project_rules | ver `docs/PROJECT_RULES.md` (mínimo, escopado à ferramenta) |
+| confidence | 92 / 100 (stack familiar, versões verificadas, sem CVE, licenças permissivas) |
+| refs | [trd.md](trd.md) · [api-design.md](api-design.md) · [data-model.md](data-model.md) · [research.md](research.md) |
+
+> **Escopo:** ferramental de **build-time** (CLI Go + steps de CI). **Sem** runtime de produção, banco, cache, fila, rede, auth ou licenciamento — logo as seções de Auth/License/Cost de infra do gate **não se aplicam** (custo incremental = 0; roda no runner de CI existente).
+
+---
+
+## 1. Runtime / Toolchain
+
+| Item | Versão | Constraint | Justificativa |
+|---|---|---|---|
+| Go | **1.21** | **piso duro — NÃO subir** | `directive go 1.21` em `.github/scripts/go.mod`. Subir o piso quebraria o módulo e forçaria bump de `actions/setup-go`. Toda dep nova deve ser compatível com 1.21. |
+| Módulo Go | `github.com/LerianStudio/helm/.github/scripts` | — | Módulo único que já hospeda as 4 ferramentas irmãs + lib `tableutil`. A nova ferramenta entra aqui. |
+
+## 2. Dependências Go
+
+### 2.1 Reusadas (já no go.mod — sem mudança)
+| Pacote | Versão | Uso nesta feature | Licença |
+|---|---|---|---|
+| `gopkg.in/yaml.v3` | v3.0.1 | Parse do Chart.yaml + two-step unmarshal da annotation (string YAML embutida) | MIT/Apache-2.0 |
+| `golang.org/x/text` | v0.21.0 | (indireto, já presente; não usado diretamente) | BSD-3-Clause |
+| `tableutil` (interno) | — | Edição segura das tabelas do README entre markers | (repo) |
+
+### 2.2 NOVA dependência a adicionar
+| Pacote | Versão | Uso | Licença |
+|---|---|---|---|
+| **`github.com/Masterminds/semver/v3`** | **v3.2.1** | Ordenar tags (`semver.Collection`), avaliar ranges de `requires` (`NewConstraint().Check`), agrupar por minor (`Major()/Minor()`) | MIT |
+
+**Análise da versão (crítica):**
+- **v3.2.1** → `go 1.18` directive. **Compatível com o piso 1.21.** É **exatamente** a versão que Helm 3.14.4 pina → paridade com o ecossistema Helm.
+- v3.3.1 → `go 1.21` (também compatível, mas floors exatamente em 1.21). **v3.5.0 (latest) → exige `go 1.26` = PROIBIDO** (forçaria bump do módulo).
+- **Decisão:** pinar **v3.2.1**. Não usar `@latest`.
+- **Alternativa rejeitada:** `golang.org/x/mod/semver` — só compara strings, **não tem parser de range** (`>=8.4.0 <9.0.0`), inviável para `requires`.
+- **Alternativa rejeitada:** `helm.sh/helm/v3` (traria `chart.Metadata`) — **overkill**: árvore transitiva enorme (k8s.io/*, oras, containerd), tags `json:` incompatíveis com o parse yaml.v3 atual. Modelar structs próprias é mais leve.
+
+**Segurança:** Masterminds/semver v3.2.1 — sem CVE conhecido (biblioteca pura, sem I/O/rede). Mantida (usada pelo Helm). Adição ao `go.sum` verificável.
+
+## 3. Dependências de CI (GitHub Actions) — reusadas
+
+| Ação/recurso | Versão/pin | Uso | Nota |
+|---|---|---|---|
+| `actions/create-github-app-token` | **@v1** (manter pin do repo) | Token do bot p/ o step de write-back (2B) | App-token dispara CI → 3 camadas anti-loop obrigatórias |
+| `crazy-max/ghaction-import-gpg` | (já no job) | **Reusar** o GPG já importado — commit verified | NÃO reimportar |
+| `actions/setup-go` | (já no repo, go 1.21) | Build da ferramenta | cache key = `.github/scripts/go.sum` |
+| `git` (runner) | nativo | `git fetch --tags --force` p/ histórico N-1..N-3 | `fetch-depth: 0` já usado |
+
+## 4. Manifest & Lock
+- **Manifest:** `.github/scripts/go.mod` — adicionar `require github.com/Masterminds/semver/v3 v3.2.1`.
+- **Lock:** `.github/scripts/go.sum` — atualizado por `go mod tidy`; é o **cache key de CI**.
+- **Upgrade policy:** semver/v3 **capado em `<3.4`** enquanto o módulo for `go 1.21` (v3.4+ sobem o piso). Documentar no PROJECT_RULES.
+
+## 5. Licenças (resumo)
+| Licença | Pacotes | Ação |
+|---|---|---|
+| MIT | Masterminds/semver, yaml.v3 | Nenhuma restrição a uso comercial; atribuição já coberta pelo go.sum |
+| BSD-3-Clause | golang.org/x/text | idem |
+Sem GPL. Sem dependência comercial. Nada a notificar ao jurídico.
+
+## 6. Custo
+**Incremental = US$ 0.** Roda no runner de CI que já executa `validate-helm-charts`/`generate-values-schemas`. Sem infra nova, sem serviço gerenciado, sem armazenamento pago (o JSON vive no repo git).
+
+## 7. Mudanças fora de código (recap do TRD §9)
+- `pr-title.yml`: garantir scope permitido para os PRs (ex.: `ci`, `charts`, `doc`) — checar allowlist existente antes de abrir PR.
+- `docs/helm-chart-standard.md`: subseção nova formalizando a annotation (não é dependência, é contrato/doc).
+
+---
+
+## Gate 6 — Validação
+| Categoria | Status |
+|---|---|
+| Standards carregados (golang.md, devops.md) | ✅ (Gate 3) |
+| PROJECT_RULES.md gerado (mínimo, escopado) | ✅ |
+| Toda dep com versão explícita (sem @latest) | ✅ (semver v3.2.1 pinado) |
+| Sem conflito de versão (compat Go 1.21 verificada) | ✅ |
+| Sem CVE crítico/alto | ✅ (semver puro, sem I/O) |
+| Licenças compatíveis (MIT/BSD, sem GPL) | ✅ |
+| Auth/License libs | N/A (ferramental de build, não serviço) |
+| Custo documentado | ✅ (US$ 0 incremental) |
+| Todo componente do TRD mapeado a tecnologia | ✅ |
+
+**Resultado: ✅ PASS → Gate 7 (Task Breakdown)**

--- a/docs/pre-dev/helm-version-compatibility-matrix/feature-map.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/feature-map.md
@@ -1,0 +1,164 @@
+# Feature Map — Matriz de Compatibilidade de Versões (v1)
+
+| | |
+|---|---|
+| **PRD** | `docs/pre-dev/helm-version-compatibility-matrix/prd.md` |
+| **Gate** | 2 — Feature Map |
+| **Date** | 2026-07-22 |
+| **Status** | Locked após validação |
+| **Confidence** | 88 / 100 |
+
+---
+
+## 1. Feature Inventory
+
+### Core (bloqueiam o resto)
+| ID | Nome | Descrição | Valor | Depende de |
+|---|---|---|---|---|
+| F-1 | Fonte declarativa por produto | Cada produto declara sua compatibilidade num único lugar, separando "exige" de "testado com" | Verdade única, junto do produto | — |
+| F-2 | Janela de suporte derivada | Calcula automaticamente o nível (Full/Security/Extended×2/EOL) da versão atual + histórico | Ninguém digita "N-3"; contrato vira automação | F-1 (versão atual), histórico de versões |
+| F-3 | Geração automática na publicação | Ao publicar uma versão, regenera as saídas daquele produto | Zero manutenção manual | F-1, F-2, F-4, F-5 |
+
+### Supporting (materializam a saída)
+| ID | Nome | Descrição | Valor | Depende de |
+|---|---|---|---|---|
+| F-4 | Visualização legível | Tabela por produto: versões sob suporte + nível + compatibilidade cruzada; EOL resumido | Cliente decide migração em segundos | F-1, F-2 |
+| F-5 | Representação por máquina | Mesma informação estruturada e versionada, derivada da mesma fonte | Consumo futuro por ferramentas | F-1, F-2 |
+
+### Enhancement (qualidade / confiança)
+| ID | Nome | Descrição | Valor | Depende de |
+|---|---|---|---|---|
+| F-6 | Avisos não-bloqueantes | Alerta sobre dado malformado/inexistente e sobre divergência gerado↔fonte, sem impedir | Higiene sem travar entrega | F-1, F-3 |
+| F-7 | Degradação graciosa | Produtos com <4 versões (ou 0) mostram só o que existe | Sem erro em produto novo | F-2 |
+| F-8 | Preenchimento inicial derivável | Backfill automático do "testado com" da release atual em todos os produtos ativos | Matriz nasce populada no dia 1 | F-1 |
+
+*Não há categoria Integration no v1: a exibição fora do local público primário (painel, portal de docs) é out-of-scope e consumirá F-5 numa fase futura.*
+
+---
+
+## 2. Domain Groupings
+
+### Domínio A — Declaração de Compatibilidade
+- **Propósito:** capturar, junto de cada produto, a verdade sobre o que ele exige e com o que foi testado.
+- **Features:** F-1, F-8.
+- **Owns:** o dado declarado de compatibilidade por produto.
+- **Provides:** a fonte única consumida por todo o resto.
+- **Consumes:** nada (é a raiz).
+
+### Domínio B — Cálculo de Suporte
+- **Propósito:** transformar versão atual + histórico no nível de suporte por versão, segundo o contrato LTS.
+- **Features:** F-2, F-7.
+- **Owns:** a regra da janela N..N-3 e o tratamento de histórico incompleto.
+- **Consumes:** versão atual e histórico (Domínio A + fonte de histórico).
+- **Provides:** a classificação de suporte usada nas saídas.
+
+### Domínio C — Materialização das Saídas
+- **Propósito:** produzir as duas visões (legível e por máquina) a partir da fonte + classificação.
+- **Features:** F-4, F-5.
+- **Consumes:** Domínios A e B.
+- **Provides:** artefatos consumíveis por cliente e por ferramenta.
+
+### Domínio D — Orquestração & Higiene
+- **Propósito:** disparar a geração na publicação e sinalizar inconsistências.
+- **Features:** F-3, F-6.
+- **Consumes:** Domínios A, B, C.
+- **Provides:** atualização automática e avisos.
+
+Dependências cross-domain fluem em **uma direção**: A → B → C → D. Sem ciclos.
+
+---
+
+## 3. User Journeys
+
+### J-1 — Cliente verifica se sua versão é suportada (P1)
+1. Abre o local público de informação de instalação.
+2. Localiza o produto e sua versão instalada. *(F-4)*
+3. Lê o nível de suporte da versão (Full/Security/Extended/EOL). *(F-2 → F-4)*
+4. **Sucesso:** decide migrar ou não. **Falha graciosa:** produto novo com poucas versões mostra só o que há. *(F-7)*
+
+### J-2 — Cliente planeja atualizar um produto sem quebrar outro (P1)
+1. Vê a versão que pretende adotar do produto A. *(F-4)*
+2. Lê com quais versões do produto B ela combina. *(F-1 → F-4)*
+3. **Sucesso:** confirma compatibilidade antes de atualizar. **Limitação v1:** se A não declarou "exige", a coluna não aparece — cliente cai no caso J-1. *(R-2 do PRD)*
+
+### J-3 — Engenharia publica uma nova versão (P3)
+1. Publica a versão do produto (fluxo existente).
+2. A geração regenera as saídas daquele produto. *(F-3 → F-4, F-5)*
+3. Se a declaração estiver inconsistente, recebe aviso — publicação segue. *(F-6)*
+4. **Sucesso:** saídas atualizadas sem edição manual.
+
+### J-4 — Suporte direciona o cliente (P2)
+1. Recebe pergunta "essa versão tem suporte?".
+2. Aponta para a visualização única e atual. *(F-4)*
+3. **Sucesso:** autoatendimento; sem resposta caso a caso.
+
+---
+
+## 4. Feature Interaction Map
+
+```
+[F-1 Fonte declarativa] ──┬─────────────► [F-4 Visualização legível] ──► J-1,J-2,J-4
+        ▲                 │                        ▲
+        │                 └──► [F-2 Janela] ───────┤
+   [F-8 Backfill]              [F-7 gracioso]      │
+                                   │               └──► [F-5 Repr. máquina] ──► (fase futura)
+                                   ▼
+                         [F-3 Geração na publicação] ──► J-3
+                                   │
+                                   └──► [F-6 Avisos]
+```
+
+### Matriz de dependências
+| Feature | Depende de | Bloqueia | Opcional |
+|---|---|---|---|
+| F-1 | — | F-2,F-4,F-5,F-8 | — |
+| F-2 | F-1 + histórico | F-4,F-5 | — |
+| F-3 | F-1,F-2,F-4,F-5 | J-3 | — |
+| F-4 | F-1,F-2 | J-1,J-2,J-4 | — |
+| F-5 | F-1,F-2 | fase futura | sim (não bloqueia leitura humana) |
+| F-6 | F-1,F-3 | — | sim |
+| F-7 | F-2 | — | — |
+| F-8 | F-1 | — | sim (matriz funciona vazia, só menos rica) |
+
+---
+
+## 5. Phasing Strategy
+
+**Fase 1 (este v1):** F-1..F-8 sem bloqueio. Entrega: visualização + representação por máquina, geradas automaticamente, com backfill do derivável. Critério de saída: 100% dos produtos ativos com suporte gerado, 0 edições manuais.
+
+**Gatilhos p/ fase futura:** (a) times de produto começam a preencher "exige" → matriz cruzada enriquece; (b) demanda por bloqueio → promover F-6 de aviso a gate; (c) consumo real de F-5 pelo painel do cliente.
+
+---
+
+## 6. Scope Boundaries
+
+- **In:** F-1..F-8 (v1 do PRD §9).
+- **Out:** bloqueio de publicação, backfill completo de "exige", exibição em painel/portal, datas de EOL por calendário, notificação ativa de EOL (PRD §9 out-of-scope).
+- **Assumções:** versão declarada = autoridade do "N"; histórico recuperável; cada time é autoridade do "exige".
+- **Constraint:** saída convive com documentação existente sem corrompê-la (NFR-2).
+
+---
+
+## 7. Risk Assessment
+
+| Risco | Origem | Mitigação |
+|---|---|---|
+| Histórico incompleto → janela parcial | F-2/F-7 | F-7 degradação; N vem da declaração, não do histórico |
+| "Exige" vazio → matriz rasa | F-1/F-8 | aceito; enriquece por fase |
+| Divergência gerado↔fonte passa despercebida | F-6 | aviso de drift na publicação |
+| Corromper documentação existente | F-4 | geração confinada e idempotente (NFR-4) |
+
+---
+
+## Gate 2 — Validação
+| Check | Status |
+|---|---|
+| Todas as features do PRD mapeadas | ✅ (F-1..F-8) |
+| Categorias atribuídas | ✅ |
+| Domínios coesos, sem ciclo (A→B→C→D) | ✅ |
+| Jornadas completas (happy + falha graciosa) | ✅ (J-1..J-4) |
+| Pontos de integração e direção claros | ✅ |
+| Prioridade/fase suporta entrega incremental | ✅ |
+| Sem detalhe técnico | ✅ |
+
+**Resultado: ✅ PASS → Gate 3 (TRD)**

--- a/docs/pre-dev/helm-version-compatibility-matrix/prd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/prd.md
@@ -1,0 +1,167 @@
+# PRD — Matriz de Compatibilidade de Versões dos Charts (v1)
+
+| | |
+|---|---|
+| **Date** | 2026-07-22 |
+| **Feature** | helm-version-compatibility-matrix |
+| **Track** | Large (9 gates) |
+| **Gate** | 1 — PRD |
+| **Research** | `docs/pre-dev/helm-version-compatibility-matrix/research.md` |
+| **Confidence** | 82 / 100 (proven pattern, dor qualitativa clara, valor de negócio direto) |
+
+---
+
+## 1. Executive Summary
+
+Os clientes que instalam os produtos Lerian não têm hoje uma forma confiável de saber **quais versões ainda são suportadas** e **quais versões de produtos diferentes funcionam juntas**. Esta feature entrega uma visualização única, sempre atualizada e fácil de escanear, que mostra — por produto — as versões cobertas pela política de suporte (as quatro releases mais recentes: atual, e três anteriores) com seu respectivo nível de suporte, além de com quais versões de outros produtos cada uma combina. O valor: o cliente decide sozinho e com segurança quando migrar, e o time de suporte para de responder "essa versão ainda é suportada?" manualmente.
+
+---
+
+## 2. Problem Definition
+
+**Problema:** Não existe fonte única e confiável que diga ao cliente se a versão que ele roda ainda é suportada e com o que ela é compatível. A informação de versões hoje é mantida à mão, mostra apenas a versão atual (não o histórico coberto por suporte), e não expressa compatibilidade entre produtos diferentes.
+
+**Impacto (qualitativo — não há telemetria de suporte disponível para quantificar):**
+- Cliente não sabe se está em versão suportada → migra tarde demais (risco) ou cedo demais (custo desnecessário).
+- Compatibilidade entre produtos (ex.: qual versão do produto A roda com qual versão do produto B) **não existe documentada em lugar nenhum** — descoberta só em incidente.
+- Manutenção manual da informação de versões gera divergência (drift) entre o que está documentado e o que foi realmente publicado.
+- Suporte recebe perguntas repetidas de "essa versão ainda tem suporte?" que poderiam ser autoatendidas.
+
+**Workaround atual:** Tabelas de "mapeamento de versão" editadas manualmente, mostrando só a versão corrente de cada produto, sem nível de suporte e sem compatibilidade cruzada.
+
+---
+
+## 3. Política de Suporte (contrato de negócio existente — a base da feature)
+
+A empresa já opera com um contrato LTS de suporte às **quatro releases minor mais recentes** de cada produto:
+
+| Posição | Nível | Custo adicional | Cobertura |
+|---|---|---|---|
+| N (atual) | Full Support | Incluído | Todas as funcionalidades |
+| N-1 | Security | Incluído | Patches de segurança |
+| N-2 | Extended | +30% | Suporte sob demanda |
+| N-3 | Extended | +150% | Suporte limitado |
+| N-4+ | Legacy / EOL | — | Sem suporte |
+
+Ciclo: major anual, minor trimestral, patches conforme necessidade, notificação de EOL com 6 meses de antecedência. Esta feature **torna esse contrato visível e automático** — não o cria nem o altera.
+
+---
+
+## 4. Personas
+
+**P1 — Operador do cliente (BYOC / Lerian Cloud)** — instala e mantém os produtos no ambiente do cliente.
+- Objetivo: saber, em segundos, se a versão instalada é suportada e até quando; planejar migração.
+- Frustração: hoje precisa perguntar ao suporte ou inferir; não enxerga compatibilidade entre produtos antes de atualizar um deles.
+
+**P2 — Time de suporte / CSM Lerian** — atende dúvidas de versão e suporte.
+- Objetivo: apontar o cliente a uma fonte única e confiável em vez de responder caso a caso.
+- Frustração: informação espalhada e manual, que envelhece.
+
+**P3 — Engenharia de produto Lerian** — publica novas versões dos produtos.
+- Objetivo: que a informação de compatibilidade/suporte se atualize sozinha ao publicar, sem edição manual.
+- Frustração: manter tabelas de versão à mão é trabalho repetitivo e fonte de erro.
+
+---
+
+## 5. User Stories
+
+**US-1** — Como operador do cliente, quero ver, por produto, quais versões estão sob suporte e em que nível (Full / Security / Extended / EOL), para saber se preciso migrar.
+- AC: cada produto mostra até 4 versões (atual e três anteriores) com nível de suporte identificável visualmente; versões sem suporte aparecem resumidas como EOL.
+
+**US-2** — Como operador do cliente, quero ver com quais versões de outros produtos cada versão combina, para atualizar um produto sem quebrar a compatibilidade com os demais.
+- AC: quando um produto declara depender de outro, essa relação aparece de forma legível na visualização; quando não declara, a coluna simplesmente não aparece para aquele produto.
+
+**US-3** — Como time de suporte, quero uma única fonte pública e sempre atual, para direcionar o cliente em vez de responder manualmente.
+- AC: a visualização vive num local público que o cliente já acessa e reflete o que foi de fato publicado.
+
+**US-4** — Como engenharia de produto, quero que a visualização se atualize automaticamente quando publico uma versão, para não manter tabela à mão.
+- AC: ao publicar uma nova versão de um produto, a informação de suporte/compatibilidade daquele produto é regenerada sem intervenção manual; o conteúdo gerado nunca é editado à mão.
+
+**US-5** — Como consumidor programático (ferramentas internas / painel do cliente, fase futura), quero a mesma informação em formato consumível por máquina, para exibir "sua versão está em nível X" sem interpretar texto.
+- AC: além da visualização legível, existe uma representação estruturada e versionada da mesma informação, derivada da mesma fonte.
+
+---
+
+## 6. Requisitos Funcionais (WHAT)
+
+- **FR-1 — Fonte declarativa por produto.** Cada produto declara sua própria informação de compatibilidade num único lugar mantido junto do produto. Distinguir o que o produto **exige** de outro (relação técnica) do que foi **testado em conjunto** (informativo).
+- **FR-2 — Janela de suporte automática.** O nível de suporte de cada versão (Full / Security / Extended×2 / EOL) é **derivado automaticamente** da versão atual do produto e do histórico de versões publicadas, seguindo o contrato da seção 3 — ninguém digita "N-3".
+- **FR-3 — Visualização legível.** Uma visualização por produto, fácil de escanear, mostrando as versões sob suporte (atual + 3 anteriores) com nível identificável e, quando aplicável, a compatibilidade com outros produtos; versões fora de suporte resumidas como EOL numa única entrada.
+- **FR-4 — Representação por máquina.** A mesma informação disponível também em formato estruturado e versionado, derivado da mesma fonte, para consumo futuro por ferramentas.
+- **FR-5 — Geração automática na publicação.** Ao publicar uma nova versão de um produto, as saídas (FR-3 e FR-4) são regeneradas automaticamente para aquele produto; conteúdo gerado é substituído integralmente, nunca editado à mão.
+- **FR-6 — Aviso de inconsistência (não bloqueante no v1).** Se a informação declarada estiver malformada ou apontar para algo inexistente, o processo de publicação **avisa** (não impede). Divergência entre o gerado e a fonte também gera aviso. Bloqueio fica para fase futura.
+- **FR-7 — Degradação graciosa.** Produtos com menos de quatro versões publicadas (ou nenhuma) mostram apenas o que existe, sem erro.
+
+---
+
+## 7. Requisitos Não-Funcionais
+
+- **NFR-1 — Sem manutenção manual da saída.** Nenhuma tabela de versão volta a ser editada à mão.
+- **NFR-2 — Não regressão.** A geração não pode corromper conteúdo existente ao redor (a visualização convive com documentação já presente).
+- **NFR-3 — Confiabilidade da janela.** A "versão atual" de um produto deve ser sempre correta, independentemente de o histórico estar completo ou não.
+- **NFR-4 — Idempotência.** Rodar a geração duas vezes sobre a mesma fonte produz exatamente o mesmo resultado.
+- **NFR-5 — Público correto.** A visualização vive onde o cliente já busca informação de instalação.
+
+---
+
+## 8. Success Metrics
+
+- **M1 (adoção):** redução das perguntas de suporte do tipo "essa versão ainda é suportada?" (medida qualitativamente pelo time de suporte no primeiro trimestre pós-lançamento).
+- **M2 (frescor):** 0 edições manuais da visualização de versões após o lançamento (toda mudança vem da geração automática).
+- **M3 (cobertura):** 100% dos produtos ativos com informação de suporte gerada; ≥1 produto com compatibilidade cruzada declarada até o fim da fase de adoção.
+- **M4 (confiabilidade):** 0 casos de "versão atual errada" na visualização.
+
+---
+
+## 9. Escopo
+
+### In-scope (v1)
+- Visualização legível de suporte por produto (atual + 3 anteriores + resumo EOL).
+- Compatibilidade cruzada **exibida quando declarada** por um produto.
+- Representação por máquina, versionada, derivada da mesma fonte.
+- Geração automática na publicação de versão.
+- Avisos não bloqueantes de inconsistência e de divergência.
+- Preenchimento inicial automático do que é derivável (a combinação testada da release atual) para todos os produtos ativos.
+
+### Out-of-scope (v1 — fases futuras)
+- **Bloqueio** de publicação por incompatibilidade (v1 só avisa).
+- Preenchimento das relações "exige" (dependência técnica declarada) para todos os produtos — depende de conhecimento de cada time de produto; no v1 esse campo é opcional e pode ficar vazio.
+- Exibição da matriz fora do local público primário (painel do cliente, portal de docs) — consome a representação por máquina numa fase posterior.
+- Datas de EOL calculadas por calendário (o v1 usa posição N-x; datas concretas ficam para depois).
+- Notificação ativa de EOL ao cliente (o contrato prevê 6 meses de antecedência; automatizar isso é fase futura).
+
+---
+
+## 10. Premissas e Dependências
+
+- **A1:** A versão declarada por cada produto é a autoridade sobre "versão atual".
+- **A2:** O histórico de versões publicadas de cada produto é recuperável de forma confiável.
+- **A3:** Cada time de produto é a autoridade sobre as relações "exige" — por isso ficam opcionais no v1.
+- **D1:** Depende do processo de publicação existente para disparar a geração automática.
+- **D2:** Depende de um local público já acessado pelo cliente para hospedar a visualização.
+
+---
+
+## 11. Riscos (nível de negócio)
+
+- **R1 — Histórico incompleto de um produto** → janela parcial. Mitigado por FR-7 (degradação graciosa) e por A1 (a versão atual nunca depende do histórico).
+- **R2 — Relações "exige" vazias no v1** → matriz de compatibilidade cruzada inicialmente rasa. Aceito conscientemente; enriquece conforme os times preenchem.
+- **R3 — Percepção de que EOL por posição (N-4) não basta sem data** → comunicado como limitação conhecida do v1; datas concretas são fase futura.
+
+---
+
+## Gate 1 — Validação
+
+| Categoria | Status |
+|---|---|
+| Problema articulado (1-2 frases) | ✅ |
+| Impacto qualificado (sem telemetria → qualitativo, declarado) | ✅ |
+| Usuários identificados (P1–P3) | ✅ |
+| Features endereçam o problema | ✅ |
+| Métricas mensuráveis | ✅ (M1 qualitativa declarada; M2–M4 objetivas) |
+| Escopo in/out explícito com racional | ✅ |
+| PRD sem detalhe técnico | ✅ (HOW abstraído; guardado para o TRD) |
+
+**Resultado: ✅ PASS → Gate 2 (Feature Map)**
+
+> Nota de separação business/técnico: decisões de HOW já tomadas com o usuário (annotation em metadados do chart, derivação por tags, ferramenta geradora, biblioteca semver, marcadores no documento, formato JSON) foram **deliberadamente omitidas** deste PRD e estão registradas no `research.md` para entrarem no TRD (Gate 3).

--- a/docs/pre-dev/helm-version-compatibility-matrix/prd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/prd.md
@@ -121,7 +121,7 @@ Ciclo: major anual, minor trimestral, patches conforme necessidade, notificaçã
 - Representação por máquina, versionada, derivada da mesma fonte.
 - Geração automática na publicação de versão.
 - Avisos não bloqueantes de inconsistência e de divergência.
-- Preenchimento inicial automático do que é derivável (a combinação testada da release atual) para todos os produtos ativos.
+- ~~Preenchimento inicial automático do `testedWith` derivável para todos os produtos ativos.~~ **REMOVIDO do v1** (decisão posterior — ver BACKLOG): `testedWith` manual saiu do v1; volta na v2 preenchido via E2E. No v1, `requires` é declarado pelo dev por chart, sob demanda; nenhum backfill automático.
 
 ### Out-of-scope (v1 — fases futuras)
 - **Bloqueio** de publicação por incompatibilidade (v1 só avisa).

--- a/docs/pre-dev/helm-version-compatibility-matrix/research.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/research.md
@@ -1,0 +1,119 @@
+# Research — Helm Version Compatibility Matrix (Gate 0)
+
+| | |
+|---|---|
+| **Date** | 2026-07-21 |
+| **Feature** | helm-version-compatibility-matrix |
+| **Research mode** | modification (extending existing Go tooling + release pipeline) |
+| **Agents** | repo-research-analyst (primary), best-practices-researcher, framework-docs-researcher |
+| **Repo** | `/home/gauchito/lerian/helm` (github.com/LerianStudio/helm) |
+
+---
+
+## Executive Summary
+
+O repo já tem **toda a fundação** para gerar a matriz de compatibilidade: um módulo Go em `.github/scripts/` que itera charts e parseia `Chart.yaml` (com precedente exato de leitura de annotation `lerian.studio/chart-type`), uma lib compartilhada `tableutil` que já edita as tabelas do README de forma segura, e um pipeline de release que já commita o README de volta via `@semantic-release/git` + push-bot GPG-assinado. A implementação é **extensão**, não greenfield. Três descobertas mudam o desenho inicial (ver "Surpresas"). Não existe padrão de mercado para "compatibility matrix declarativa em Helm" — vamos **definir convenção**, ancorada em Artifact Hub (shape da annotation) + endoflife.date (schema do JSON) + terraform-docs (markers no README).
+
+---
+
+## SURPRESAS vs. o plano inicial (ler primeiro)
+
+1. **A tabela do README NÃO é gerada pelo validador.** É gerada por duas ferramentas Go irmãs — `update-chart-version-readme` (release-time) e `update-readme-matrix` (dispatch) — que usam a lib `tableutil`. Consequência: o gerador de compatibilidade encaixa melhor como **nova ferramenta Go irmã** (`generate-compatibility` ou similar), espelhando `generate-values-schemas`, e **não** como flag do validador.
+
+2. **Tags git locais estão DESATUALIZADAS vs. Chart.yaml.** Ex.: Chart.yaml diz midaz `8.6.0`, mas a tag mais alta neste clone é `midaz-v8.2.0`. A janela N..N-3 derivada de tags precisa **buscar tags no CI** (`git fetch --tags`) e/ou reconciliar com o `version` do Chart.yaml. **Decisão pendente para o TRD.** Sem isso, a janela sai errada.
+
+3. **App-token DISPARA CI** (diferente do `GITHUB_TOKEN`). O push do bot pode re-disparar o próprio workflow. O repo já se defende com **3 camadas** (`paths-ignore` + `[skip ci]` no commit + guard `github.actor != '...push-bot[bot]'`). O gerador DEVE usar as 3. Bom: `docs/**` e `README.md` já estão em `paths-ignore` do release.yml, então escrever nesses caminhos não re-dispara.
+
+---
+
+## Codebase Research (estado atual — file:line)
+
+### Módulo Go — `.github/scripts/`
+Um único `go.mod` (`go 1.21`; deps: `gopkg.in/yaml.v3 v3.0.1`, `golang.org/x/text v0.21.0`; **sem lib semver**). Quatro `package main` + uma lib:
+
+| Path | Papel |
+|---|---|
+| `.github/scripts/tableutil/tableutil.go` | Lib compartilhada: parser/formatter das tabelas do README |
+| `.github/scripts/validate-helm-charts/main.go` | Validador de contrato + render gate (1581 linhas) |
+| `.github/scripts/update-chart-version-readme/main.go` | Escreve chart version + app versions no README (release-time) |
+| `.github/scripts/update-readme-matrix/main.go` | Escreve 1 componente no README (fluxo dispatch) |
+| `.github/scripts/generate-values-schemas/main.go` | Gera `values.schema.json` por chart — **template estrutural pro nosso gerador** |
+
+**Pontos de extensão concretos:**
+- Iterar charts: `chartDirectories(root)` em `validate-helm-charts/main.go:292-307` (enumera dirs de `charts/`, não glob).
+- Parse Chart.yaml: struct `chartYAML` em `main.go:66-70` — **hoje NÃO lê `version`/`appVersion`**, só `type`, `annotations`, `dependencies`. Novo gerador estende ou define struct própria.
+- Precedente de leitura de annotation: `chartTypeAnnotation = "lerian.studio/chart-type"` em `main.go:21`, lido via `chart.Annotations[...]` em `main.go:244`. **Mesmo padrão para `lerian.studio/compatibility`.**
+- Precedente de geração de arquivo determinístico: `generate-values-schemas/main.go` inteiro, e `writeRenderInventory` em `main.go:1474-1488` (strings.Builder → `os.MkdirAll` + `os.WriteFile` 0644).
+- Erros vs warnings: tudo é `violation{Chart,Rule,Path,Reason}` (`main.go:78-83`), `newViolation()` em `main.go:965`, impresso por `printViolations` `main.go:1010`. Exit 1 em `--strict`.
+
+### `tableutil` — motor das tabelas do README (reusar exatamente)
+`tableutil/tableutil.go`: `ParseTableForChart(lines, chartName)` `:71-166` — normaliza nome (`TrimSuffix "-helm"`, hífens→espaços), acha `### <Name>`, acha a tabela, para no `-----------------` ou próximo `### `. `FormatTable` `:169-196` re-emite com separador `:---:`. **Detecção de fronteira depende do header literal `| Chart Version |` e da linha `-----------------`.**
+
+### Workflows — `.github/workflows/`
+- **release.yml** — gatilho push em `main`/`develop`, `paths-ignore` inclui `README.md`, `**/CHANGELOG.md`, `.github/workflows/**`, `**/docs/**` (`:8-14`). Detecta charts alterados via `LerianStudio/github-actions-changed-paths@main` (`:22-41`). **Padrão de write-back (SEGUIR):** `@semantic-release/git` com `assets=[Chart.yaml, README.md]` (`:158`) + `prepareCmd = update-chart-version-readme-bin` (`:156`); tag format `$CHART_NAME-v${version}` (`:154`). Bot `lerian-studio-midaz-push-bot[bot]`, token via `actions/create-github-app-token@v1` (`:54-58`), commit GPG-assinado (`:124-134`). Guard anti-loop `github.actor != '...push-bot[bot]'` (`:23`).
+- **helm-chart-standard.yml** — PR-time, `permissions: contents: read` (não commita), roda `--strict` (`:41`) e `--render-gate`. Gatilho em `charts/**` + `.github/scripts/validate-helm-charts/**`. Um check v1 não-bloqueante entra aqui MAS não pode emitir violação `--strict` (senão falha CI).
+- **helm-upgrade-doc.yml** — só chama shared-workflow externo `@v1.29.0` (lógica de commit não é inspecionável localmente). Gatilho tag `'**-v[0-9]*'`.
+- Outros: app-sync (dispatch update), gptchangelog (AI changelog em tag), pr-title (Conventional Commits, `requireScope: true` — PR nova precisa scope permitido), pr-sizing (label de tamanho).
+
+### README.md — formato exato
+`### <Name>` → prosa → `#### Application Version Mapping` → `| Chart Version | <Comp> Version | ... |` → linhas → `-----------------`. **Colunas variam 2–6** (BR Pix Indirect BTG tem 6; maioria tem 2). Boundaries irregulares: Matcher e Plugin BC Correios **não têm** o separador final; Fees e Pix Indirect BTG têm linha em branco antes. **20 seções no README vs 21 dirs de chart** — `br-spi` existe em `charts/` mas NÃO tem seção no README. Gerador deve ser **schema-driven por chart**, respeitar boundaries irregulares, e lidar com chart sem seção.
+
+### Inventário de annotations (backfill target)
+**Nenhum chart tem `lerian.studio/compatibility` hoje** (grep zero). Todos os 21 têm exatamente `lerian.studio/chart-type`. Versões atuais e chart-type por chart estão tabelados no relatório do agente (midaz 8.6.0/multi-component, reporter 3.1.1, fees 7.2.0, etc.). `go-boilerplate-ddd` tem `deprecated: true`. Charts sem tags git ainda: `br-spi`, `br-sisbajud`, `notifications` → gerador deve tratar "<4 minors" e "0 tags".
+
+### Tags git — formato confirmado
+`<chart-dir>-v<semver>` (ex: `midaz-v8.2.0`). Corroborado por release.yml `:154`, helm-upgrade-doc gatilho, e release-notification.yml `:76` (`git tag -l "${CHART}-v*" --sort=-v:refname | head -1`). **Filtrar com `<dir>-v*`** (o `-v` desambigua `plugin-br-bank-transfer` de `...-jd`, e `otel-collector` de `otel-collector-lerian`). Tags de charts removidos existem (plugin-crm, etc.) — pular. **Staleness tag↔Chart.yaml é o risco #1** (ver Surpresa 2).
+
+### `docs/helm-chart-standard.md` — contrato existente
+Exige `annotations.lerian.studio/chart-type ∈ {single-service, multi-component, dependency-wrapper}`. **Não proíbe** annotations adicionais → `lerian.studio/compatibility` é compatível com o contrato, mas o doc precisaria de subseção nova pra formalizar. Baseline de migração deve ficar vazio; "CI usa strict mode" → check v1 não pode virar violação strict.
+
+### Knowledge base — NEGATIVO
+Não existe `docs/solutions/` nem qualquer KB. `docs/` só tem `helm-chart-standard.md`. Sem solução prévia de versionamento/compatibilidade.
+
+---
+
+## Best Practices Research (URLs)
+
+- **Annotation shape:** Helm permite annotations free-form (`map[string]string`); valores multi-linha são **string com block scalar `|`** (não nesting nativo). Precedente: `artifacthub.io/*` (`changes`, `prerelease`, `containsSecurityUpdates`, `links`). Reusar chaves Artifact Hub onde a semântica bate. https://artifacthub.io/docs/topics/annotations/helm/ · https://helm.sh/docs/topics/charts/
+- **Ranges semver:** Masterminds/semver — `>=8.4.0 <9.0.0` válido (space/vírgula=AND, `||`=OR, `~`/`^`/wildcards). **Trap:** constraint ignora pre-releases por padrão; `^0.x` só tolera patch. https://github.com/Masterminds/semver
+- **Support matrix legível:** modelar no `endoflife.date` product-schema (linha por ciclo minor, `eol`/`eoas` como união bool-ou-data). Frase de política estilo Kubernetes "N-2" (nós: "as 4 minors mais recentes: N, N-1, N-2, N-3"). Grid X-vs-Y estilo Cilium. https://github.com/endoflife-date/endoflife.date/blob/master/product-schema.json · https://kubernetes.io/releases/version-skew-policy · https://docs.cilium.io/en/stable/network/kubernetes/compatibility/
+- **README markers:** padrão terraform-docs `inject` (`<!-- BEGIN_X -->`/`<!-- END_X -->`) — só substitui entre markers, idempotente, diff limpo, tem "check mode" pra falhar em drift. https://terraform-docs.io/reference/markdown/
+- **JSON artifact:** `schemaVersion` monotônico distinto de `$schema`. https://offlinetools.org/a/json-formatter/schema-versioning-for-json-configuration-files
+- **Anti-patterns:** `sort -V` erra pre-release (segregar antes); nesting YAML nativo em annotation (usar block scalar); editar dentro dos markers; caret em 0.x.
+
+---
+
+## Framework Docs Research (versões concretas)
+
+- **Go:** módulo é `go 1.21` (piso duro). Não adotar lib que exija ≥1.22.
+- **YAML:** manter `gopkg.in/yaml.v3 v3.0.1` (já usado). Annotation-YAML-embutido = **two-step unmarshal** (parse outer → pega string → `yaml.Unmarshal([]byte(raw), &struct)`). Preservar comentários/ordem → `yaml.Node`; pra read-and-classify, `map[string]string` basta.
+- **SemVer:** adicionar `github.com/Masterminds/semver/v3` **v3.2.1** (piso go 1.18; exatamente o que Helm 3.14.4 pina; v3.5.0 exige go 1.26 — NÃO usar). `semver.NewVersion`, `semver.Collection` (sort), `semver.NewConstraint(...).Check(v)`. Agrupar por minor via `fmt.Sprintf("%d.%d", v.Major(), v.Minor())`. Pre-release inclusion em constraint só v3.3.0+ → tratar grouping de pre-release manualmente no Go.
+- **Helm SDK (`helm.sh/helm/v3`):** existe (`chart.Metadata`, `chartutil.LoadChartfile`) mas é **overkill** (árvore transitiva enorme, tags `json:`). Manter parse yaml.v3 direto.
+- **Commit-back (Actions):** `actions/create-github-app-token@v1` (manter pin) → checkout com o token → commit GPG + `[skip ci]`. **App-token dispara CI** → usar as 3 camadas anti-loop. `fetch-depth: 0` obrigatório pra enxergar tags; `git fetch --tags --force origin` no topo do step pra evitar drift local.
+
+---
+
+## Synthesis — para o PRD/TRD
+
+### Padrões a seguir (com âncora)
+- Nova ferramenta Go irmã `generate-compatibility`, espelhando `generate-values-schemas` (invocada com `--root ../..`, gera arquivos determinísticos). NÃO estender o validador.
+- Reusar `tableutil` para editar o README; usar markers `<!-- BEGIN COMPAT:<chart> -->`/`<!-- END COMPAT:<chart> -->` estilo terraform-docs.
+- Annotation `lerian.studio/compatibility` como string YAML (block scalar), com `requires` (semver range, validado) e `testedWith` (informativo). Reusar chaves Artifact Hub onde couber.
+- JSON em `docs/compatibility.json` com `schemaVersion: 1`, modelado em endoflife.date.
+- Write-back via padrão release.yml (`@semantic-release/git` assets ou step dedicado com as 3 camadas anti-loop).
+- Adicionar `Masterminds/semver/v3 v3.2.1` ao go.mod.
+
+### Constraints
+- Go 1.21 é piso duro.
+- v1 não-bloqueante: check só em dado malformado; NÃO emitir violação `--strict`.
+- Boundaries do README irregulares (2–6 colunas, separador ausente em 2 seções, br-spi sem seção).
+- Charts sem tags / <4 minors precisam degradar graciosamente.
+- PR nova precisa scope permitido em pr-title.yml.
+- `docs/helm-chart-standard.md` precisa de subseção formalizando a nova annotation.
+
+### Open questions — RESOLVIDAS (decisão do usuário, 2026-07-21)
+1. **Fonte da janela N..N-3:** ✅ **`Chart.yaml.version` = N (autoridade); tags git = histórico N-1..N-3.** Elimina o risco de tags stale/não-fetchadas (Surpresa 2 resolvida). CI ainda faz `git fetch --tags` pra preencher o histórico, mas o "N atual" nunca depende disso.
+2. Quando um chart tem `<4` minors publicadas: ✅ mostrar só as linhas que existem (parcial), degradar graciosamente.
+3. **`docs/compatibility.json`:** ✅ **commitado em `docs/`** (fora do paths-ignore trigger; cliente/console fazem GET no raw). Sem infra nova.
+4. **Backfill dos `requires`:** ✅ **v1 preenche só `testedWith` (derivável do release atual); `requires` fica OPCIONAL/vazio** até cada time de produto preencher. Destrava o v1 sem esperar input humano de ~7 times.
+5. Check de drift (terraform-docs "check mode"): entra no v1 como **warning** em helm-chart-standard.yml (não-bloqueante); gate bloqueante fica pra fase futura.

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/README.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/README.md
@@ -1,0 +1,75 @@
+# Subtasks — Matriz de Compatibilidade (Gate 8)
+
+Índice das subtasks zero-context (2–5 min, TDD RED-GREEN-REFACTOR, código completo, verificação copiável + rollback) da feature `helm-version-compatibility-matrix`.
+
+Cada arquivo abre com o header padrão (Goal, Prerequisites com comando+saída, Files) e traz `> **For Agents:** REQUIRED SUB-SKILL: executing-plans`.
+
+Ferramenta-alvo: `.github/scripts/generate-compatibility/` (novo `package main`, mesmo padrão de `generate-values-schemas`). Go **1.21** (piso duro). Deps: `gopkg.in/yaml.v3 v3.0.1` + **`github.com/Masterminds/semver/v3 v3.2.1`** (exato, não v3.4+). Lib interna reusada: `tableutil`.
+
+---
+
+## ⚠️ Gate de teste §10 (regra dura — vale para TODA subtask de geração)
+
+O maior risco da feature é **corromper o README de todos os charts de uma vez** ou o write-back gerar loop/commit unverified. Ordem de validação, do mais barato ao mais arriscado (TRD §10):
+
+1. **Unit (Go, offline):** `go test ./generate-compatibility/` — table-driven de janela (T-3) e boundaries irregulares (T-5).
+2. **Dry-run local em CLONE DESCARTÁVEL:** rodar `--write` e revisar `git diff` do README — só muda entre markers; prosa/separadores intactos; `br-spi` ganha seção (ADR-5); 2× = diff idêntico. → **ST-5-6**.
+3. **`--check`:** rodar contra o repo real, apontar drift **sem escrever**. → **ST-6-2** (verificação).
+4. **Write-back SEM push real:** `git push --dry-run` / remote bare local; commit GPG-verified; `[skip ci]` + guard de actor comprovados. → **ST-8-5**, **ST-8-6**.
+5. **Backfill:** `testedWith` nas annotations em **PR de teste** + `--check` verde antes do PR real. → **ST-7-1**.
+
+**Nada vai para `main` sem 1–5 verdes.** Toda geração roda em clone descartável antes de qualquer commit real e é idempotente (2× = mesmo byte). Alinhado a [[feedback_test_changed_artifacts]] e [[feedback_ask_before_push]] (o usuário aprova todo push).
+
+---
+
+## Ordem de execução (caminho crítico: T-1 → T-2 → T-3 → (T-4 ‖ T-5) → T-6 → T-8)
+
+| # | Tarefa | Subtask | O que entrega |
+|---|--------|---------|---------------|
+| 1 | **T-1** | [ST-1-1](T-1/ST-1-1-add-semver-dependency.md) | Dep `Masterminds/semver/v3 v3.2.1` (exata) no go.mod/go.sum |
+| 2 | T-1 | [ST-1-2](T-1/ST-1-2-chart-directories-helper-tdd.md) | Package + `chartDirectories` (TDD) |
+| 3 | T-1 | [ST-1-3](T-1/ST-1-3-read-chart-version-tdd.md) | `readChartState` → Name/Dir/Version/AppVersion (TDD) |
+| 4 | T-1 | [ST-1-4](T-1/ST-1-4-main-emit-current-json.md) | `main()` demoável: JSON com `current` |
+| 5 | **T-2** | [ST-2-1](T-2/ST-2-1-parse-annotation-twostep-tdd.md) | Two-step unmarshal da annotation (TDD) |
+| 6 | T-2 | [ST-2-2](T-2/ST-2-2-validate-annotation-warnings-tdd.md) | Regras V1–V6 como WARN/INFO (TDD) |
+| 7 | T-2 | [ST-2-3](T-2/ST-2-3-wire-annotation-into-state-and-doc.md) | Annotation no ChartState + WARN no buildDoc |
+| 8 | **T-3** ⚠️ | [ST-3-1](T-3/ST-3-1-list-git-tags-for-dir-tdd.md) | Listar/parsear tags `<dir>-v*` (TDD) |
+| 9 | T-3 ⚠️ | [ST-3-2](T-3/ST-3-2-segregate-prereleases-and-group-by-minor-tdd.md) | Segregar pre-releases + agrupar por minor (TDD) |
+| 10 | T-3 ⚠️ | [ST-3-3](T-3/ST-3-3-resolve-window-N-authoritative-tdd.md) | `resolveWindow`: N do Chart.yaml + top-4 + degradação (TDD) |
+| 11 | T-3 ⚠️ | [ST-3-4](T-3/ST-3-4-wire-window-into-buildDoc-golden-tdd.md) | Ligar janela no buildDoc + golden JSON |
+| 12 | T-3 ⚠️ | [ST-3-5](T-3/ST-3-5-verify-window-against-real-repo.md) | Validar janela contra o repo real (/tmp) |
+| 13 | **T-4** | [ST-4-1](T-4/ST-4-1-assert-no-tier-and-schema-shape-tdd.md) | JSON sem `tier`, conforme §B (TDD) |
+| 14 | T-4 | [ST-4-2](T-4/ST-4-2-write-output-flag-and-commit-json.md) | `--output` + `docs/compatibility.json` versionado |
+| 15 | **T-5** ⚠️ | [ST-5-1](T-5/ST-5-1-render-compat-table-lines-tdd.md) | Render das linhas COMPAT + badges (TDD) |
+| 16 | T-5 ⚠️ | [ST-5-2](T-5/ST-5-2-marker-block-replace-idempotent-tdd.md) | Substituição confinada entre markers, idempotente (TDD) |
+| 17 | T-5 ⚠️ | [ST-5-3](T-5/ST-5-3-locate-section-via-tableutil-tdd.md) | Localizar seção via normalização do `tableutil` (TDD) |
+| 18 | T-5 ⚠️ | [ST-5-4](T-5/ST-5-4-ensure-block-create-section-adr5-tdd.md) | `ensureCompatBlock` + criar seção mínima br-spi (ADR-5) (TDD) |
+| 19 | T-5 ⚠️ | [ST-5-5](T-5/ST-5-5-wire-readme-write-into-main-golden-tdd.md) | Escrita do README no main + golden de layout irregular |
+| 20 | T-5 ⚠️ | [ST-5-6](T-5/ST-5-6-dry-run-disposable-clone-diff-review.md) | **Dry-run em clone descartável + review de diff (§10 passo 2)** |
+| 21 | **T-6** | [ST-6-1](T-6/ST-6-1-flag-parsing-exit-codes-tdd.md) | Flags + exit codes 0/1/2 (`run()` testável) (TDD) |
+| 22 | T-6 | [ST-6-2](T-6/ST-6-2-check-mode-drift-tdd.md) | Modo `--check`: drift WARN + exit 0 (TDD) |
+| 23 | **T-7** | [ST-7-1](T-7/ST-7-1-backfill-testedwith-annotations.md) | Backfill `testedWith` nas annotations (PR de teste) |
+| 24 | **T-8** ⚠️ | [ST-8-1](T-8/ST-8-1-build-binary-and-fetch-tags.md) | Build do binário + `git fetch --tags --force` |
+| 25 | T-8 ⚠️ | [ST-8-2](T-8/ST-8-2-writeback-step-2B-skip-ci-actor-guard.md) | Step 2B: commit GPG + `[skip ci]` + guard + rebase |
+| 26 | T-8 ⚠️ | [ST-8-3](T-8/ST-8-3-check-warning-in-standard-workflow.md) | `--check` warning no PR + trigger path |
+| 27 | T-8 ⚠️ | [ST-8-4](T-8/ST-8-4-pr-title-scope-allowlist.md) | Scope permitido no `pr-title.yml` |
+| 28 | T-8 ⚠️ | [ST-8-5](T-8/ST-8-5-validate-writeback-no-real-push.md) | **Validar write-back SEM push real (§10 passo 4)** |
+| 29 | T-8 ⚠️ | [ST-8-6](T-8/ST-8-6-verify-no-ci-loop-on-bot-push.md) | Comprovar zero re-trigger (3 camadas anti-loop) |
+| ∥ | **T-9** | [ST-9-1](T-9/ST-9-1-document-annotation-contract.md) | Documentar contrato da annotation (após T-2) |
+
+⚠️ = tarefa de **ALTO risco** (T-3 corretude da janela; T-5 corrupção do README; T-8 loop de CI / commit unverified). São as que mais precisam do gate §10.
+
+---
+
+## Paralelização
+- **T-2** e **T-3** rodam em paralelo após **T-1**.
+- **T-4** e **T-5** rodam em paralelo após **T-2**+**T-3**.
+- **T-9** roda a qualquer momento após **T-2** estabilizar a gramática.
+- **T-7** idealmente antes de **T-8** (para o 1º commit automático já nascer populado).
+
+## Convenções aplicadas em todas as subtasks
+- **TDD:** cada subtask de código tem passo RED (teste que falha, com saída capturada) → GREEN (código mínimo completo) → REFACTOR quando aplicável.
+- **Código completo:** sem `...`, sem TODO, sem "adicione imports necessários" implícito — os imports estão explícitos.
+- **Testável:** lógica pura extraída de `main` (funções `chartDirectories`, `parseCompatAnnotation`, `resolveWindow`, `renderCompatTable`, `ensureCompatBlock`, `run`), tabelas `table-driven`, golden-files sob `testdata/`.
+- **Verificação copiável + saída esperada + rollback** em cada arquivo.
+- **Sem libs além de** `yaml.v3` + `Masterminds/semver/v3`. Go **1.21**.

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-1-add-semver-dependency.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-1-add-semver-dependency.md
@@ -1,0 +1,76 @@
+# ST-1-1 — Adicionar dependência `Masterminds/semver/v3 v3.2.1` ao módulo
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Adicionar a dependência semver ao módulo Go em `.github/scripts` na versão EXATA `v3.2.1` (piso Go 1.18, compatível com o piso duro Go 1.21 do módulo). NÃO usar `@latest` (v3.4+ sobe o piso para Go 1.26 = proibido).
+
+## Prerequisites
+Rode e confirme a saída:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && head -3 go.mod
+```
+Saída esperada (exata):
+```
+module github.com/LerianStudio/helm/.github/scripts
+
+go 1.21
+```
+Confirme também que o toolchain Go 1.21+ está disponível:
+```bash
+go version
+```
+Saída esperada: uma linha começando com `go version go1.` e minor `>= 21` (ex.: `go version go1.24.x linux/amd64`).
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/go.mod` (bloco `require`)
+- modify: `/home/gauchito/lerian/helm/.github/scripts/go.sum` (gerado por `go mod tidy` — não editar à mão)
+
+## Steps
+
+### Passo 1 — Adicionar a dependência na versão exata
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go get github.com/Masterminds/semver/v3@v3.2.1
+```
+Saída esperada (contém a linha):
+```
+go: added github.com/Masterminds/semver/v3 v3.2.1
+```
+
+### Passo 2 — Confirmar a versão pinada no go.mod
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && grep 'Masterminds/semver' go.mod
+```
+Saída esperada (EXATA, versão v3.2.1, não v3.4+):
+```
+	github.com/Masterminds/semver/v3 v3.2.1
+```
+Se aparecer qualquer versão diferente de `v3.2.1`, PARE e refaça o Passo 1 com a versão exata.
+
+### Passo 3 — Confirmar que o piso Go NÃO subiu
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && grep -E '^go |^toolchain ' go.mod
+```
+Saída esperada (EXATA — só a diretiva `go 1.21`, SEM linha `toolchain`):
+```
+go 1.21
+```
+Se aparecer uma linha `toolchain goX.Y.Z` ou `go` diferente de `1.21`, PARE: a versão da dep está errada (subiu o piso). Reverta (ver Rollback) e refaça com `@v3.2.1`.
+
+### Passo 4 — Confirmar que o go.sum foi atualizado
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && grep -c 'Masterminds/semver/v3 v3.2.1' go.sum
+```
+Saída esperada: um número `>= 1` (tipicamente `2` — a linha do módulo e a do `/go.mod`).
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go build ./... && echo "BUILD_OK"
+```
+Saída esperada: `BUILD_OK` (o módulo ainda compila com a nova dep; nenhum código a usa ainda).
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout go.mod go.sum
+```
+Isso remove a dependência recém-adicionada, restaurando o estado anterior do manifest e do lock.

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-1-add-semver-dependency.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-1-add-semver-dependency.md
@@ -8,7 +8,7 @@ Adicionar a dependência semver ao módulo Go em `.github/scripts` na versão EX
 ## Prerequisites
 Rode e confirme a saída:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && head -3 go.mod
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && head -3 go.mod
 ```
 Saída esperada (exata):
 ```
@@ -23,14 +23,14 @@ go version
 Saída esperada: uma linha começando com `go version go1.` e minor `>= 21` (ex.: `go version go1.24.x linux/amd64`).
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/go.mod` (bloco `require`)
-- modify: `/home/gauchito/lerian/helm/.github/scripts/go.sum` (gerado por `go mod tidy` — não editar à mão)
+- modify: `./.github/scripts/go.mod` (bloco `require`)
+- modify: `./.github/scripts/go.sum` (gerado por `go mod tidy` — não editar à mão)
 
 ## Steps
 
 ### Passo 1 — Adicionar a dependência na versão exata
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go get github.com/Masterminds/semver/v3@v3.2.1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go get github.com/Masterminds/semver/v3@v3.2.1
 ```
 Saída esperada (contém a linha):
 ```
@@ -39,7 +39,7 @@ go: added github.com/Masterminds/semver/v3 v3.2.1
 
 ### Passo 2 — Confirmar a versão pinada no go.mod
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && grep 'Masterminds/semver' go.mod
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && grep 'Masterminds/semver' go.mod
 ```
 Saída esperada (EXATA, versão v3.2.1, não v3.4+):
 ```
@@ -49,7 +49,7 @@ Se aparecer qualquer versão diferente de `v3.2.1`, PARE e refaça o Passo 1 com
 
 ### Passo 3 — Confirmar que o piso Go NÃO subiu
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && grep -E '^go |^toolchain ' go.mod
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && grep -E '^go |^toolchain ' go.mod
 ```
 Saída esperada (EXATA — só a diretiva `go 1.21`, SEM linha `toolchain`):
 ```
@@ -59,18 +59,18 @@ Se aparecer uma linha `toolchain goX.Y.Z` ou `go` diferente de `1.21`, PARE: a v
 
 ### Passo 4 — Confirmar que o go.sum foi atualizado
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && grep -c 'Masterminds/semver/v3 v3.2.1' go.sum
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && grep -c 'Masterminds/semver/v3 v3.2.1' go.sum
 ```
 Saída esperada: um número `>= 1` (tipicamente `2` — a linha do módulo e a do `/go.mod`).
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go build ./... && echo "BUILD_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go build ./... && echo "BUILD_OK"
 ```
 Saída esperada: `BUILD_OK` (o módulo ainda compila com a nova dep; nenhum código a usa ainda).
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout go.mod go.sum
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout go.mod go.sum
 ```
 Isso remove a dependência recém-adicionada, restaurando o estado anterior do manifest e do lock.

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-2-chart-directories-helper-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-2-chart-directories-helper-tdd.md
@@ -7,7 +7,7 @@ Criar o package `generate-compatibility` e a função pura testável `chartDirec
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && grep 'Masterminds/semver' go.mod
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && grep 'Masterminds/semver' go.mod
 ```
 Saída esperada:
 ```
@@ -16,13 +16,13 @@ Saída esperada:
 (Se falhar, execute ST-1-1 primeiro.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart_test.go`
+- create: `./.github/scripts/generate-compatibility/chart.go`
+- create: `./.github/scripts/generate-compatibility/chart_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Escrever o teste table-driven que FALHA
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart_test.go` com este conteúdo COMPLETO:
+Crie `./.github/scripts/generate-compatibility/chart_test.go` com este conteúdo COMPLETO:
 ```go
 package main
 
@@ -104,7 +104,7 @@ func TestChartDirectories_MissingRoot(t *testing.T) {
 
 Rode o teste e CAPTURE a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | head -20
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | head -20
 ```
 Saída esperada (falha de compilação — a função ainda não existe):
 ```
@@ -114,7 +114,7 @@ FAIL	github.com/LerianStudio/helm/.github/scripts/generate-compatibility [build 
 ```
 
 ### Passo 2 (GREEN) — Implementar a função mínima
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart.go` com este conteúdo COMPLETO:
+Crie `./.github/scripts/generate-compatibility/chart.go` com este conteúdo COMPLETO:
 ```go
 // Command generate-compatibility produces the per-product support-window matrix
 // (README blocks + docs/compatibility.json) for the charts in this repo.
@@ -156,7 +156,7 @@ func chartDirectories(root string) ([]string, error) {
 
 ### Passo 3 — Rodar o teste (deve passar)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -5
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -5
 ```
 Saída esperada (contém):
 ```
@@ -165,12 +165,12 @@ ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility	0.0...s
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-1-2_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-1-2_OK"
 ```
 Saída esperada: termina com `ST-1-2_OK`.
 
 ## Rollback
 ```bash
-rm -rf /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart.go \
-       /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart_test.go
+rm -rf ./.github/scripts/generate-compatibility/chart.go \
+       ./.github/scripts/generate-compatibility/chart_test.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-2-chart-directories-helper-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-2-chart-directories-helper-tdd.md
@@ -1,0 +1,176 @@
+# ST-1-2 — Helper `chartDirectories` (RED → GREEN) no novo package
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Criar o package `generate-compatibility` e a função pura testável `chartDirectories(root string) ([]string, error)` que lista os subdiretórios de `<root>/charts` ordenados. Copia o padrão de `validate-helm-charts/main.go:292-307` DENTRO do novo package (o standard proíbe importar de outro `package main`).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && grep 'Masterminds/semver' go.mod
+```
+Saída esperada:
+```
+	github.com/Masterminds/semver/v3 v3.2.1
+```
+(Se falhar, execute ST-1-1 primeiro.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Escrever o teste table-driven que FALHA
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart_test.go` com este conteúdo COMPLETO:
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeTree cria uma árvore charts/<name> temporária e devolve o root.
+func writeTree(t *testing.T, chartDirs []string, extraFiles map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range chartDirs {
+		if err := os.MkdirAll(filepath.Join(root, "charts", d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	for rel, content := range extraFiles {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+func TestChartDirectories(t *testing.T) {
+	tests := []struct {
+		name      string
+		dirs      []string
+		extra     map[string]string
+		want      []string
+		wantError bool
+	}{
+		{
+			name: "sorted ascending, dirs only",
+			dirs: []string{"midaz", "plugin-fees", "br-spi"},
+			want: []string{"br-spi", "midaz", "plugin-fees"},
+		},
+		{
+			name:  "ignores loose files in charts/",
+			dirs:  []string{"midaz"},
+			extra: map[string]string{"charts/README.md": "x"},
+			want:  []string{"midaz"},
+		},
+		{
+			name: "empty charts dir returns empty slice",
+			dirs: []string{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeTree(t, tt.dirs, tt.extra)
+			got, err := chartDirectories(root)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("err = %v, wantError = %v", err, tt.wantError)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChartDirectories_MissingRoot(t *testing.T) {
+	_, err := chartDirectories(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing charts dir, got nil")
+	}
+}
+```
+
+Rode o teste e CAPTURE a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | head -20
+```
+Saída esperada (falha de compilação — a função ainda não existe):
+```
+# github.com/LerianStudio/helm/.github/scripts/generate-compatibility [github.com/LerianStudio/helm/.github/scripts/generate-compatibility.test]
+./chart_test.go:...: undefined: chartDirectories
+FAIL	github.com/LerianStudio/helm/.github/scripts/generate-compatibility [build failed]
+```
+
+### Passo 2 (GREEN) — Implementar a função mínima
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart.go` com este conteúdo COMPLETO:
+```go
+// Command generate-compatibility produces the per-product support-window matrix
+// (README blocks + docs/compatibility.json) for the charts in this repo.
+//
+// It mirrors the sibling tools in .github/scripts (generate-values-schemas,
+// update-readme-matrix): invoked with --root ../.., reads the repo state, and
+// writes deterministic artifacts. No network access beyond the git tags already
+// present in the checkout.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// chartDirectories returns the names (not full paths) of the immediate
+// subdirectories of <root>/charts, sorted ascending. Loose files under charts/
+// are ignored. Mirrors validate-helm-charts/main.go:292-307 but returns bare
+// names (the caller joins paths), copied here because Go forbids importing one
+// package main from another.
+func chartDirectories(root string) ([]string, error) {
+	chartsRoot := filepath.Join(root, "charts")
+	entries, err := os.ReadDir(chartsRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}
+```
+
+### Passo 3 — Rodar o teste (deve passar)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -5
+```
+Saída esperada (contém):
+```
+ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility	0.0...s
+```
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-1-2_OK"
+```
+Saída esperada: termina com `ST-1-2_OK`.
+
+## Rollback
+```bash
+rm -rf /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart.go \
+       /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/chart_test.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-3-read-chart-version-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-3-read-chart-version-tdd.md
@@ -1,0 +1,160 @@
+# ST-1-3 — Ler `Chart.yaml` → `ChartState{Name,Dir,Version,AppVersion}` (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Criar a struct `ChartState` (data-model §A.2, campos deste passo apenas) e a função pura `readChartState(root, dir string) (ChartState, error)` que lê `<root>/charts/<dir>/Chart.yaml` via `gopkg.in/yaml.v3` e extrai `name`, `version` (= N, autoridade) e `appVersion`. Annotation/tags são passos posteriores (T-2/T-3).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada (contém `ok`):
+```
+ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility	0.0...s
+```
+(Se falhar, execute ST-1-2 primeiro.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Teste que FALHA
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go`:
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeChart(t *testing.T, root, dir, chartYAML string) {
+	t.Helper()
+	full := filepath.Join(root, "charts", dir)
+	if err := os.MkdirAll(full, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(full, "Chart.yaml"), []byte(chartYAML), 0o644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+}
+
+func TestReadChartState(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "midaz", `apiVersion: v2
+name: midaz-helm
+type: application
+version: 8.6.0
+appVersion: "3.7.8"
+`)
+
+	got, err := readChartState(root, "midaz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "midaz-helm" {
+		t.Errorf("Name = %q, want midaz-helm", got.Name)
+	}
+	if got.Dir != "midaz" {
+		t.Errorf("Dir = %q, want midaz", got.Dir)
+	}
+	if got.Version != "8.6.0" {
+		t.Errorf("Version = %q, want 8.6.0", got.Version)
+	}
+	if got.AppVersion != "3.7.8" {
+		t.Errorf("AppVersion = %q, want 3.7.8", got.AppVersion)
+	}
+}
+
+func TestReadChartState_MissingFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "charts", "empty"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := readChartState(root, "empty")
+	if err == nil {
+		t.Fatal("expected error for missing Chart.yaml, got nil")
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReadChartState 2>&1 | head -10
+```
+Saída esperada: `undefined: readChartState` e `FAIL ... [build failed]`.
+
+### Passo 2 (GREEN) — Implementar
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go`:
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ChartState is the normalized state read from one chart's Chart.yaml.
+// Version is N, the absolute authority for the support window (ADR-3):
+// it is NEVER derived from git tags.
+type ChartState struct {
+	Name       string // published chart name, e.g. "midaz-helm"
+	Dir        string // directory under charts/, e.g. "midaz" (tag prefix)
+	Version    string // N — from Chart.yaml.version
+	AppVersion string // informational
+}
+
+// chartYAML is the minimal shape we parse out of Chart.yaml for T-1.
+// Annotations and dependencies are added in later subtasks (T-2/T-3).
+type chartYAML struct {
+	Name       string `yaml:"name"`
+	Version    string `yaml:"version"`
+	AppVersion string `yaml:"appVersion"`
+}
+
+// readChartState reads <root>/charts/<dir>/Chart.yaml and returns its
+// normalized state. Returns an error if the file is missing or unparseable.
+func readChartState(root, dir string) (ChartState, error) {
+	path := filepath.Join(root, "charts", dir, "Chart.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ChartState{}, err
+	}
+
+	var c chartYAML
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return ChartState{}, err
+	}
+
+	return ChartState{
+		Name:       c.Name,
+		Dir:        dir,
+		Version:    c.Version,
+		AppVersion: c.AppVersion,
+	}, nil
+}
+```
+
+### Passo 3 — Rodar o teste
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReadChartState 2>&1 | tail -3
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ && echo "ST-1-3_OK"
+```
+Saída esperada: termina com `ST-1-3_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-3-read-chart-version-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-3-read-chart-version-tdd.md
@@ -7,7 +7,7 @@ Criar a struct `ChartState` (data-model §A.2, campos deste passo apenas) e a fu
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada (contém `ok`):
 ```
@@ -16,13 +16,13 @@ ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility	0.0...s
 (Se falhar, execute ST-1-2 primeiro.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go`
+- create: `./.github/scripts/generate-compatibility/state.go`
+- create: `./.github/scripts/generate-compatibility/state_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Teste que FALHA
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go`:
+Crie `./.github/scripts/generate-compatibility/state_test.go`:
 ```go
 package main
 
@@ -84,12 +84,12 @@ func TestReadChartState_MissingFile(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReadChartState 2>&1 | head -10
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestReadChartState 2>&1 | head -10
 ```
 Saída esperada: `undefined: readChartState` e `FAIL ... [build failed]`.
 
 ### Passo 2 (GREEN) — Implementar
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go`:
+Crie `./.github/scripts/generate-compatibility/state.go`:
 ```go
 package main
 
@@ -143,18 +143,18 @@ func readChartState(root, dir string) (ChartState, error) {
 
 ### Passo 3 — Rodar o teste
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReadChartState 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestReadChartState 2>&1 | tail -3
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ && echo "ST-1-3_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ && echo "ST-1-3_OK"
 ```
 Saída esperada: termina com `ST-1-3_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go
+rm -f ./.github/scripts/generate-compatibility/state.go \
+      ./.github/scripts/generate-compatibility/state_test.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-4-main-emit-current-json.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-4-main-emit-current-json.md
@@ -1,0 +1,238 @@
+# ST-1-4 — `main()` executável: emite `compatibility.json` só com `current` (esqueleto demoável)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Amarrar `chartDirectories` + `readChartState` num `main()` executável que produz um `compatibility.json` determinístico com `schemaVersion:1` e `products{<name>:{dir,current}}` para todos os charts. Flags mínimas: `--root` (default `../..`) e `--output` (default `docs/compatibility.json`). Demoável: `go run ./generate-compatibility --root ../..`.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`
+(Se falhar, execute ST-1-2 e ST-1-3 primeiro.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Teste de serialização determinística
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go`:
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderJSON_DeterministicAndSchemaV1(t *testing.T) {
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "test",
+		Products: map[string]Product{
+			"plugin-fees-helm": {Dir: "plugin-fees", Current: "7.2.0"},
+			"midaz-helm":       {Dir: "midaz", Current: "8.6.0"},
+		},
+	}
+
+	out1, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+	out2, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON (2nd): %v", err)
+	}
+	if string(out1) != string(out2) {
+		t.Fatal("renderJSON not deterministic across runs")
+	}
+
+	s := string(out1)
+	if !strings.Contains(s, `"schemaVersion": 1`) {
+		t.Errorf("missing schemaVersion:1\n%s", s)
+	}
+	// Products must be emitted in sorted key order: midaz-helm before plugin-fees-helm.
+	iMidaz := strings.Index(s, "midaz-helm")
+	iFees := strings.Index(s, "plugin-fees-helm")
+	if iMidaz == -1 || iFees == -1 || iMidaz > iFees {
+		t.Errorf("products not in sorted order\n%s", s)
+	}
+	if !strings.HasSuffix(s, "\n") {
+		t.Error("output must end with a trailing newline")
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderJSON 2>&1 | head -10
+```
+Saída esperada: `undefined: CompatDoc` / `undefined: renderJSON` e `FAIL ... [build failed]`.
+
+### Passo 2 (GREEN) — Structs do JSON + render determinístico
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json.go`:
+```go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// CompatDoc is the root of docs/compatibility.json (data-model §B.1).
+type CompatDoc struct {
+	SchemaVersion int                `json:"schemaVersion"`
+	GeneratedFrom string             `json:"generatedFrom"`
+	Products      map[string]Product `json:"products"`
+}
+
+// Product is one chart's projection (data-model §B.2).
+// Cycles is added in T-3/T-4; T-1 emits only dir + current.
+type Product struct {
+	Dir     string  `json:"dir"`
+	Current string  `json:"current"`
+	Cycles  []Cycle `json:"cycles,omitempty"`
+}
+
+// Cycle is one minor-cycle line (data-model §B.3). Populated from T-3 onward.
+type Cycle struct {
+	Cycle      string            `json:"cycle"`
+	Latest     string            `json:"latest"`
+	Supported  bool              `json:"supported"`
+	Requires   map[string]string `json:"requires,omitempty"`
+	TestedWith map[string]string `json:"testedWith,omitempty"`
+}
+
+// renderJSON marshals the document deterministically (Go's encoding/json sorts
+// map keys) with two-space indent and a trailing newline, matching the sibling
+// generate-values-schemas output style.
+func renderJSON(doc CompatDoc) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(doc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+```
+
+### Passo 3 (GREEN) — `main()` que amarra tudo
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`:
+```go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	root := flag.String("root", "../..", "Repository root containing the charts/ directory")
+	output := flag.String("output", "docs/compatibility.json", "Destination for the JSON artifact (relative to --root)")
+	flag.Parse()
+
+	doc, err := buildDoc(*root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR %v\n", err)
+		os.Exit(1)
+	}
+
+	data, err := renderJSON(doc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR marshal compatibility.json: %v\n", err)
+		os.Exit(1)
+	}
+
+	outPath := filepath.Join(*root, *output)
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR write %s: %v\n", outPath, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote %s (%d products)\n", outPath, len(doc.Products))
+}
+
+// buildDoc reads every chart under <root>/charts and assembles the document.
+// T-1 fills only dir + current per product; cycles/requires/testedWith arrive
+// in later subtasks.
+func buildDoc(root string) (CompatDoc, error) {
+	dirs, err := chartDirectories(root)
+	if err != nil {
+		return CompatDoc{}, fmt.Errorf("list charts: %w", err)
+	}
+
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "local",
+		Products:      map[string]Product{},
+	}
+
+	for _, dir := range dirs {
+		state, err := readChartState(root, dir)
+		if err != nil {
+			// A chart without a parseable Chart.yaml is skipped with a warning;
+			// it must never abort the whole run (ADR-4).
+			fmt.Fprintf(os.Stderr, "WARN %s: cannot read Chart.yaml — %v\n", dir, err)
+			continue
+		}
+		if state.Name == "" {
+			fmt.Fprintf(os.Stderr, "WARN %s: Chart.yaml has no name; skipping\n", dir)
+			continue
+		}
+		doc.Products[state.Name] = Product{
+			Dir:     state.Dir,
+			Current: state.Version,
+		}
+	}
+
+	return doc, nil
+}
+```
+
+### Passo 4 — Rodar testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -3
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
+
+### Passo 5 — DEMO: rodar contra o repo real
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json && head -12 ../../docs/compatibility.json
+```
+Saída esperada: uma linha `wrote ../../docs/compatibility.json (N products)` (N ~= 21) seguida do início do JSON:
+```
+{
+  "schemaVersion": 1,
+  "generatedFrom": "local",
+  "products": {
+    "br-sisbajud-helm": {
+      "dir": "br-sisbajud",
+      "current": "..."
+    },
+```
+(Nomes/versões exatos variam; o importante é `schemaVersion:1` e um bloco por produto com `dir`+`current`.)
+
+## Verification (copiável) — determinismo 2×
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && \
+  go run ./generate-compatibility --root ../.. --output /tmp/compat-a.json && \
+  go run ./generate-compatibility --root ../.. --output /tmp/compat-b.json && \
+  diff /tmp/compat-a.json /tmp/compat-b.json && echo "DETERMINISTIC_OK"
+```
+Saída esperada: `DETERMINISTIC_OK` (sem linhas de diff).
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go
+cd /home/gauchito/lerian/helm && git checkout docs/compatibility.json 2>/dev/null || rm -f docs/compatibility.json
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-4-main-emit-current-json.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-1/ST-1-4-main-emit-current-json.md
@@ -7,20 +7,20 @@ Amarrar `chartDirectories` + `readChartState` num `main()` executável que produ
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`
 (Se falhar, execute ST-1-2 e ST-1-3 primeiro.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go`
+- create: `./.github/scripts/generate-compatibility/main.go`
+- create: `./.github/scripts/generate-compatibility/json.go`
+- create: `./.github/scripts/generate-compatibility/json_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Teste de serialização determinística
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go`:
+Crie `./.github/scripts/generate-compatibility/json_test.go`:
 ```go
 package main
 
@@ -69,12 +69,12 @@ func TestRenderJSON_DeterministicAndSchemaV1(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderJSON 2>&1 | head -10
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRenderJSON 2>&1 | head -10
 ```
 Saída esperada: `undefined: CompatDoc` / `undefined: renderJSON` e `FAIL ... [build failed]`.
 
 ### Passo 2 (GREEN) — Structs do JSON + render determinístico
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json.go`:
+Crie `./.github/scripts/generate-compatibility/json.go`:
 ```go
 package main
 
@@ -123,7 +123,7 @@ func renderJSON(doc CompatDoc) ([]byte, error) {
 ```
 
 ### Passo 3 (GREEN) — `main()` que amarra tudo
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`:
+Crie `./.github/scripts/generate-compatibility/main.go`:
 ```go
 package main
 
@@ -199,13 +199,13 @@ func buildDoc(root string) (CompatDoc, error) {
 
 ### Passo 4 — Rodar testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -3
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
 
 ### Passo 5 — DEMO: rodar contra o repo real
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json && head -12 ../../docs/compatibility.json
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output docs/compatibility.json && head -12 ../../docs/compatibility.json
 ```
 Saída esperada: uma linha `wrote ../../docs/compatibility.json (N products)` (N ~= 21) seguida do início do JSON:
 ```
@@ -222,7 +222,7 @@ Saída esperada: uma linha `wrote ../../docs/compatibility.json (N products)` (N
 
 ## Verification (copiável) — determinismo 2×
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && \
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && \
   go run ./generate-compatibility --root ../.. --output /tmp/compat-a.json && \
   go run ./generate-compatibility --root ../.. --output /tmp/compat-b.json && \
   diff /tmp/compat-a.json /tmp/compat-b.json && echo "DETERMINISTIC_OK"
@@ -231,8 +231,8 @@ Saída esperada: `DETERMINISTIC_OK` (sem linhas de diff).
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go
-cd /home/gauchito/lerian/helm && git checkout docs/compatibility.json 2>/dev/null || rm -f docs/compatibility.json
+rm -f ./.github/scripts/generate-compatibility/main.go \
+      ./.github/scripts/generate-compatibility/json.go \
+      ./.github/scripts/generate-compatibility/json_test.go
+cd "$(git rev-parse --show-toplevel)" && git checkout docs/compatibility.json 2>/dev/null || rm -f docs/compatibility.json
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-1-parse-annotation-twostep-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-1-parse-annotation-twostep-tdd.md
@@ -7,19 +7,19 @@ Ler a annotation `lerian.studio/compatibility` (string YAML embutida) via TWO-ST
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`
 (Se falhar, complete T-1 primeiro.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation_test.go`
+- create: `./.github/scripts/generate-compatibility/annotation.go`
+- create: `./.github/scripts/generate-compatibility/annotation_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Teste table-driven cobrindo válido/ausente/quebrado
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation_test.go`:
+Crie `./.github/scripts/generate-compatibility/annotation_test.go`:
 ```go
 package main
 
@@ -87,12 +87,12 @@ testedWith:
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseCompatAnnotation 2>&1 | head -10
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestParseCompatAnnotation 2>&1 | head -10
 ```
 Saída esperada: `undefined: CompatAnnotation` / `undefined: parseCompatAnnotation` e `FAIL ... [build failed]`.
 
 ### Passo 2 (GREEN) — Implementar o parse (segundo passo do two-step)
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go`:
+Crie `./.github/scripts/generate-compatibility/annotation.go`:
 ```go
 package main
 
@@ -134,18 +134,18 @@ func parseCompatAnnotation(raw string) (*CompatAnnotation, error) {
 
 ### Passo 3 — Rodar o teste
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseCompatAnnotation 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestParseCompatAnnotation 2>&1 | tail -3
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ && echo "ST-2-1_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ && echo "ST-2-1_OK"
 ```
 Saída esperada: termina com `ST-2-1_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation_test.go
+rm -f ./.github/scripts/generate-compatibility/annotation.go \
+      ./.github/scripts/generate-compatibility/annotation_test.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-1-parse-annotation-twostep-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-1-parse-annotation-twostep-tdd.md
@@ -1,0 +1,151 @@
+# ST-2-1 — Two-step unmarshal da annotation `lerian.studio/compatibility` (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Ler a annotation `lerian.studio/compatibility` (string YAML embutida) via TWO-STEP unmarshal e parseá-la em `CompatAnnotation{Requires, TestedWith}` (data-model §A.1). Precedente da leitura de annotation: `validate-helm-charts/main.go:21` (`chartTypeAnnotation`) lido via `chart.Annotations[...]` (`:244`). A nova chave é `"lerian.studio/compatibility"`. Ausência = válida (nil). YAML embutido quebrado NÃO aborta — retorna erro tratável pelo chamador (WARN em ST-2-2).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`
+(Se falhar, complete T-1 primeiro.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Teste table-driven cobrindo válido/ausente/quebrado
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation_test.go`:
+```go
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCompatAnnotation(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		want      *CompatAnnotation
+		wantError bool
+	}{
+		{
+			name: "complete requires + testedWith",
+			raw: `requires:
+  midaz-helm: ">=8.4.0 <9.0.0"
+testedWith:
+  midaz-helm: "8.6.0"
+`,
+			want: &CompatAnnotation{
+				Requires:   map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"},
+				TestedWith: map[string]string{"midaz-helm": "8.6.0"},
+			},
+		},
+		{
+			name: "only testedWith (typical v1 post-backfill)",
+			raw: `testedWith:
+  midaz-helm: "8.6.0"
+`,
+			want: &CompatAnnotation{
+				TestedWith: map[string]string{"midaz-helm": "8.6.0"},
+			},
+		},
+		{
+			name: "empty string => nil (absent)",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name:      "broken embedded YAML => error (V1)",
+			raw:       "requires:\n  midaz-helm \">=8.4.0\"\n", // missing colon
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCompatAnnotation(tt.raw)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("err = %v, wantError = %v", err, tt.wantError)
+			}
+			if tt.wantError {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseCompatAnnotation 2>&1 | head -10
+```
+Saída esperada: `undefined: CompatAnnotation` / `undefined: parseCompatAnnotation` e `FAIL ... [build failed]`.
+
+### Passo 2 (GREEN) — Implementar o parse (segundo passo do two-step)
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go`:
+```go
+package main
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// compatAnnotationKey is the reverse-DNS annotation carrying compatibility data.
+// It follows the precedent of lerian.studio/chart-type
+// (validate-helm-charts/main.go:21).
+const compatAnnotationKey = "lerian.studio/compatibility"
+
+// CompatAnnotation is the parsed representation of the embedded YAML in the
+// lerian.studio/compatibility annotation (data-model §A.1). Both maps are
+// optional in v1; a wholly absent annotation is represented by a nil pointer.
+type CompatAnnotation struct {
+	Requires   map[string]string `yaml:"requires"`
+	TestedWith map[string]string `yaml:"testedWith"`
+}
+
+// parseCompatAnnotation is the SECOND step of the two-step unmarshal: the caller
+// has already pulled the annotation string out of Chart.yaml.annotations; here
+// we unmarshal that embedded YAML document. An empty/whitespace-only string
+// means "no annotation declared" and returns (nil, nil). Broken YAML returns an
+// error so the caller can emit a V1 WARN and continue (never aborts).
+func parseCompatAnnotation(raw string) (*CompatAnnotation, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var ann CompatAnnotation
+	if err := yaml.Unmarshal([]byte(raw), &ann); err != nil {
+		return nil, err
+	}
+	return &ann, nil
+}
+```
+
+### Passo 3 — Rodar o teste
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseCompatAnnotation 2>&1 | tail -3
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ && echo "ST-2-1_OK"
+```
+Saída esperada: termina com `ST-2-1_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation_test.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-2-validate-annotation-warnings-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-2-validate-annotation-warnings-tdd.md
@@ -1,0 +1,246 @@
+# ST-2-2 — Validação V1–V6 da annotation como WARN/INFO (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Implementar `validateCompat(chart string, ann *CompatAnnotation, knownProducts map[string]bool) []Warning` que aplica as regras V1–V6 (api-design §I.3) SEM abortar: cada violação vira um `Warning` com regra + detalhe. Regras: V3 (produto inexistente), V4 (range `requires` não-parseável via Masterminds), V5 (`testedWith` não é versão exata), V6 (INFO se `testedWith` ausente). V1/V2 (YAML/chaves) já cobertos por ST-2-1 e pela struct tipada. Contrato de mensagem (api-design §II.3): `WARN <chart>: <regra> — <detalhe>`.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && grep -c compatAnnotationKey generate-compatibility/annotation.go
+```
+Saída esperada: número `>= 1` (ST-2-1 concluído).
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn.go`
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go` (adiciona `validateCompat`)
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Teste table-driven das regras
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn_test.go`:
+```go
+package main
+
+import (
+	"testing"
+)
+
+func rulesOf(ws []Warning) []string {
+	out := make([]string, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, w.Rule)
+	}
+	return out
+}
+
+func containsRule(ws []Warning, rule string) bool {
+	for _, r := range rulesOf(ws) {
+		if r == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateCompat(t *testing.T) {
+	known := map[string]bool{"midaz-helm": true, "plugin-fees-helm": true}
+
+	tests := []struct {
+		name      string
+		ann       *CompatAnnotation
+		wantRules []string // rules that MUST be present
+		absent    []string // rules that must NOT be present
+	}{
+		{
+			name:      "nil annotation => single V6 INFO",
+			ann:       nil,
+			wantRules: []string{"V6"},
+		},
+		{
+			name: "valid complete => no warnings",
+			ann: &CompatAnnotation{
+				Requires:   map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"},
+				TestedWith: map[string]string{"midaz-helm": "8.6.0"},
+			},
+			absent: []string{"V3", "V4", "V5", "V6"},
+		},
+		{
+			name: "V3 unknown product in requires",
+			ann: &CompatAnnotation{
+				Requires: map[string]string{"midaz-ledger": ">=8.0.0"},
+			},
+			wantRules: []string{"V3"},
+		},
+		{
+			name: "V4 unparseable range",
+			ann: &CompatAnnotation{
+				Requires: map[string]string{"midaz-helm": "maior que 8"},
+			},
+			wantRules: []string{"V4"},
+		},
+		{
+			name: "V5 testedWith not an exact version",
+			ann: &CompatAnnotation{
+				TestedWith: map[string]string{"midaz-helm": ">=8.6.0"},
+			},
+			wantRules: []string{"V5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateCompat("plugin-fees-helm", tt.ann, known)
+			for _, r := range tt.wantRules {
+				if !containsRule(got, r) {
+					t.Errorf("expected rule %s in %v", r, rulesOf(got))
+				}
+			}
+			for _, r := range tt.absent {
+				if containsRule(got, r) {
+					t.Errorf("did not expect rule %s in %v", r, rulesOf(got))
+				}
+			}
+		})
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestValidateCompat 2>&1 | head -10
+```
+Saída esperada: `undefined: Warning` / `undefined: validateCompat` e `[build failed]`.
+
+### Passo 2 (GREEN) — Tipo `Warning` + emissor de mensagem estável
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn.go`:
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Severity is the stable, CI-parseable prefix (api-design §II.3).
+type Severity string
+
+const (
+	SevWarn Severity = "WARN"
+	SevInfo Severity = "INFO"
+)
+
+// Warning is one diagnostic tied to a chart and a validation rule.
+type Warning struct {
+	Severity Severity
+	Chart    string
+	Rule     string // e.g. "V3", "V4", "V6"
+	Detail   string
+}
+
+// Line renders the stable message contract: "WARN <chart>: <rule> — <detail>".
+func (w Warning) Line() string {
+	return fmt.Sprintf("%s %s: %s — %s", w.Severity, w.Chart, w.Rule, w.Detail)
+}
+
+// emitWarnings writes each warning as one line to stderr, sorted by chart then
+// rule for deterministic output. Returns the count of SevWarn (not INFO).
+func emitWarnings(stderr io.Writer, ws []Warning) int {
+	sorted := make([]Warning, len(ws))
+	copy(sorted, ws)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Chart != sorted[j].Chart {
+			return sorted[i].Chart < sorted[j].Chart
+		}
+		return sorted[i].Rule < sorted[j].Rule
+	})
+	warnCount := 0
+	for _, w := range sorted {
+		fmt.Fprintln(stderr, w.Line())
+		if w.Severity == SevWarn {
+			warnCount++
+		}
+	}
+	return warnCount
+}
+```
+
+### Passo 3 (GREEN) — `validateCompat` em annotation.go
+Adicione ao FINAL de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go` (mantenha o import existente e ACRESCENTE os novos):
+
+Primeiro, ajuste o bloco de imports no topo do arquivo para:
+```go
+import (
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"gopkg.in/yaml.v3"
+)
+```
+
+Depois, adicione ao final do arquivo:
+```go
+// validateCompat applies rules V3–V6 (api-design §I.3) without ever failing.
+// V1 (valid YAML) and V2 (unknown keys) are handled by parseCompatAnnotation
+// and the typed struct respectively. knownProducts is the set of chart names
+// present in the repo, used for the V3 existence check.
+func validateCompat(chart string, ann *CompatAnnotation, knownProducts map[string]bool) []Warning {
+	var out []Warning
+
+	if ann == nil || (len(ann.Requires) == 0 && len(ann.TestedWith) == 0) {
+		// V6: testedWith is expected in v1 but its absence is INFO, not WARN.
+		out = append(out, Warning{
+			Severity: SevInfo,
+			Chart:    chart,
+			Rule:     "V6",
+			Detail:   "no compatibility declared (testedWith expected in v1)",
+		})
+		return out
+	}
+
+	// V3 + V4: requires.
+	for product, rng := range ann.Requires {
+		if !knownProducts[product] {
+			out = append(out, Warning{SevWarn, chart, "V3", fmt.Sprintf("requires[%s] — unknown chart", product)})
+		}
+		if _, err := semver.NewConstraint(rng); err != nil {
+			out = append(out, Warning{SevWarn, chart, "V4", fmt.Sprintf("requires[%s] — invalid semver range %q", product, rng)})
+		}
+	}
+
+	// V3 + V5: testedWith.
+	for product, ver := range ann.TestedWith {
+		if !knownProducts[product] {
+			out = append(out, Warning{SevWarn, chart, "V3", fmt.Sprintf("testedWith[%s] — unknown chart", product)})
+		}
+		if _, err := semver.NewVersion(ver); err != nil {
+			out = append(out, Warning{SevWarn, chart, "V5", fmt.Sprintf("testedWith[%s] — not an exact version %q", product, ver)})
+		}
+	}
+
+	return out
+}
+```
+
+Note: `fmt` já não estava importado em annotation.go — o `strings` estava. Se `go build` reclamar de `fmt` faltando, adicione `"fmt"` ao bloco de imports (ordem: `"fmt"`, `"strings"`, depois os externos).
+
+### Passo 4 — Rodar o teste
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestValidateCompat 2>&1 | tail -3
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-2-2_OK"
+```
+Saída esperada: termina com `ST-2-2_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn_test.go
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/annotation.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-2-validate-annotation-warnings-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-2-validate-annotation-warnings-tdd.md
@@ -7,19 +7,19 @@ Implementar `validateCompat(chart string, ann *CompatAnnotation, knownProducts m
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && grep -c compatAnnotationKey generate-compatibility/annotation.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && grep -c compatAnnotationKey generate-compatibility/annotation.go
 ```
 Saída esperada: número `>= 1` (ST-2-1 concluído).
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn.go`
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go` (adiciona `validateCompat`)
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn_test.go`
+- create: `./.github/scripts/generate-compatibility/warn.go`
+- modify: `./.github/scripts/generate-compatibility/annotation.go` (adiciona `validateCompat`)
+- create: `./.github/scripts/generate-compatibility/warn_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Teste table-driven das regras
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn_test.go`:
+Crie `./.github/scripts/generate-compatibility/warn_test.go`:
 ```go
 package main
 
@@ -109,12 +109,12 @@ func TestValidateCompat(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestValidateCompat 2>&1 | head -10
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestValidateCompat 2>&1 | head -10
 ```
 Saída esperada: `undefined: Warning` / `undefined: validateCompat` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Tipo `Warning` + emissor de mensagem estável
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn.go`:
+Crie `./.github/scripts/generate-compatibility/warn.go`:
 ```go
 package main
 
@@ -168,11 +168,12 @@ func emitWarnings(stderr io.Writer, ws []Warning) int {
 ```
 
 ### Passo 3 (GREEN) — `validateCompat` em annotation.go
-Adicione ao FINAL de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/annotation.go` (mantenha o import existente e ACRESCENTE os novos):
+Adicione ao FINAL de `./.github/scripts/generate-compatibility/annotation.go` (mantenha o import existente e ACRESCENTE os novos):
 
 Primeiro, ajuste o bloco de imports no topo do arquivo para:
 ```go
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -228,19 +229,19 @@ Note: `fmt` já não estava importado em annotation.go — o `strings` estava. S
 
 ### Passo 4 — Rodar o teste
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestValidateCompat 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestValidateCompat 2>&1 | tail -3
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-2-2_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-2-2_OK"
 ```
 Saída esperada: termina com `ST-2-2_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/warn_test.go
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/annotation.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/warn.go \
+      ./.github/scripts/generate-compatibility/warn_test.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/annotation.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-3-wire-annotation-into-state-and-doc.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-3-wire-annotation-into-state-and-doc.md
@@ -1,0 +1,230 @@
+# ST-2-3 — Ligar a annotation no `ChartState` e emitir WARN no `buildDoc` (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Primeiro passo do two-step no leitor: ler `annotations["lerian.studio/compatibility"]` no `Chart.yaml`, parsear via `parseCompatAnnotation`, guardar em `ChartState.Compat`, e — em `buildDoc` — emitir WARN de YAML quebrado (V1) e chamar `validateCompat` com o conjunto de produtos conhecidos. Annotation ausente/quebrada NUNCA aborta (ADR-4, exit 0).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestParseCompatAnnotation|TestValidateCompat' 2>&1 | tail -1
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`
+(Se falhar, complete ST-2-1 e ST-2-2.)
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go` (add `Compat` + parse da annotation)
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go` (novo caso)
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (buildDoc coleta produtos + valida)
+
+## Steps
+
+### Passo 1 (RED) — Novo teste em state_test.go
+Adicione ao FINAL de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go`:
+```go
+func TestReadChartState_ParsesCompatAnnotation(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "plugin-fees", `apiVersion: v2
+name: plugin-fees-helm
+type: application
+version: 7.2.0
+appVersion: "3.3.0"
+annotations:
+  lerian.studio/chart-type: multi-component
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: ">=8.4.0 <9.0.0"
+    testedWith:
+      midaz-helm: "8.6.0"
+`)
+
+	got, err := readChartState(root, "plugin-fees")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Compat == nil {
+		t.Fatal("Compat is nil, want parsed annotation")
+	}
+	if got.Compat.Requires["midaz-helm"] != ">=8.4.0 <9.0.0" {
+		t.Errorf("Requires[midaz-helm] = %q", got.Compat.Requires["midaz-helm"])
+	}
+	if got.Compat.TestedWith["midaz-helm"] != "8.6.0" {
+		t.Errorf("TestedWith[midaz-helm] = %q", got.Compat.TestedWith["midaz-helm"])
+	}
+}
+
+func TestReadChartState_NoAnnotationIsNilCompat(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "matcher", `apiVersion: v2
+name: matcher-helm
+type: application
+version: 3.0.0
+`)
+	got, err := readChartState(root, "matcher")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Compat != nil {
+		t.Errorf("Compat = %+v, want nil", got.Compat)
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReadChartState_ParsesCompatAnnotation 2>&1 | head -8
+```
+Saída esperada: `got.Compat undefined (type ChartState has no field or method Compat)` e `[build failed]`.
+
+### Passo 2 (GREEN) — Estender ChartState + chartYAML e fazer o parse
+Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go`:
+
+Substitua a struct `ChartState` por:
+```go
+type ChartState struct {
+	Name       string // published chart name, e.g. "midaz-helm"
+	Dir        string // directory under charts/, e.g. "midaz" (tag prefix)
+	Version    string // N — from Chart.yaml.version
+	AppVersion string // informational
+	Compat     *CompatAnnotation
+}
+```
+
+Substitua a struct `chartYAML` por (adiciona `Annotations`):
+```go
+type chartYAML struct {
+	Name        string            `yaml:"name"`
+	Version     string            `yaml:"version"`
+	AppVersion  string            `yaml:"appVersion"`
+	Annotations map[string]string `yaml:"annotations"`
+}
+```
+
+Substitua o corpo de `readChartState` (o `return`) por:
+```go
+	compat, err := parseCompatAnnotation(c.Annotations[compatAnnotationKey])
+	if err != nil {
+		// Broken embedded YAML (V1): surface as a tagged error so buildDoc can
+		// emit a WARN and continue. State is still usable (name/version known).
+		return ChartState{
+			Name:       c.Name,
+			Dir:        dir,
+			Version:    c.Version,
+			AppVersion: c.AppVersion,
+		}, &badAnnotationError{chart: c.Name, err: err}
+	}
+
+	return ChartState{
+		Name:       c.Name,
+		Dir:        dir,
+		Version:    c.Version,
+		AppVersion: c.AppVersion,
+		Compat:     compat,
+	}, nil
+}
+
+// badAnnotationError marks a Chart.yaml whose compatibility annotation is
+// unparseable (V1). The chart state is still returned; the caller downgrades
+// this to a WARN rather than aborting (ADR-4).
+type badAnnotationError struct {
+	chart string
+	err   error
+}
+
+func (e *badAnnotationError) Error() string {
+	return fmt.Sprintf("compatibility annotation is invalid YAML: %v", e.err)
+}
+```
+
+Adicione `"errors"` e `"fmt"` ao bloco de imports de `state.go`:
+```go
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+```
+(`errors` é usado no Passo 3 via `errors.As`; mantenha-o mesmo que o linter não reclame agora — o buildDoc importará via este arquivo? Não: cada arquivo importa o que usa. Se `errors` ficar sem uso em state.go, REMOVA-o daqui e deixe só em main.go. Rode `go build` para confirmar.)
+
+### Passo 3 (GREEN) — buildDoc: coletar produtos, tratar bad annotation, validar
+Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`, substitua a função `buildDoc` inteira por:
+```go
+// buildDoc reads every chart under <root>/charts and assembles the document,
+// emitting WARN/INFO diagnostics to stderr. It never aborts on data problems
+// (ADR-4); only environment errors (unreadable charts/ dir) propagate.
+func buildDoc(root string) (CompatDoc, error) {
+	dirs, err := chartDirectories(root)
+	if err != nil {
+		return CompatDoc{}, fmt.Errorf("list charts: %w", err)
+	}
+
+	// First pass: read all states so we know the full set of known products
+	// before running the V3 existence check.
+	states := make([]ChartState, 0, len(dirs))
+	knownProducts := map[string]bool{}
+	for _, dir := range dirs {
+		state, err := readChartState(root, dir)
+		var badAnn *badAnnotationError
+		switch {
+		case errors.As(err, &badAnn):
+			fmt.Fprintln(os.Stderr, Warning{SevWarn, badAnn.chart, "V1", err.Error()}.Line())
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "WARN %s: cannot read Chart.yaml — %v\n", dir, err)
+			continue
+		}
+		if state.Name == "" {
+			fmt.Fprintf(os.Stderr, "WARN %s: Chart.yaml has no name; skipping\n", dir)
+			continue
+		}
+		states = append(states, state)
+		knownProducts[state.Name] = true
+	}
+
+	// Second pass: validate annotations and build the document.
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "local",
+		Products:      map[string]Product{},
+	}
+	for _, state := range states {
+		emitWarnings(os.Stderr, validateCompat(state.Name, state.Compat, knownProducts))
+		doc.Products[state.Name] = Product{
+			Dir:     state.Dir,
+			Current: state.Version,
+		}
+	}
+
+	return doc, nil
+}
+```
+
+Garanta que o bloco de imports de `main.go` inclua `"errors"`:
+```go
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+```
+
+### Passo 4 — Rodar testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -3
+```
+Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
+
+## Verification (copiável) — rodar contra repo real, ver WARN/INFO em stderr
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-t2.json 2> /tmp/compat-t2.stderr; echo "exit=$?"; echo "--- stderr (primeiras linhas) ---"; head -5 /tmp/compat-t2.stderr
+```
+Saída esperada: `exit=0` (nunca ≠0 por dado). stderr contém linhas `INFO <chart>: V6 — ...` para charts sem annotation (a maioria no v1 pré-backfill). Nenhuma alteração no `compatibility.json` do repo (usamos /tmp).
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/state.go generate-compatibility/state_test.go generate-compatibility/main.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-3-wire-annotation-into-state-and-doc.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-2/ST-2-3-wire-annotation-into-state-and-doc.md
@@ -7,20 +7,20 @@ Primeiro passo do two-step no leitor: ler `annotations["lerian.studio/compatibil
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestParseCompatAnnotation|TestValidateCompat' 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run 'TestParseCompatAnnotation|TestValidateCompat' 2>&1 | tail -1
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`
 (Se falhar, complete ST-2-1 e ST-2-2.)
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go` (add `Compat` + parse da annotation)
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go` (novo caso)
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (buildDoc coleta produtos + valida)
+- modify: `./.github/scripts/generate-compatibility/state.go` (add `Compat` + parse da annotation)
+- modify: `./.github/scripts/generate-compatibility/state_test.go` (novo caso)
+- modify: `./.github/scripts/generate-compatibility/main.go` (buildDoc coleta produtos + valida)
 
 ## Steps
 
 ### Passo 1 (RED) — Novo teste em state_test.go
-Adicione ao FINAL de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state_test.go`:
+Adicione ao FINAL de `./.github/scripts/generate-compatibility/state_test.go`:
 ```go
 func TestReadChartState_ParsesCompatAnnotation(t *testing.T) {
 	root := t.TempDir()
@@ -72,12 +72,12 @@ version: 3.0.0
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReadChartState_ParsesCompatAnnotation 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestReadChartState_ParsesCompatAnnotation 2>&1 | head -8
 ```
 Saída esperada: `got.Compat undefined (type ChartState has no field or method Compat)` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Estender ChartState + chartYAML e fazer o parse
-Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/state.go`:
+Em `./.github/scripts/generate-compatibility/state.go`:
 
 Substitua a struct `ChartState` por:
 ```go
@@ -150,7 +150,7 @@ import (
 (`errors` é usado no Passo 3 via `errors.As`; mantenha-o mesmo que o linter não reclame agora — o buildDoc importará via este arquivo? Não: cada arquivo importa o que usa. Se `errors` ficar sem uso em state.go, REMOVA-o daqui e deixe só em main.go. Rode `go build` para confirmar.)
 
 ### Passo 3 (GREEN) — buildDoc: coletar produtos, tratar bad annotation, validar
-Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`, substitua a função `buildDoc` inteira por:
+Em `./.github/scripts/generate-compatibility/main.go`, substitua a função `buildDoc` inteira por:
 ```go
 // buildDoc reads every chart under <root>/charts and assembles the document,
 // emitting WARN/INFO diagnostics to stderr. It never aborts on data problems
@@ -214,17 +214,17 @@ import (
 
 ### Passo 4 — Rodar testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -3
 ```
 Saída esperada: `ok  	github.com/LerianStudio/helm/.github/scripts/generate-compatibility ...`.
 
 ## Verification (copiável) — rodar contra repo real, ver WARN/INFO em stderr
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-t2.json 2> /tmp/compat-t2.stderr; echo "exit=$?"; echo "--- stderr (primeiras linhas) ---"; head -5 /tmp/compat-t2.stderr
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output /tmp/compat-t2.json 2> /tmp/compat-t2.stderr; echo "exit=$?"; echo "--- stderr (primeiras linhas) ---"; head -5 /tmp/compat-t2.stderr
 ```
 Saída esperada: `exit=0` (nunca ≠0 por dado). stderr contém linhas `INFO <chart>: V6 — ...` para charts sem annotation (a maioria no v1 pré-backfill). Nenhuma alteração no `compatibility.json` do repo (usamos /tmp).
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/state.go generate-compatibility/state_test.go generate-compatibility/main.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/state.go generate-compatibility/state_test.go generate-compatibility/main.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-1-list-git-tags-for-dir-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-1-list-git-tags-for-dir-tdd.md
@@ -1,0 +1,193 @@
+# ST-3-1 — Listar tags git `<dir>-v*` e parsear em versões semver (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Isolar o acesso ao git atrás de uma interface testável. Criar `tagLister` (interface) + `gitTagLister` (impl real via `git tag --list <dir>-v*`) e a função pura `parseTags(dir string, rawTags []string) []*semver.Version` que filtra pelo prefixo `<dir>-v`, tira o prefixo, e parseia com Masterminds/semver, DESCARTANDO strings não-semver (ex.: `midaz-v1.0.0-HELM-94.1` cujo sufixo não é semver-limpo é MANTIDO como pre-release; strings que o parser rejeita são descartadas). Segregação de pre-release vem em ST-3-2.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete T-2.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Teste table-driven de parseTags
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags_test.go`:
+```go
+package main
+
+import (
+	"testing"
+)
+
+func versionStrings(vs []interface{ String() string }) []string {
+	out := make([]string, 0, len(vs))
+	for _, v := range vs {
+		out = append(out, v.String())
+	}
+	return out
+}
+
+func TestParseTags(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		raw  []string
+		want []string // semver .String() values, order as returned
+	}{
+		{
+			name: "filters by dir prefix and strips it",
+			dir:  "midaz",
+			raw:  []string{"midaz-v8.6.0", "midaz-v8.5.0", "plugin-fees-v7.2.0"},
+			want: []string{"8.6.0", "8.5.0"},
+		},
+		{
+			name: "keeps semver pre-releases",
+			dir:  "midaz",
+			raw:  []string{"midaz-v8.6.0-beta.11", "midaz-v8.6.0"},
+			want: []string{"8.6.0-beta.11", "8.6.0"},
+		},
+		{
+			name: "drops tags whose suffix is not parseable semver",
+			dir:  "midaz",
+			raw:  []string{"midaz-vLATEST", "midaz-v8.6.0", "midaz-vnightly"},
+			want: []string{"8.6.0"},
+		},
+		{
+			name: "does not match a different dir that shares a prefix boundary",
+			dir:  "plugin-fees",
+			raw:  []string{"plugin-fees-v7.2.0", "plugin-fees-helm-v1.0.0"},
+			// "plugin-fees-helm-v1.0.0" has prefix "plugin-fees-v"? No: after
+			// "plugin-fees-v" the remainder would be "..." only if the tag is
+			// literally plugin-fees-v<semver>. "plugin-fees-helm-v1.0.0" does
+			// NOT start with "plugin-fees-v", so it is excluded.
+			want: []string{"7.2.0"},
+		},
+		{
+			name: "empty input",
+			dir:  "br-spi",
+			raw:  []string{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTags(tt.dir, tt.raw)
+			gotStr := make([]string, 0, len(got))
+			for _, v := range got {
+				gotStr = append(gotStr, v.String())
+			}
+			if len(gotStr) != len(tt.want) {
+				t.Fatalf("got %v (len %d), want %v (len %d)", gotStr, len(gotStr), tt.want, len(tt.want))
+			}
+			for i := range tt.want {
+				if gotStr[i] != tt.want[i] {
+					t.Fatalf("index %d: got %q, want %q (full got %v)", i, gotStr[i], tt.want[i], gotStr)
+				}
+			}
+		})
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseTags 2>&1 | head -8
+```
+Saída esperada: `undefined: parseTags` e `[build failed]`.
+
+### Passo 2 (GREEN) — Implementar tags.go
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags.go`:
+```go
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// tagLister abstracts the git tag lookup so tests can inject fixtures without
+// touching a real repo.
+type tagLister interface {
+	// listTags returns raw tag names matching the <dir>-v* glob for a chart dir.
+	listTags(dir string) ([]string, error)
+}
+
+// gitTagLister is the real implementation, backed by `git tag --list`.
+// It runs against the working tree at root.
+type gitTagLister struct {
+	root string
+}
+
+func (g gitTagLister) listTags(dir string) ([]string, error) {
+	cmd := exec.Command("git", "-C", g.root, "tag", "--list", dir+"-v*")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	tags := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if s := strings.TrimSpace(l); s != "" {
+			tags = append(tags, s)
+		}
+	}
+	return tags, nil
+}
+
+// parseTags filters raw tags to those of the form "<dir>-v<semver>", strips the
+// "<dir>-v" prefix, and parses each remainder with Masterminds/semver. Tags
+// whose remainder is not valid semver are dropped. Pre-releases are KEPT here;
+// segregation happens later (ST-3-2). Output order mirrors input order.
+func parseTags(dir string, rawTags []string) []*semver.Version {
+	prefix := dir + "-v"
+	out := make([]*semver.Version, 0, len(rawTags))
+	for _, tag := range rawTags {
+		if !strings.HasPrefix(tag, prefix) {
+			continue
+		}
+		remainder := strings.TrimPrefix(tag, prefix)
+		v, err := semver.NewVersion(remainder)
+		if err != nil {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+```
+
+Remova o helper não usado `versionStrings` do teste se `go vet` reclamar — não é referenciado. (Deixe-o de fora: apague as linhas de `versionStrings` em tags_test.go se estiverem sinalizadas como unused. Go só reclama de imports/variáveis locais não usadas, não de funções de nível de pacote, então provavelmente fica OK; confirme com `go vet`.)
+
+### Passo 3 — Rodar o teste
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseTags 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável) — impl real contra o repo
+```bash
+cd /home/gauchito/lerian/helm && git tag --list 'midaz-v*' | head -3
+```
+Saída esperada: tags reais como `midaz-v1.0.0`, `midaz-v1.0.0-HELM-94.1`, etc. (confirma que o glob `<dir>-v*` funciona no repo).
+
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-1_OK"
+```
+Saída esperada: termina com `ST-3-1_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags_test.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-1-list-git-tags-for-dir-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-1-list-git-tags-for-dir-tdd.md
@@ -7,19 +7,19 @@ Isolar o acesso ao git atrás de uma interface testável. Criar `tagLister` (int
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete T-2.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags_test.go`
+- create: `./.github/scripts/generate-compatibility/tags.go`
+- create: `./.github/scripts/generate-compatibility/tags_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Teste table-driven de parseTags
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags_test.go`:
+Crie `./.github/scripts/generate-compatibility/tags_test.go`:
 ```go
 package main
 
@@ -100,12 +100,12 @@ func TestParseTags(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseTags 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestParseTags 2>&1 | head -8
 ```
 Saída esperada: `undefined: parseTags` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Implementar tags.go
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags.go`:
+Crie `./.github/scripts/generate-compatibility/tags.go`:
 ```go
 package main
 
@@ -171,23 +171,23 @@ Remova o helper não usado `versionStrings` do teste se `go vet` reclamar — n�
 
 ### Passo 3 — Rodar o teste
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseTags 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestParseTags 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável) — impl real contra o repo
 ```bash
-cd /home/gauchito/lerian/helm && git tag --list 'midaz-v*' | head -3
+cd "$(git rev-parse --show-toplevel)" && git tag --list 'midaz-v*' | head -3
 ```
 Saída esperada: tags reais como `midaz-v1.0.0`, `midaz-v1.0.0-HELM-94.1`, etc. (confirma que o glob `<dir>-v*` funciona no repo).
 
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-1_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-1_OK"
 ```
 Saída esperada: termina com `ST-3-1_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/tags_test.go
+rm -f ./.github/scripts/generate-compatibility/tags.go \
+      ./.github/scripts/generate-compatibility/tags_test.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-2-segregate-prereleases-and-group-by-minor-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-2-segregate-prereleases-and-group-by-minor-tdd.md
@@ -1,0 +1,209 @@
+# ST-3-2 — Segregar pre-releases e agrupar por `Major().Minor()` (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Duas funções puras: `segregateStable(vs []*semver.Version) []*semver.Version` (descarta qualquer versão com `.Prerelease() != ""` — decisão do TRD §2: pre-releases `-beta.N`/`-HELM-N` NÃO viram ciclo próprio) e `groupByMinor(vs []*semver.Version) map[string]*semver.Version` (chave `"MAJOR.MINOR"` → maior patch estável daquele ciclo). Isto é o coração da correção da janela; teste EXAUSTIVO.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseTags 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-3-1.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes table-driven exaustivos
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window_test.go`:
+```go
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// mustVers parses a list of semver strings, failing the test on any error.
+func mustVers(t *testing.T, ss ...string) []*semver.Version {
+	t.Helper()
+	out := make([]*semver.Version, 0, len(ss))
+	for _, s := range ss {
+		v, err := semver.NewVersion(s)
+		if err != nil {
+			t.Fatalf("bad test version %q: %v", s, err)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func TestSegregateStable(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"drops beta", []string{"8.6.0", "8.6.0-beta.11", "8.5.0"}, []string{"8.6.0", "8.5.0"}},
+		{"drops HELM prerelease", []string{"1.0.0-HELM-94.1", "1.0.0"}, []string{"1.0.0"}},
+		{"all stable kept", []string{"3.2.0", "3.1.0"}, []string{"3.2.0", "3.1.0"}},
+		{"all prerelease => empty", []string{"2.0.0-rc.1", "2.0.0-beta.2"}, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := segregateStable(mustVers(t, tt.in...))
+			gotStr := make([]string, 0, len(got))
+			for _, v := range got {
+				gotStr = append(gotStr, v.String())
+			}
+			if len(gotStr) != len(tt.want) {
+				t.Fatalf("got %v, want %v", gotStr, tt.want)
+			}
+			for i := range tt.want {
+				if gotStr[i] != tt.want[i] {
+					t.Fatalf("index %d: got %q want %q", i, gotStr[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGroupByMinor(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want map[string]string // "MAJOR.MINOR" -> latest patch .String()
+	}{
+		{
+			name: "picks highest patch per minor",
+			in:   []string{"8.6.0", "8.6.2", "8.6.1", "8.5.0", "8.5.3"},
+			want: map[string]string{"8.6": "8.6.2", "8.5": "8.5.3"},
+		},
+		{
+			name: "single minor",
+			in:   []string{"3.0.0"},
+			want: map[string]string{"3.0": "3.0.0"},
+		},
+		{
+			name: "crosses majors",
+			in:   []string{"9.0.0", "8.9.0", "8.9.5"},
+			want: map[string]string{"9.0": "9.0.0", "8.9": "8.9.5"},
+		},
+		{
+			name: "empty",
+			in:   []string{},
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := groupByMinor(mustVers(t, tt.in...))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d cycles, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for cycle, wantLatest := range tt.want {
+				v, ok := got[cycle]
+				if !ok {
+					t.Fatalf("missing cycle %q in %v", cycle, got)
+				}
+				if v.String() != wantLatest {
+					t.Errorf("cycle %q: got latest %q, want %q", cycle, v.String(), wantLatest)
+				}
+			}
+		})
+	}
+}
+
+// TestGroupByMinor_OrderIndependent proves grouping does not depend on input
+// order (map iteration is random; the pick must be deterministic by value).
+func TestGroupByMinor_OrderIndependent(t *testing.T) {
+	forward := mustVers(t, "8.6.0", "8.6.1", "8.6.2")
+	rev := mustVers(t, "8.6.2", "8.6.1", "8.6.0")
+	// shuffle-ish: sort rev descending to differ from forward
+	sort.Sort(sort.Reverse(semver.Collection(rev)))
+	a := groupByMinor(forward)
+	b := groupByMinor(rev)
+	if a["8.6"].String() != b["8.6"].String() {
+		t.Fatalf("order-dependent: %q vs %q", a["8.6"], b["8.6"])
+	}
+	if a["8.6"].String() != "8.6.2" {
+		t.Fatalf("expected latest 8.6.2, got %q", a["8.6"])
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | head -8
+```
+Saída esperada: `undefined: segregateStable` / `undefined: groupByMinor` e `[build failed]`.
+
+### Passo 2 (GREEN) — Implementar window.go
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go`:
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// segregateStable drops every pre-release version (e.g. -beta.N, -HELM-N,
+// -rc.N). Per TRD §2, pre-releases never become their own support cycle; they
+// are removed before minors are computed. Input order is preserved for the
+// survivors.
+func segregateStable(vs []*semver.Version) []*semver.Version {
+	out := make([]*semver.Version, 0, len(vs))
+	for _, v := range vs {
+		if v.Prerelease() != "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// minorKey renders the "MAJOR.MINOR" cycle key for a version.
+func minorKey(v *semver.Version) string {
+	return fmt.Sprintf("%d.%d", v.Major(), v.Minor())
+}
+
+// groupByMinor buckets stable versions by their MAJOR.MINOR cycle, keeping the
+// highest patch in each bucket. The result is deterministic regardless of input
+// order because the winner is chosen by semver comparison, not by position.
+func groupByMinor(vs []*semver.Version) map[string]*semver.Version {
+	latest := map[string]*semver.Version{}
+	for _, v := range vs {
+		key := minorKey(v)
+		if cur, ok := latest[key]; !ok || v.GreaterThan(cur) {
+			latest[key] = v
+		}
+	}
+	return latest
+}
+```
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-2_OK"
+```
+Saída esperada: termina com `ST-3-2_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window_test.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-2-segregate-prereleases-and-group-by-minor-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-2-segregate-prereleases-and-group-by-minor-tdd.md
@@ -7,19 +7,19 @@ Duas funções puras: `segregateStable(vs []*semver.Version) []*semver.Version` 
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestParseTags 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestParseTags 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-3-1.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window_test.go`
+- create: `./.github/scripts/generate-compatibility/window.go`
+- create: `./.github/scripts/generate-compatibility/window_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes table-driven exaustivos
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window_test.go`:
+Crie `./.github/scripts/generate-compatibility/window_test.go`:
 ```go
 package main
 
@@ -140,12 +140,12 @@ func TestGroupByMinor_OrderIndependent(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | head -8
 ```
 Saída esperada: `undefined: segregateStable` / `undefined: groupByMinor` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Implementar window.go
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go`:
+Crie `./.github/scripts/generate-compatibility/window.go`:
 ```go
 package main
 
@@ -192,18 +192,18 @@ func groupByMinor(vs []*semver.Version) map[string]*semver.Version {
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-2_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-2_OK"
 ```
 Saída esperada: termina com `ST-3-2_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window_test.go
+rm -f ./.github/scripts/generate-compatibility/window.go \
+      ./.github/scripts/generate-compatibility/window_test.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-3-resolve-window-N-authoritative-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-3-resolve-window-N-authoritative-tdd.md
@@ -11,19 +11,19 @@ Este passo NÃO preenche `requires`/`testedWith` (isso é T-4/ST-3-4 wiring). Fo
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-3-2.)
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go` (add `resolveWindow`)
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/resolve_test.go`
+- modify: `./.github/scripts/generate-compatibility/window.go` (add `resolveWindow`)
+- create: `./.github/scripts/generate-compatibility/resolve_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes exaustivos (0/1/2/3/4+ minors, N ausente das tags, pre-release)
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/resolve_test.go`:
+Crie `./.github/scripts/generate-compatibility/resolve_test.go`:
 ```go
 package main
 
@@ -193,12 +193,12 @@ func assertNoINFO(t *testing.T, ws []Warning) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | head -8
 ```
 Saída esperada: `undefined: resolveWindow` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Implementar resolveWindow em window.go
-Adicione ao final de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go`:
+Adicione ao final de `./.github/scripts/generate-compatibility/window.go`:
 ```go
 // supportedWindowSize is the number of most-recent minor cycles that are marked
 // supported (N..N-3). Cycles below that are supported=false.
@@ -228,11 +228,11 @@ func resolveWindow(chartVersion string, tagVersions []*semver.Version) ([]Cycle,
 	// Group stable tag versions by minor cycle.
 	byMinor := groupByMinor(segregateStable(tagVersions))
 
-	// Force the N cycle to exist, sourced from Chart.yaml (authority). If a tag
-	// for the N cycle also exists, keep the greater of the two as latest.
-	if existing, ok := byMinor[nKey]; !ok || nVer.GreaterThan(existing) {
-		byMinor[nKey] = nVer
-	}
+	// Force the N cycle to exist, sourced from Chart.yaml (authority), UNCONDITIONALLY.
+	// N always wins for its own minor cycle — even if a higher patch tag exists
+	// (e.g. tag 8.6.1 while Chart.yaml N=8.6.0), so the N cycle is never sequestered
+	// by a > N patch and then dropped by the "never exceed N" filter below.
+	byMinor[nKey] = nVer
 
 	// Collect the "latest" version of each minor, drop any cycle above N, then
 	// sort descending by that latest version.
@@ -292,18 +292,18 @@ Substitua, em `resolveWindow`, a chamada `sortVersionsDesc(latests)` por `sortSe
 
 ### Passo 4 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-3_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-3_OK"
 ```
 Saída esperada: termina com `ST-3-3_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/resolve_test.go
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/window.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/resolve_test.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/window.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-3-resolve-window-N-authoritative-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-3-resolve-window-N-authoritative-tdd.md
@@ -1,0 +1,309 @@
+# ST-3-3 — `resolveWindow`: N do Chart.yaml + top-4 minors + degradação (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+A função-coração `resolveWindow(chartVersion string, tagVersions []*semver.Version) ([]Cycle, []Warning)`:
+- **N = `chartVersion` (Chart.yaml), AUTORIDADE ABSOLUTA** — nunca das tags (ADR-3/NFR-3).
+- Combina o ciclo de N com os ciclos das tags (segregadas + agrupadas por minor via ST-3-2), garante que o ciclo de N exista mesmo sem tag, ordena minors DESC, pega as **top-4 minors distintas ≤ N** → `supported=true`; o resto → `supported=false`.
+- Degradação: 0 tags → só o ciclo N (+INFO); <4 → só os existentes.
+Este passo NÃO preenche `requires`/`testedWith` (isso é T-4/ST-3-4 wiring). Foca na janela + `supported`.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestSegregateStable|TestGroupByMinor' 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-3-2.)
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go` (add `resolveWindow`)
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/resolve_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes exaustivos (0/1/2/3/4+ minors, N ausente das tags, pre-release)
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/resolve_test.go`:
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func tagVers(t *testing.T, ss ...string) []*semver.Version {
+	t.Helper()
+	out := make([]*semver.Version, 0, len(ss))
+	for _, s := range ss {
+		v, err := semver.NewVersion(s)
+		if err != nil {
+			t.Fatalf("bad version %q: %v", s, err)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// cyclePairs flattens []Cycle to a compact [cycle, latest, supported] view.
+func cyclePairs(cs []Cycle) []struct {
+	cycle     string
+	latest    string
+	supported bool
+} {
+	out := make([]struct {
+		cycle     string
+		latest    string
+		supported bool
+	}, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, struct {
+			cycle     string
+			latest    string
+			supported bool
+		}{c.Cycle, c.Latest, c.Supported})
+	}
+	return out
+}
+
+func TestResolveWindow(t *testing.T) {
+	tests := []struct {
+		name        string
+		chartVer    string
+		tags        []string
+		wantCycles  [][3]string // {cycle, latest, "true"/"false"}
+		wantINFO    bool        // expect an INFO warning (0 tags case)
+	}{
+		{
+			name:     "midaz: N=8.6.0, five minors => top-4 supported, 8.2 EOL",
+			chartVer: "8.6.0",
+			tags:     []string{"midaz-x"}, // placeholder replaced below in per-test setup
+			// NOTE: this test provides tags via tagVers in the loop; see below.
+		},
+	}
+	_ = tests // replaced by explicit cases below to keep versions readable
+
+	// --- Explicit cases (clearer than a giant table for this logic) ---
+
+	t.Run("N=8.6.0 with 8.6..8.2 => top-4 supported, 8.2 unsupported", func(t *testing.T) {
+		cs, ws := resolveWindow("8.6.0", tagVers(t,
+			"8.6.0", "8.5.0", "8.4.0", "8.3.0", "8.2.0"))
+		got := cyclePairs(cs)
+		want := [][3]string{
+			{"8.6", "8.6.0", "true"},
+			{"8.5", "8.5.0", "true"},
+			{"8.4", "8.4.0", "true"},
+			{"8.3", "8.3.0", "true"},
+			{"8.2", "8.2.0", "false"},
+		}
+		assertCycles(t, got, want)
+		assertNoINFO(t, ws)
+	})
+
+	t.Run("N authoritative: chart=8.6.0 but tags stale at 8.5 => N cycle still present & supported", func(t *testing.T) {
+		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.5.0", "8.4.0"))
+		got := cyclePairs(cs)
+		// N=8.6 must appear as top cycle, supported, latest=8.6.0 (from Chart.yaml).
+		if got[0].cycle != "8.6" || got[0].supported != true || got[0].latest != "8.6.0" {
+			t.Fatalf("N cycle wrong: %+v", got[0])
+		}
+	})
+
+	t.Run("0 tags => only N cycle + INFO", func(t *testing.T) {
+		cs, ws := resolveWindow("1.0.0", tagVers(t))
+		if len(cs) != 1 || cs[0].Cycle != "1.0" || !cs[0].Supported || cs[0].Latest != "1.0.0" {
+			t.Fatalf("expected single supported N cycle, got %+v", cs)
+		}
+		if !hasINFO(ws) {
+			t.Fatal("expected INFO warning for 0 tags")
+		}
+	})
+
+	t.Run("<4 minors => only existing", func(t *testing.T) {
+		cs, _ := resolveWindow("3.0.0", tagVers(t, "3.0.0", "2.9.0"))
+		got := cyclePairs(cs)
+		want := [][3]string{
+			{"3.0", "3.0.0", "true"},
+			{"2.9", "2.9.0", "true"},
+		}
+		assertCycles(t, got, want)
+	})
+
+	t.Run("pre-release tag is ignored, does not create a cycle", func(t *testing.T) {
+		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.6.0-beta.11", "8.6.0", "8.5.0"))
+		for _, c := range cs {
+			if c.Cycle == "8.6" && c.Latest != "8.6.0" {
+				t.Fatalf("pre-release leaked into cycle: %+v", c)
+			}
+		}
+		if len(cs) != 2 {
+			t.Fatalf("expected 2 cycles (8.6, 8.5), got %d: %+v", len(cs), cs)
+		}
+	})
+
+	t.Run("higher tag than N is dropped (never exceeds N)", func(t *testing.T) {
+		// A tag 8.7.0 exists but Chart.yaml says N=8.6.0: 8.7 must NOT appear.
+		cs, _ := resolveWindow("8.6.0", tagVers(t, "8.7.0", "8.6.0", "8.5.0"))
+		for _, c := range cs {
+			if c.Cycle == "8.7" {
+				t.Fatalf("cycle above N leaked in: %+v", cs)
+			}
+		}
+		if cs[0].Cycle != "8.6" {
+			t.Fatalf("top cycle should be N=8.6, got %q", cs[0].Cycle)
+		}
+	})
+}
+
+func assertCycles(t *testing.T, got []struct {
+	cycle     string
+	latest    string
+	supported bool
+}, want [][3]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d cycles, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		sup := w[2] == "true"
+		if got[i].cycle != w[0] || got[i].latest != w[1] || got[i].supported != sup {
+			t.Errorf("cycle %d: got {%s %s %v}, want {%s %s %v}",
+				i, got[i].cycle, got[i].latest, got[i].supported, w[0], w[1], sup)
+		}
+	}
+}
+
+func hasINFO(ws []Warning) bool {
+	for _, w := range ws {
+		if w.Severity == SevInfo {
+			return true
+		}
+	}
+	return false
+}
+
+func assertNoINFO(t *testing.T, ws []Warning) {
+	t.Helper()
+	if hasINFO(ws) {
+		t.Errorf("unexpected INFO: %+v", ws)
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | head -8
+```
+Saída esperada: `undefined: resolveWindow` e `[build failed]`.
+
+### Passo 2 (GREEN) — Implementar resolveWindow em window.go
+Adicione ao final de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/window.go`:
+```go
+// supportedWindowSize is the number of most-recent minor cycles that are marked
+// supported (N..N-3). Cycles below that are supported=false.
+const supportedWindowSize = 4
+
+// resolveWindow builds the ordered support-window cycles for one chart.
+//
+// N = chartVersion (from Chart.yaml) is authoritative: its cycle is always
+// present and supported, even when no matching tag exists (ADR-3, NFR-3). Tag
+// history supplies N-1..N-3. Cycles strictly above N are discarded (a stray
+// higher tag must never exceed the declared current version). The top
+// supportedWindowSize distinct minors are supported=true; the rest false.
+//
+// Degradation (FR-7): 0 tags => only the N cycle (+ an INFO); <4 minors => only
+// those that exist.
+func resolveWindow(chartVersion string, tagVersions []*semver.Version) ([]Cycle, []Warning) {
+	var warnings []Warning
+
+	nVer, err := semver.NewVersion(chartVersion)
+	if err != nil {
+		// Chart.yaml version is unparseable: emit WARN, produce no cycles.
+		warnings = append(warnings, Warning{SevWarn, chartVersion, "N", fmt.Sprintf("Chart.yaml version %q is not valid semver", chartVersion)})
+		return nil, warnings
+	}
+	nKey := minorKey(nVer)
+
+	// Group stable tag versions by minor cycle.
+	byMinor := groupByMinor(segregateStable(tagVersions))
+
+	// Force the N cycle to exist, sourced from Chart.yaml (authority). If a tag
+	// for the N cycle also exists, keep the greater of the two as latest.
+	if existing, ok := byMinor[nKey]; !ok || nVer.GreaterThan(existing) {
+		byMinor[nKey] = nVer
+	}
+
+	// Collect the "latest" version of each minor, drop any cycle above N, then
+	// sort descending by that latest version.
+	latests := make([]*semver.Version, 0, len(byMinor))
+	for _, v := range byMinor {
+		if v.GreaterThan(nVer) {
+			continue // never exceed N
+		}
+		latests = append(latests, v)
+	}
+	// Descending sort.
+	sortVersionsDesc(latests)
+
+	cycles := make([]Cycle, 0, len(latests))
+	for i, v := range latests {
+		cycles = append(cycles, Cycle{
+			Cycle:     minorKey(v),
+			Latest:    v.String(),
+			Supported: i < supportedWindowSize,
+		})
+	}
+
+	if len(tagVersions) == 0 {
+		warnings = append(warnings, Warning{SevInfo, chartVersion, "N", "no published tags; window = only N (Chart.yaml)"})
+	}
+
+	return cycles, warnings
+}
+
+// sortVersionsDesc sorts in place, greatest first, using Masterminds ordering.
+func sortVersionsDesc(vs []*semver.Version) {
+	coll := semver.Collection(vs)
+	// semver.Collection sorts ascending; reverse after.
+	for i, j := 0, len(coll)-1; i < j; i, j = i+1, j-1 {
+		coll[i], coll[j] = coll[j], coll[i]
+	}
+	// The swap above only reverses; we must sort first. Do a proper sort:
+	sortSemverDesc(vs)
+}
+
+// sortSemverDesc performs a stable descending sort of semver versions.
+func sortSemverDesc(vs []*semver.Version) {
+	// insertion via sort.Slice on the underlying slice
+	// (kept explicit to avoid an extra import churn)
+	for i := 1; i < len(vs); i++ {
+		for j := i; j > 0 && vs[j].GreaterThan(vs[j-1]); j-- {
+			vs[j], vs[j-1] = vs[j-1], vs[j]
+		}
+	}
+}
+```
+
+> **Nota de simplificação (aplicar no REFACTOR, ST-3-2/3 review):** `sortVersionsDesc` acima contém um reverse redundante antes de `sortSemverDesc`. Simplifique para chamar apenas `sortSemverDesc(vs)` no corpo de `resolveWindow` e apague `sortVersionsDesc`. Deixado aqui só para o GREEN inicial passar de forma óbvia; o REFACTOR abaixo remove.
+
+### Passo 3 (REFACTOR) — Simplificar a ordenação
+Substitua, em `resolveWindow`, a chamada `sortVersionsDesc(latests)` por `sortSemverDesc(latests)` e APAGUE a função `sortVersionsDesc` inteira. Rode o teste de novo (Passo 4) para confirmar que continua verde.
+
+### Passo 4 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-3_OK"
+```
+Saída esperada: termina com `ST-3-3_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/resolve_test.go
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/window.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-4-wire-window-into-buildDoc-golden-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-4-wire-window-into-buildDoc-golden-tdd.md
@@ -7,20 +7,20 @@ Injetar um `tagLister` no `buildDoc`, resolver a janela por produto e preencher 
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-3-3.)
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (`buildDoc` recebe `tagLister`)
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/builddoc_test.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/golden_two_products.json`
+- modify: `./.github/scripts/generate-compatibility/main.go` (`buildDoc` recebe `tagLister`)
+- create: `./.github/scripts/generate-compatibility/builddoc_test.go`
+- create: `./.github/scripts/generate-compatibility/testdata/golden_two_products.json`
 
 ## Steps
 
 ### Passo 1 (RED) — Golden test com fixture lister
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/builddoc_test.go`:
+Crie `./.github/scripts/generate-compatibility/builddoc_test.go`:
 ```go
 package main
 
@@ -100,12 +100,12 @@ annotations:
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | head -8
 ```
 Saída esperada: `too many arguments in call to buildDoc` (a assinatura ainda é `buildDoc(root)`), `[build failed]`.
 
 ### Passo 2 (GREEN) — `buildDoc` recebe `tagLister` e preenche cycles
-Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`:
+Em `./.github/scripts/generate-compatibility/main.go`:
 
 Atualize a chamada em `main()` para construir o lister real e passá-lo:
 ```go
@@ -174,31 +174,31 @@ func tagChart(name string, ws []Warning) []Warning {
 
 ### Passo 3 (GREEN) — Gerar o golden
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && mkdir -p generate-compatibility/testdata && UPDATE_GOLDEN=1 go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && mkdir -p generate-compatibility/testdata && UPDATE_GOLDEN=1 go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...` (o golden foi escrito).
 
 ### Passo 4 — Inspecionar e sanity-check do golden
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && cat generate-compatibility/testdata/golden_two_products.json
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && cat generate-compatibility/testdata/golden_two_products.json
 ```
 Saída esperada (verifique os pontos-chave): `midaz-helm` com 5 cycles (8.6..8.2, sendo 8.2 `"supported": false`, sem `8.6.0-beta.11` como ciclo); `plugin-fees-helm` com 1 cycle `7.2` carregando `requires` e `testedWith`. Confira que `midaz-helm` aparece ANTES de `plugin-fees-helm` (ordenação de chaves).
 
 ### Passo 5 — Rodar o golden test SEM UPDATE (deve passar do disco)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-4_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-4_OK"
 ```
 Saída esperada: termina com `ST-3-4_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/builddoc_test.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/golden_two_products.json
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/builddoc_test.go \
+      ./.github/scripts/generate-compatibility/testdata/golden_two_products.json
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/main.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-4-wire-window-into-buildDoc-golden-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-4-wire-window-into-buildDoc-golden-tdd.md
@@ -1,0 +1,204 @@
+# ST-3-4 — Ligar `resolveWindow` no `buildDoc` + golden test do JSON com cycles (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Injetar um `tagLister` no `buildDoc`, resolver a janela por produto e preencher `Product.Cycles`. Validar com um GOLDEN test que usa um `tagLister` de fixture (sem git real) e um repo temporário — prova o pipeline C-1→C-2→C-3b ponta a ponta de forma determinística e offline.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestResolveWindow 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-3-3.)
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (`buildDoc` recebe `tagLister`)
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/builddoc_test.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/golden_two_products.json`
+
+## Steps
+
+### Passo 1 (RED) — Golden test com fixture lister
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/builddoc_test.go`:
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeTagLister returns canned tags per dir.
+type fakeTagLister struct {
+	tags map[string][]string
+}
+
+func (f fakeTagLister) listTags(dir string) ([]string, error) {
+	return f.tags[dir], nil
+}
+
+func TestBuildDoc_Golden(t *testing.T) {
+	root := t.TempDir()
+
+	// midaz: N=8.6.0, tags cover 8.6..8.2.
+	writeChart(t, root, "midaz", `apiVersion: v2
+name: midaz-helm
+type: application
+version: 8.6.0
+appVersion: "3.7.8"
+`)
+	// plugin-fees: N=7.2.0, only its own tag; declares requires+testedWith.
+	writeChart(t, root, "plugin-fees", `apiVersion: v2
+name: plugin-fees-helm
+type: application
+version: 7.2.0
+appVersion: "3.3.0"
+annotations:
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: ">=8.4.0 <9.0.0"
+    testedWith:
+      midaz-helm: "8.6.0"
+`)
+
+	lister := fakeTagLister{tags: map[string][]string{
+		"midaz": {
+			"midaz-v8.6.0", "midaz-v8.5.0", "midaz-v8.4.0",
+			"midaz-v8.3.0", "midaz-v8.2.0", "midaz-v8.6.0-beta.11",
+		},
+		"plugin-fees": {"plugin-fees-v7.2.0"},
+	}}
+
+	doc, err := buildDoc(root, lister)
+	if err != nil {
+		t.Fatalf("buildDoc: %v", err)
+	}
+	doc.GeneratedFrom = "test" // pin the provenance field for a stable golden
+
+	got, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "golden_two_products.json")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("update golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (run with UPDATE_GOLDEN=1 first): %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("JSON mismatch.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | head -8
+```
+Saída esperada: `too many arguments in call to buildDoc` (a assinatura ainda é `buildDoc(root)`), `[build failed]`.
+
+### Passo 2 (GREEN) — `buildDoc` recebe `tagLister` e preenche cycles
+Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`:
+
+Atualize a chamada em `main()` para construir o lister real e passá-lo:
+```go
+	doc, err := buildDoc(*root, gitTagLister{root: *root})
+```
+
+Substitua a assinatura e o segundo passo de `buildDoc`. A primeira metade (leitura de states + knownProducts) permanece; troque só a assinatura e o loop final:
+
+Assinatura:
+```go
+func buildDoc(root string, lister tagLister) (CompatDoc, error) {
+```
+
+Segundo passo (loop final) — substitua por:
+```go
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "local",
+		Products:      map[string]Product{},
+	}
+	for _, state := range states {
+		emitWarnings(os.Stderr, validateCompat(state.Name, state.Compat, knownProducts))
+
+		rawTags, err := lister.listTags(state.Dir)
+		if err != nil {
+			// A tag-listing failure degrades to "no tags" (window = only N),
+			// never an abort (ADR-3): N is authoritative.
+			fmt.Fprintf(os.Stderr, "WARN %s: cannot list tags — %v\n", state.Dir, err)
+			rawTags = nil
+		}
+		tagVers := parseTags(state.Dir, rawTags)
+
+		cycles, ws := resolveWindow(state.Version, tagVers)
+		emitWarnings(os.Stderr, tagChart(state.Name, ws))
+
+		// Attach declared requires/testedWith to the N cycle (index 0), the only
+		// cycle whose cross-compatibility we know from the current Chart.yaml.
+		if len(cycles) > 0 && state.Compat != nil {
+			if len(state.Compat.Requires) > 0 {
+				cycles[0].Requires = state.Compat.Requires
+			}
+			if len(state.Compat.TestedWith) > 0 {
+				cycles[0].TestedWith = state.Compat.TestedWith
+			}
+		}
+
+		doc.Products[state.Name] = Product{
+			Dir:     state.Dir,
+			Current: state.Version,
+			Cycles:  cycles,
+		}
+	}
+
+	return doc, nil
+}
+
+// tagChart rewrites the Chart field of window warnings (which carry the raw
+// version string) to the product name, for a consistent WARN/INFO contract.
+func tagChart(name string, ws []Warning) []Warning {
+	for i := range ws {
+		ws[i].Chart = name
+	}
+	return ws
+}
+```
+
+### Passo 3 (GREEN) — Gerar o golden
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && mkdir -p generate-compatibility/testdata && UPDATE_GOLDEN=1 go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -3
+```
+Saída esperada: `ok  ...` (o golden foi escrito).
+
+### Passo 4 — Inspecionar e sanity-check do golden
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && cat generate-compatibility/testdata/golden_two_products.json
+```
+Saída esperada (verifique os pontos-chave): `midaz-helm` com 5 cycles (8.6..8.2, sendo 8.2 `"supported": false`, sem `8.6.0-beta.11` como ciclo); `plugin-fees-helm` com 1 cycle `7.2` carregando `requires` e `testedWith`. Confira que `midaz-helm` aparece ANTES de `plugin-fees-helm` (ordenação de chaves).
+
+### Passo 5 — Rodar o golden test SEM UPDATE (deve passar do disco)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-3-4_OK"
+```
+Saída esperada: termina com `ST-3-4_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/builddoc_test.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/golden_two_products.json
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-5-verify-window-against-real-repo.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-5-verify-window-against-real-repo.md
@@ -7,14 +7,14 @@ Prova executiva (TRD §10 passo 2, parcial): rodar o gerador contra o repo REAL 
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-3-4.)
 
 Confirme que as tags git existem no checkout (o CI usa `fetch-depth: 0`; localmente pode faltar histórico):
 ```bash
-cd /home/gauchito/lerian/helm && git tag --list 'midaz-v*' | wc -l
+cd "$(git rev-parse --show-toplevel)" && git tag --list 'midaz-v*' | wc -l
 ```
 Saída esperada: um número `> 0`. Se for `0`, rode `git fetch --tags --force` antes de prosseguir (a janela N-1..N-3 depende das tags; N ainda vem do Chart.yaml).
 
@@ -25,45 +25,45 @@ Saída esperada: um número `> 0`. Se for `0`, rode `git fetch --tags --force` a
 
 ### Passo 1 — Gerar contra o repo real, saída em /tmp
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-real.json 2> /tmp/compat-real.stderr; echo "exit=$?"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output docs/compat-verify.json 2> /tmp/compat-real.stderr; echo "exit=$?"
 ```
 Saída esperada: `exit=0` (nunca ≠0 por dado ausente).
 
 ### Passo 2 — Conferir que N do midaz vem do Chart.yaml (autoridade)
 ```bash
-cd /home/gauchito/lerian/helm && echo "Chart.yaml version:" && grep '^version:' charts/midaz/Chart.yaml && echo "JSON current:" && grep -A2 '"midaz-helm"' /tmp/compat-real.json | grep current
+cd "$(git rev-parse --show-toplevel)" && echo "Chart.yaml version:" && grep '^version:' charts/midaz/Chart.yaml && echo "JSON current:" && grep -A2 '"midaz-helm"' docs/compat-verify.json | grep current
 ```
 Saída esperada: o `current` no JSON é IDÊNTICO ao `version:` do `charts/midaz/Chart.yaml` (ex.: ambos `8.6.0`), independentemente das tags.
 
 ### Passo 3 — Conferir degradação de um chart sem tags (br-spi)
 ```bash
-cd /home/gauchito/lerian/helm && git tag --list 'br-spi-v*' | wc -l && echo "--- INFO esperado no stderr ---" && grep 'br-spi' /tmp/compat-real.stderr
+cd "$(git rev-parse --show-toplevel)" && git tag --list 'br-spi-v*' | wc -l && echo "--- INFO esperado no stderr ---" && grep 'br-spi' /tmp/compat-real.stderr
 ```
 Saída esperada: contagem de tags `0` e uma linha `INFO br-spi-...: N — no published tags; window = only N (Chart.yaml)`. No JSON, `br-spi-*` deve ter apenas 1 cycle.
 
 ### Passo 4 — Determinismo contra repo real (2×)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && \
-  go run ./generate-compatibility --root ../.. --output /tmp/compat-real-a.json 2>/dev/null && \
-  go run ./generate-compatibility --root ../.. --output /tmp/compat-real-b.json 2>/dev/null && \
-  diff /tmp/compat-real-a.json /tmp/compat-real-b.json && echo "DETERMINISTIC_REAL_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && \
+  go run ./generate-compatibility --root ../.. --output docs/compat-verify-a.json 2>/dev/null && \
+  go run ./generate-compatibility --root ../.. --output docs/compat-verify-b.json 2>/dev/null && \
+  diff docs/compat-verify-a.json docs/compat-verify-b.json && echo "DETERMINISTIC_REAL_OK"
 ```
 Saída esperada: `DETERMINISTIC_REAL_OK` (sem diff).
 
 ### Passo 5 — Garantir que o repo NÃO foi alterado
 ```bash
-cd /home/gauchito/lerian/helm && git status --porcelain docs/compatibility.json charts/ README.md
+cd "$(git rev-parse --show-toplevel)" && git status --porcelain docs/compatibility.json charts/ README.md
 ```
 Saída esperada: VAZIA (nenhuma linha). Se algo aparecer, você escreveu no repo por engano — reverta com `git checkout <arquivo>`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && test -s /tmp/compat-real.json && grep -q '"schemaVersion": 1' /tmp/compat-real.json && echo "ST-3-5_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && test -s docs/compat-verify.json && grep -q '"schemaVersion": 1' docs/compat-verify.json && echo "ST-3-5_OK"
 ```
 Saída esperada: `ST-3-5_OK`.
 
 ## Rollback
 Nada a reverter (só escreveu em /tmp). Opcional:
 ```bash
-rm -f /tmp/compat-real*.json /tmp/compat-real.stderr
+rm -f docs/compat-verify*.json /tmp/compat-real.stderr
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-5-verify-window-against-real-repo.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-3/ST-3-5-verify-window-against-real-repo.md
@@ -1,0 +1,69 @@
+# ST-3-5 — Validar a janela contra o repo real (clone descartável, sem escrever no repo)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Prova executiva (TRD §10 passo 2, parcial): rodar o gerador contra o repo REAL num diretório de saída em /tmp e conferir que a janela de suporte bate com a realidade (ex.: midaz N vindo do Chart.yaml; degradação para charts sem tags como `br-spi`). NÃO escreve no repo. Não toca README ainda (isso é T-5).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-3-4.)
+
+Confirme que as tags git existem no checkout (o CI usa `fetch-depth: 0`; localmente pode faltar histórico):
+```bash
+cd /home/gauchito/lerian/helm && git tag --list 'midaz-v*' | wc -l
+```
+Saída esperada: um número `> 0`. Se for `0`, rode `git fetch --tags --force` antes de prosseguir (a janela N-1..N-3 depende das tags; N ainda vem do Chart.yaml).
+
+## Files
+- (nenhum arquivo do repo é modificado; saída vai para /tmp)
+
+## Steps
+
+### Passo 1 — Gerar contra o repo real, saída em /tmp
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-real.json 2> /tmp/compat-real.stderr; echo "exit=$?"
+```
+Saída esperada: `exit=0` (nunca ≠0 por dado ausente).
+
+### Passo 2 — Conferir que N do midaz vem do Chart.yaml (autoridade)
+```bash
+cd /home/gauchito/lerian/helm && echo "Chart.yaml version:" && grep '^version:' charts/midaz/Chart.yaml && echo "JSON current:" && grep -A2 '"midaz-helm"' /tmp/compat-real.json | grep current
+```
+Saída esperada: o `current` no JSON é IDÊNTICO ao `version:` do `charts/midaz/Chart.yaml` (ex.: ambos `8.6.0`), independentemente das tags.
+
+### Passo 3 — Conferir degradação de um chart sem tags (br-spi)
+```bash
+cd /home/gauchito/lerian/helm && git tag --list 'br-spi-v*' | wc -l && echo "--- INFO esperado no stderr ---" && grep 'br-spi' /tmp/compat-real.stderr
+```
+Saída esperada: contagem de tags `0` e uma linha `INFO br-spi-...: N — no published tags; window = only N (Chart.yaml)`. No JSON, `br-spi-*` deve ter apenas 1 cycle.
+
+### Passo 4 — Determinismo contra repo real (2×)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && \
+  go run ./generate-compatibility --root ../.. --output /tmp/compat-real-a.json 2>/dev/null && \
+  go run ./generate-compatibility --root ../.. --output /tmp/compat-real-b.json 2>/dev/null && \
+  diff /tmp/compat-real-a.json /tmp/compat-real-b.json && echo "DETERMINISTIC_REAL_OK"
+```
+Saída esperada: `DETERMINISTIC_REAL_OK` (sem diff).
+
+### Passo 5 — Garantir que o repo NÃO foi alterado
+```bash
+cd /home/gauchito/lerian/helm && git status --porcelain docs/compatibility.json charts/ README.md
+```
+Saída esperada: VAZIA (nenhuma linha). Se algo aparecer, você escreveu no repo por engano — reverta com `git checkout <arquivo>`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && test -s /tmp/compat-real.json && grep -q '"schemaVersion": 1' /tmp/compat-real.json && echo "ST-3-5_OK"
+```
+Saída esperada: `ST-3-5_OK`.
+
+## Rollback
+Nada a reverter (só escreveu em /tmp). Opcional:
+```bash
+rm -f /tmp/compat-real*.json /tmp/compat-real.stderr
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-1-assert-no-tier-and-schema-shape-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-1-assert-no-tier-and-schema-shape-tdd.md
@@ -7,18 +7,18 @@ Travar o contrato do `compatibility.json` com um teste: `schemaVersion:1`, `prod
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete T-3.)
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go` (novos casos)
+- modify: `./.github/scripts/generate-compatibility/json_test.go` (novos casos)
 
 ## Steps
 
 ### Passo 1 (RED) — Teste de contrato (no-tier + campos obrigatórios)
-Adicione ao final de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go`:
+Adicione ao final de `./.github/scripts/generate-compatibility/json_test.go`:
 ```go
 func TestRenderJSON_NoTierField(t *testing.T) {
 	doc := CompatDoc{
@@ -67,7 +67,7 @@ func TestRenderJSON_OmitsEmptyRequiresTestedWith(t *testing.T) {
 
 Rode:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestRenderJSON_NoTierField|TestRenderJSON_OmitsEmpty' 2>&1 | tail -6
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run 'TestRenderJSON_NoTierField|TestRenderJSON_OmitsEmpty' 2>&1 | tail -6
 ```
 Se PASSAR de primeira: o contrato já está correto (structs de T-1 não têm `tier` e usam `omitempty`). Registre o pass como confirmação. Se FALHAR: siga o Passo 2.
 
@@ -76,17 +76,17 @@ Se o teste falhou por conter `tier`, remova qualquer campo `Tier` das structs `C
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável) — grep no JSON real por `tier`
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-t4.json 2>/dev/null && ! grep -q '"tier"' /tmp/compat-t4.json && echo "NO_TIER_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output /tmp/compat-t4.json 2>/dev/null && ! grep -q '"tier"' /tmp/compat-t4.json && echo "NO_TIER_OK"
 ```
 Saída esperada: `NO_TIER_OK` (o grep NÃO encontra `tier`).
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/json_test.go 2>/dev/null || true
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/json_test.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-1-assert-no-tier-and-schema-shape-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-1-assert-no-tier-and-schema-shape-tdd.md
@@ -1,0 +1,92 @@
+# ST-4-1 — Garantir JSON sem `tier` e conforme data-model §B (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Travar o contrato do `compatibility.json` com um teste: `schemaVersion:1`, `products{dir,current,cycles[]}`, cada cycle com `cycle/latest/supported` e `requires?/testedWith?` — e ZERO ocorrência da chave `tier` (tier é apresentação, nunca vai no JSON — data-model §1). A serialização já existe (T-1/T-3); este passo é a asserção formal do contrato.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestBuildDoc_Golden 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete T-3.)
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go` (novos casos)
+
+## Steps
+
+### Passo 1 (RED) — Teste de contrato (no-tier + campos obrigatórios)
+Adicione ao final de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/json_test.go`:
+```go
+func TestRenderJSON_NoTierField(t *testing.T) {
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		GeneratedFrom: "test",
+		Products: map[string]Product{
+			"midaz-helm": {
+				Dir:     "midaz",
+				Current: "8.6.0",
+				Cycles: []Cycle{
+					{Cycle: "8.6", Latest: "8.6.0", Supported: true},
+					{Cycle: "8.2", Latest: "8.2.0", Supported: false},
+				},
+			},
+		},
+	}
+	out, err := renderJSON(doc)
+	if err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, `"tier"`) {
+		t.Fatalf("JSON must NOT contain a tier field (presentation-only)\n%s", s)
+	}
+	for _, must := range []string{`"cycle": "8.6"`, `"latest": "8.6.0"`, `"supported": true`, `"supported": false`} {
+		if !strings.Contains(s, must) {
+			t.Errorf("missing %q\n%s", must, s)
+		}
+	}
+}
+
+func TestRenderJSON_OmitsEmptyRequiresTestedWith(t *testing.T) {
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		Products: map[string]Product{
+			"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}}},
+		},
+	}
+	out, _ := renderJSON(doc)
+	s := string(out)
+	if strings.Contains(s, `"requires"`) || strings.Contains(s, `"testedWith"`) {
+		t.Fatalf("empty maps must be omitted (omitempty)\n%s", s)
+	}
+}
+```
+
+Rode:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestRenderJSON_NoTierField|TestRenderJSON_OmitsEmpty' 2>&1 | tail -6
+```
+Se PASSAR de primeira: o contrato já está correto (structs de T-1 não têm `tier` e usam `omitempty`). Registre o pass como confirmação. Se FALHAR: siga o Passo 2.
+
+### Passo 2 (GREEN, só se necessário) — Corrigir as structs
+Se o teste falhou por conter `tier`, remova qualquer campo `Tier` das structs `Cycle`/`Product` em `generate-compatibility/json.go`. Se falhou por não omitir mapas vazios, confirme que `Requires`/`TestedWith` têm a tag `json:"...,omitempty"`. Depois rode o Passo 3.
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável) — grep no JSON real por `tier`
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-t4.json 2>/dev/null && ! grep -q '"tier"' /tmp/compat-t4.json && echo "NO_TIER_OK"
+```
+Saída esperada: `NO_TIER_OK` (o grep NÃO encontra `tier`).
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/json_test.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-1-assert-no-tier-and-schema-shape-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-1-assert-no-tier-and-schema-shape-tdd.md
@@ -82,7 +82,7 @@ Saída esperada: `ok  ...`.
 
 ## Verification (copiável) — grep no JSON real por `tier`
 ```bash
-cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output /tmp/compat-t4.json 2>/dev/null && ! grep -q '"tier"' /tmp/compat-t4.json && echo "NO_TIER_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output docs/compat-t4.json 2>/dev/null && ! grep -q '"tier"' docs/compat-t4.json && echo "NO_TIER_OK"
 ```
 Saída esperada: `NO_TIER_OK` (o grep NÃO encontra `tier`).
 

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-2-write-output-flag-and-commit-json.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-2-write-output-flag-and-commit-json.md
@@ -1,0 +1,53 @@
+# ST-4-2 — `--output` gravável e `docs/compatibility.json` versionado (verificação)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Confirmar que `--output` (default `docs/compatibility.json`, relativo a `--root`) grava o artefato final e que ele é o entregável de máquina (US-5) — determinístico, sem `tier`, batendo com o schema do data-model §B.4. Gerar o `docs/compatibility.json` inicial do repo para commit.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-4-1.)
+
+## Files
+- create/modify: `/home/gauchito/lerian/helm/docs/compatibility.json` (artefato gerado)
+
+## Steps
+
+### Passo 1 — Gerar o artefato final no lugar canônico
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/tmp/t4-2.stderr; echo "exit=$?"
+```
+Saída esperada: `exit=0` e uma linha `wrote ../../docs/compatibility.json (N products)`.
+
+### Passo 2 — Conferir que o arquivo existe no caminho versionado
+```bash
+cd /home/gauchito/lerian/helm && test -f docs/compatibility.json && head -6 docs/compatibility.json
+```
+Saída esperada: as 6 primeiras linhas do JSON, começando por `{` e `"schemaVersion": 1`.
+
+### Passo 3 — `--output` alternativo funciona (grava onde mandado)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/alt-compat.json 2>/dev/null && test -f /tmp/alt-compat.json && echo "OUTPUT_FLAG_OK"
+```
+Saída esperada: `OUTPUT_FLAG_OK`.
+
+### Passo 4 — Idempotência: regerar não muda o arquivo versionado
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/dev/null && cd /home/gauchito/lerian/helm && git diff --stat docs/compatibility.json
+```
+Saída esperada após a PRIMEIRA geração já commitada: VAZIA (regerar = mesmo byte). Na primeiríssima criação, o `git status` mostrará o arquivo como novo (esperado — é o commit inicial do artefato).
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm && python3 -c "import json,sys; d=json.load(open('docs/compatibility.json')); assert d['schemaVersion']==1; assert 'products' in d; assert all('tier' not in c for p in d['products'].values() for c in p.get('cycles',[])); print('SCHEMA_OK', len(d['products']), 'products')"
+```
+Saída esperada: `SCHEMA_OK <N> products` (N ~= 21). O assert falha se aparecer `tier` em qualquer cycle.
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm && git checkout docs/compatibility.json 2>/dev/null || rm -f docs/compatibility.json
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-2-write-output-flag-and-commit-json.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-4/ST-4-2-write-output-flag-and-commit-json.md
@@ -7,47 +7,47 @@ Confirmar que `--output` (default `docs/compatibility.json`, relativo a `--root`
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-4-1.)
 
 ## Files
-- create/modify: `/home/gauchito/lerian/helm/docs/compatibility.json` (artefato gerado)
+- create/modify: `./docs/compatibility.json` (artefato gerado)
 
 ## Steps
 
 ### Passo 1 — Gerar o artefato final no lugar canônico
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/tmp/t4-2.stderr; echo "exit=$?"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/tmp/t4-2.stderr; echo "exit=$?"
 ```
 Saída esperada: `exit=0` e uma linha `wrote ../../docs/compatibility.json (N products)`.
 
 ### Passo 2 — Conferir que o arquivo existe no caminho versionado
 ```bash
-cd /home/gauchito/lerian/helm && test -f docs/compatibility.json && head -6 docs/compatibility.json
+cd "$(git rev-parse --show-toplevel)" && test -f docs/compatibility.json && head -6 docs/compatibility.json
 ```
 Saída esperada: as 6 primeiras linhas do JSON, começando por `{` e `"schemaVersion": 1`.
 
 ### Passo 3 — `--output` alternativo funciona (grava onde mandado)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/alt-compat.json 2>/dev/null && test -f /tmp/alt-compat.json && echo "OUTPUT_FLAG_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output /tmp/alt-compat.json 2>/dev/null && test -f /tmp/alt-compat.json && echo "OUTPUT_FLAG_OK"
 ```
 Saída esperada: `OUTPUT_FLAG_OK`.
 
 ### Passo 4 — Idempotência: regerar não muda o arquivo versionado
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/dev/null && cd /home/gauchito/lerian/helm && git diff --stat docs/compatibility.json
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/dev/null && cd "$(git rev-parse --show-toplevel)" && git diff --stat docs/compatibility.json
 ```
 Saída esperada após a PRIMEIRA geração já commitada: VAZIA (regerar = mesmo byte). Na primeiríssima criação, o `git status` mostrará o arquivo como novo (esperado — é o commit inicial do artefato).
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm && python3 -c "import json,sys; d=json.load(open('docs/compatibility.json')); assert d['schemaVersion']==1; assert 'products' in d; assert all('tier' not in c for p in d['products'].values() for c in p.get('cycles',[])); print('SCHEMA_OK', len(d['products']), 'products')"
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import json,sys; d=json.load(open('docs/compatibility.json')); assert d['schemaVersion']==1; assert 'products' in d; assert all('tier' not in c for p in d['products'].values() for c in p.get('cycles',[])); print('SCHEMA_OK', len(d['products']), 'products')"
 ```
 Saída esperada: `SCHEMA_OK <N> products` (N ~= 21). O assert falha se aparecer `tier` em qualquer cycle.
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm && git checkout docs/compatibility.json 2>/dev/null || rm -f docs/compatibility.json
+cd "$(git rev-parse --show-toplevel)" && git checkout docs/compatibility.json 2>/dev/null || rm -f docs/compatibility.json
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-1-render-compat-table-lines-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-1-render-compat-table-lines-tdd.md
@@ -1,0 +1,227 @@
+# ST-5-1 — Renderizar as linhas da tabela COMPAT com badges (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Função pura `renderCompatTable(product Product) []string`: recebe o `Product` (com cycles ordenados desc) e devolve as linhas markdown do bloco COMPAT — cabeçalho, separador e uma linha por cycle SUPORTADO com badge por posição (🟢N 🔵N-1 🟡N-2 🟠N-3), coluna "Requer &lt;produto&gt;" SÓ quando `requires` declarado no cycle, e os cycles EOL (`supported:false`) colapsados numa ÚNICA linha-resumo com 🔴. NÃO toca arquivos; só gera linhas. Reusa a estética de `tableutil.FormatTable` (separador `:---:`).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete T-3/T-4.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes table-driven do render
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme_test.go`:
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func joined(lines []string) string { return strings.Join(lines, "\n") }
+
+func TestRenderCompatTable(t *testing.T) {
+	t.Run("badges by position + EOL summary line", func(t *testing.T) {
+		p := Product{
+			Dir: "midaz", Current: "8.6.0",
+			Cycles: []Cycle{
+				{Cycle: "8.6", Latest: "8.6.0", Supported: true},
+				{Cycle: "8.5", Latest: "8.5.0", Supported: true},
+				{Cycle: "8.4", Latest: "8.4.0", Supported: true},
+				{Cycle: "8.3", Latest: "8.3.0", Supported: true},
+				{Cycle: "8.2", Latest: "8.2.0", Supported: false},
+			},
+		}
+		out := joined(renderCompatTable(p))
+		for _, must := range []string{
+			"| Version | Support |",
+			"| :---: | :---: |",
+			"🟢", "🔵", "🟡", "🟠", "🔴",
+			"`8.6.0`", "`8.5.0`", "`8.4.0`", "`8.3.0`",
+		} {
+			if !strings.Contains(out, must) {
+				t.Errorf("missing %q in:\n%s", must, out)
+			}
+		}
+		// The single EOL summary must NOT list each EOL patch; one 🔴 line only.
+		if strings.Count(out, "🔴") != 1 {
+			t.Errorf("expected exactly one EOL (🔴) summary line, got %d\n%s", strings.Count(out, "🔴"), out)
+		}
+	})
+
+	t.Run("requires adds a Requires column only when declared", func(t *testing.T) {
+		p := Product{
+			Dir: "plugin-fees", Current: "7.2.0",
+			Cycles: []Cycle{
+				{Cycle: "7.2", Latest: "7.2.0", Supported: true,
+					Requires: map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"}},
+			},
+		}
+		out := joined(renderCompatTable(p))
+		if !strings.Contains(out, "Requires midaz-helm") {
+			t.Errorf("expected Requires column header, got:\n%s", out)
+		}
+		if !strings.Contains(out, ">=8.4.0 <9.0.0") {
+			t.Errorf("expected requires range in cell, got:\n%s", out)
+		}
+	})
+
+	t.Run("no requires => no Requires column", func(t *testing.T) {
+		p := Product{
+			Dir: "matcher", Current: "3.0.0",
+			Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}},
+		}
+		out := joined(renderCompatTable(p))
+		if strings.Contains(out, "Requires") {
+			t.Errorf("did not expect Requires column, got:\n%s", out)
+		}
+	})
+
+	t.Run("all supported => no EOL line", func(t *testing.T) {
+		p := Product{
+			Dir: "x", Current: "3.0.0",
+			Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}},
+		}
+		out := joined(renderCompatTable(p))
+		if strings.Contains(out, "🔴") {
+			t.Errorf("did not expect EOL line, got:\n%s", out)
+		}
+	})
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | head -8
+```
+Saída esperada: `undefined: renderCompatTable` e `[build failed]`.
+
+### Passo 2 (GREEN) — Implementar render_readme.go
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme.go`:
+```go
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// positionBadge maps a supported cycle's position (0=N, 1=N-1, ...) to its
+// emoji badge (data-model §1). Positions >=4 are never supported here.
+var positionBadge = []string{"🟢", "🔵", "🟡", "🟠"}
+
+// eolBadge is the single summary badge for all end-of-life cycles.
+const eolBadge = "🔴"
+
+// requiresHeaderPrefix labels the optional cross-compat column.
+const requiresHeaderPrefix = "Requires"
+
+// renderCompatTable produces the markdown lines for one product's compatibility
+// block: a table whose supported cycles carry a position badge, an optional
+// "Requires <product>" column when any supported cycle declares requires, and a
+// single collapsed EOL summary row. Cycles must arrive ordered descending
+// (index 0 = N); this function does not re-sort them.
+func renderCompatTable(p Product) []string {
+	// Split supported vs EOL, preserving order.
+	var supported, eol []Cycle
+	for _, c := range p.Cycles {
+		if c.Supported {
+			supported = append(supported, c)
+		} else {
+			eol = append(eol, c)
+		}
+	}
+
+	// Determine whether any supported cycle declares requires, and collect the
+	// distinct target products (sorted for determinism) for the column.
+	requireTargets := map[string]bool{}
+	for _, c := range supported {
+		for target := range c.Requires {
+			requireTargets[target] = true
+		}
+	}
+	var targets []string
+	for target := range requireTargets {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	hasRequires := len(targets) > 0
+
+	// Header.
+	headers := []string{"Version", "Support"}
+	for _, tgt := range targets {
+		headers = append(headers, fmt.Sprintf("%s %s", requiresHeaderPrefix, tgt))
+	}
+
+	lines := []string{tableRow(headers), separator(len(headers))}
+
+	// Supported rows.
+	for i, c := range supported {
+		badge := eolBadge
+		if i < len(positionBadge) {
+			badge = positionBadge[i]
+		}
+		row := []string{"`" + c.Latest + "`", badge}
+		for _, tgt := range targets {
+			row = append(row, c.Requires[tgt]) // empty string if not declared for this cycle
+		}
+		lines = append(lines, tableRow(row))
+	}
+
+	// Single collapsed EOL summary line.
+	if len(eol) > 0 {
+		cycles := make([]string, 0, len(eol))
+		for _, c := range eol {
+			cycles = append(cycles, c.Cycle)
+		}
+		summary := []string{eolBadge + " EOL: " + strings.Join(cycles, ", "), "unsupported"}
+		for range targets {
+			summary = append(summary, "")
+		}
+		lines = append(lines, tableRow(summary))
+	}
+
+	return lines
+}
+
+func tableRow(cells []string) string {
+	return "| " + strings.Join(cells, " | ") + " |"
+}
+
+func separator(n int) string {
+	seps := make([]string, n)
+	for i := range seps {
+		seps[i] = ":---:"
+	}
+	return "| " + strings.Join(seps, " | ") + " |"
+}
+```
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-1_OK"
+```
+Saída esperada: termina com `ST-5-1_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme_test.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-1-render-compat-table-lines-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-1-render-compat-table-lines-tdd.md
@@ -3,7 +3,7 @@
 > **For Agents:** REQUIRED SUB-SKILL: executing-plans
 
 ## Goal
-Função pura `renderCompatTable(product Product) []string`: recebe o `Product` (com cycles ordenados desc) e devolve as linhas markdown do bloco COMPAT — cabeçalho, separador e uma linha por cycle SUPORTADO com badge por posição (🟢N 🔵N-1 🟡N-2 🟠N-3), coluna "Requer &lt;produto&gt;" SÓ quando `requires` declarado no cycle, e os cycles EOL (`supported:false`) colapsados numa ÚNICA linha-resumo com 🔴. NÃO toca arquivos; só gera linhas. Reusa a estética de `tableutil.FormatTable` (separador `:---:`).
+Função pura `renderCompatTable(product Product) []string`: recebe o `Product` (com cycles ordenados desc) e devolve as linhas markdown do bloco COMPAT — cabeçalho, separador e uma linha por cycle SUPORTADO com badge por posição (🟢N 🔵N-1 🟡N-2 🟠N-3), coluna "Requires &lt;produto&gt;" SÓ quando `requires` declarado no cycle, e os cycles EOL (`supported:false`) colapsados numa ÚNICA linha-resumo com 🔴. NÃO toca arquivos; só gera linhas. Reusa a estética de `tableutil.FormatTable` (separador `:---:`).
 
 ## Prerequisites
 ```bash

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-1-render-compat-table-lines-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-1-render-compat-table-lines-tdd.md
@@ -7,19 +7,19 @@ Função pura `renderCompatTable(product Product) []string`: recebe o `Product` 
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete T-3/T-4.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme_test.go`
+- create: `./.github/scripts/generate-compatibility/render_readme.go`
+- create: `./.github/scripts/generate-compatibility/render_readme_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes table-driven do render
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme_test.go`:
+Crie `./.github/scripts/generate-compatibility/render_readme_test.go`:
 ```go
 package main
 
@@ -102,12 +102,12 @@ func TestRenderCompatTable(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | head -8
 ```
 Saída esperada: `undefined: renderCompatTable` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Implementar render_readme.go
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme.go`:
+Crie `./.github/scripts/generate-compatibility/render_readme.go`:
 ```go
 package main
 
@@ -210,18 +210,18 @@ func separator(n int) string {
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-1_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-1_OK"
 ```
 Saída esperada: termina com `ST-5-1_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/render_readme_test.go
+rm -f ./.github/scripts/generate-compatibility/render_readme.go \
+      ./.github/scripts/generate-compatibility/render_readme_test.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-2-marker-block-replace-idempotent-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-2-marker-block-replace-idempotent-tdd.md
@@ -1,0 +1,185 @@
+# ST-5-2 — Substituir bloco entre markers, idempotente e confinado (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Função pura `replaceCompatBlock(lines []string, chart string, blockBody []string) ([]string, bool, error)` que reescreve APENAS o conteúdo entre `<!-- BEGIN COMPAT:<chart> -->` e `<!-- END COMPAT:<chart> -->`, preservando byte-a-byte tudo fora dos markers. Idempotente: rodar 2× = mesma saída. Se os markers não existirem, retorna `found=false` (a criação de seção é ST-5-4). Este é o núcleo da mitigação do risco #1 (corromper README).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-5-1.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes: substituição confinada + idempotência + boundary irregular
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers_test.go`:
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func lns(s string) []string  { return strings.Split(s, "\n") }
+func str(ls []string) string { return strings.Join(ls, "\n") }
+
+func TestReplaceCompatBlock(t *testing.T) {
+	t.Run("replaces only between markers, prose untouched", func(t *testing.T) {
+		doc := lns(`### Midaz Helm Chart
+
+Intro prose that must survive.
+
+<!-- BEGIN COMPAT:midaz-helm -->
+OLD CONTENT
+<!-- END COMPAT:midaz-helm -->
+
+-----------------
+
+### Next Chart`)
+		body := []string{"| Version | Support |", "| :---: | :---: |", "| ` + "`8.6.0`" + ` | 🟢 |"}
+		out, found, err := replaceCompatBlock(doc, "midaz-helm", body)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !found {
+			t.Fatal("expected found=true")
+		}
+		s := str(out)
+		if !strings.Contains(s, "Intro prose that must survive.") {
+			t.Error("prose above block was lost")
+		}
+		if !strings.Contains(s, "-----------------") {
+			t.Error("separator below block was lost")
+		}
+		if !strings.Contains(s, "### Next Chart") {
+			t.Error("next section header was lost")
+		}
+		if strings.Contains(s, "OLD CONTENT") {
+			t.Error("old content not replaced")
+		}
+		if !strings.Contains(s, "8.6.0") {
+			t.Error("new body not inserted")
+		}
+		// Markers themselves must be preserved exactly once each.
+		if strings.Count(s, "<!-- BEGIN COMPAT:midaz-helm -->") != 1 ||
+			strings.Count(s, "<!-- END COMPAT:midaz-helm -->") != 1 {
+			t.Errorf("markers duplicated/lost:\n%s", s)
+		}
+	})
+
+	t.Run("idempotent: applying twice yields identical output", func(t *testing.T) {
+		doc := lns(`<!-- BEGIN COMPAT:x -->
+whatever
+<!-- END COMPAT:x -->`)
+		body := []string{"NEW"}
+		once, _, _ := replaceCompatBlock(doc, "x", body)
+		twice, _, _ := replaceCompatBlock(once, "x", body)
+		if str(once) != str(twice) {
+			t.Fatalf("not idempotent:\n--once--\n%s\n--twice--\n%s", str(once), str(twice))
+		}
+	})
+
+	t.Run("markers absent => found=false, doc unchanged", func(t *testing.T) {
+		doc := lns("### Some Chart\n\nno markers here")
+		out, found, err := replaceCompatBlock(doc, "some-chart", []string{"BODY"})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if found {
+			t.Fatal("expected found=false")
+		}
+		if str(out) != str(doc) {
+			t.Fatal("doc changed despite absent markers")
+		}
+	})
+
+	t.Run("only END marker => error (malformed)", func(t *testing.T) {
+		doc := lns("<!-- END COMPAT:x -->")
+		_, _, err := replaceCompatBlock(doc, "x", []string{"B"})
+		if err == nil {
+			t.Fatal("expected error for END-without-BEGIN")
+		}
+	})
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReplaceCompatBlock 2>&1 | head -8
+```
+Saída esperada: `undefined: replaceCompatBlock` e `[build failed]`.
+
+### Passo 2 (GREEN) — Implementar markers.go
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go`:
+```go
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// beginMarker / endMarker build the HTML-comment sentinels for a chart's block.
+// Only content strictly between them is ever rewritten (terraform-docs pattern),
+// which keeps hand-written prose and irregular separators intact.
+func beginMarker(chart string) string { return "<!-- BEGIN COMPAT:" + chart + " -->" }
+func endMarker(chart string) string   { return "<!-- END COMPAT:" + chart + " -->" }
+
+// replaceCompatBlock replaces the lines between the BEGIN/END markers for the
+// given chart with blockBody, preserving everything outside the markers exactly.
+// Returns found=false (and the document unchanged) when the BEGIN marker is
+// absent, so the caller can decide to create a section instead. Returns an error
+// for a malformed document (END without BEGIN, or BEGIN without END).
+func replaceCompatBlock(lines []string, chart string, blockBody []string) ([]string, bool, error) {
+	begin, end := beginMarker(chart), endMarker(chart)
+
+	beginIdx, endIdx := -1, -1
+	for i, line := range lines {
+		switch strings.TrimSpace(line) {
+		case begin:
+			beginIdx = i
+		case end:
+			endIdx = i
+		}
+	}
+
+	if beginIdx == -1 && endIdx == -1 {
+		return lines, false, nil
+	}
+	if beginIdx == -1 || endIdx == -1 || endIdx < beginIdx {
+		return nil, false, fmt.Errorf("malformed COMPAT markers for %q (begin=%d end=%d)", chart, beginIdx, endIdx)
+	}
+
+	out := make([]string, 0, len(lines)-(endIdx-beginIdx)+len(blockBody)+2)
+	out = append(out, lines[:beginIdx+1]...) // keep everything up to & including BEGIN
+	out = append(out, blockBody...)          // fresh body
+	out = append(out, lines[endIdx:]...)     // END marker onward, unchanged
+	return out, true, nil
+}
+```
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReplaceCompatBlock 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-2_OK"
+```
+Saída esperada: termina com `ST-5-2_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers_test.go
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-2-marker-block-replace-idempotent-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-2-marker-block-replace-idempotent-tdd.md
@@ -7,19 +7,19 @@ Função pura `replaceCompatBlock(lines []string, chart string, blockBody []stri
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRenderCompatTable 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-5-1.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers_test.go`
+- create: `./.github/scripts/generate-compatibility/markers.go`
+- create: `./.github/scripts/generate-compatibility/markers_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes: substituição confinada + idempotência + boundary irregular
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers_test.go`:
+Crie `./.github/scripts/generate-compatibility/markers_test.go`:
 ```go
 package main
 
@@ -113,12 +113,12 @@ whatever
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReplaceCompatBlock 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestReplaceCompatBlock 2>&1 | head -8
 ```
 Saída esperada: `undefined: replaceCompatBlock` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Implementar markers.go
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go`:
+Crie `./.github/scripts/generate-compatibility/markers.go`:
 ```go
 package main
 
@@ -168,18 +168,18 @@ func replaceCompatBlock(lines []string, chart string, blockBody []string) ([]str
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestReplaceCompatBlock 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestReplaceCompatBlock 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-2_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-2_OK"
 ```
 Saída esperada: termina com `ST-5-2_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers_test.go
+rm -f ./.github/scripts/generate-compatibility/markers.go \
+      ./.github/scripts/generate-compatibility/markers_test.go
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-3-locate-section-via-tableutil-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-3-locate-section-via-tableutil-tdd.md
@@ -7,18 +7,18 @@ Função `sectionHeaderIndex(lines []string, chart string) int` que reusa a lóg
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go doc ./tableutil ParseTableForChart 2>&1 | head -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go doc ./tableutil ParseTableForChart 2>&1 | head -3
 ```
 Saída esperada: assinatura `func ParseTableForChart(lines []string, chartName string) (int, int, []string, []map[string]string)`.
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go` (add `sectionHeaderIndex` + import tableutil)
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/section_test.go`
+- modify: `./.github/scripts/generate-compatibility/markers.go` (add `sectionHeaderIndex` + import tableutil)
+- create: `./.github/scripts/generate-compatibility/section_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes de localização de seção
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/section_test.go`:
+Crie `./.github/scripts/generate-compatibility/section_test.go`:
 ```go
 package main
 
@@ -64,12 +64,12 @@ prose`, "\n")
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestSectionHeaderIndex 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestSectionHeaderIndex 2>&1 | head -8
 ```
 Saída esperada: `undefined: sectionHeaderIndex` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Implementar reusando a normalização do tableutil
-Adicione ao bloco de imports de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go`:
+Adicione ao bloco de imports de `./.github/scripts/generate-compatibility/markers.go`:
 ```go
 import (
 	"fmt"
@@ -114,23 +114,23 @@ var _ = tableutil.ParseTableForChart
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestSectionHeaderIndex 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestSectionHeaderIndex 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável) — bate com o README real
 ```bash
-cd /home/gauchito/lerian/helm && grep -n '^### Matcher' README.md | head -1
+cd "$(git rev-parse --show-toplevel)" && grep -n '^### Matcher' README.md | head -1
 ```
 Saída esperada: uma linha `160:### Matcher` (ou similar) — confirma que a seção existe e o matcher normalizado `matcher` casa.
 
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-3_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-3_OK"
 ```
 Saída esperada: termina com `ST-5-3_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/section_test.go
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/markers.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/section_test.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/markers.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-3-locate-section-via-tableutil-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-3-locate-section-via-tableutil-tdd.md
@@ -1,0 +1,136 @@
+# ST-5-3 — Localizar a seção do chart via `tableutil.ParseTableForChart` (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Função `sectionHeaderIndex(lines []string, chart string) int` que reusa a lógica de normalização de nome de `tableutil.ParseTableForChart` (`.github/scripts/tableutil/tableutil.go:71`) para achar a linha `### <Nome>` de um chart. Retorna -1 se não houver seção (caso `br-spi` → ADR-5, tratado em ST-5-4). Reusar a lib evita reimplementar o matching de nome e corromper o README. Como `ParseTableForChart` imprime em stdout e não expõe o índice do header isolado, encapsulamos a chamada e derivamos o header.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go doc ./tableutil ParseTableForChart 2>&1 | head -3
+```
+Saída esperada: assinatura `func ParseTableForChart(lines []string, chartName string) (int, int, []string, []map[string]string)`.
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go` (add `sectionHeaderIndex` + import tableutil)
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/section_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes de localização de seção
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/section_test.go`:
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSectionHeaderIndex(t *testing.T) {
+	doc := strings.Split(`# Charts
+
+### Midaz Helm Chart
+
+prose
+
+### Plugin Fees Helm Chart
+
+prose
+
+### Matcher
+
+prose`, "\n")
+
+	tests := []struct {
+		chart string
+		want  int // line index of the "### ..." header, -1 if absent
+	}{
+		{"midaz-helm", 2},
+		{"plugin-fees-helm", 6},
+		{"matcher-helm", 10}, // normalizes to "matcher", matches "### Matcher"
+		{"br-spi-helm", -1},  // no section (ADR-5)
+	}
+	for _, tt := range tests {
+		t.Run(tt.chart, func(t *testing.T) {
+			got := sectionHeaderIndex(doc, tt.chart)
+			if got != tt.want {
+				t.Errorf("chart %q: got index %d, want %d", tt.chart, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestSectionHeaderIndex 2>&1 | head -8
+```
+Saída esperada: `undefined: sectionHeaderIndex` e `[build failed]`.
+
+### Passo 2 (GREEN) — Implementar reusando a normalização do tableutil
+Adicione ao bloco de imports de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go`:
+```go
+import (
+	"fmt"
+	"strings"
+
+	"github.com/LerianStudio/helm/.github/scripts/tableutil"
+)
+```
+
+Adicione ao final de `markers.go`:
+```go
+// sectionHeaderIndex returns the line index of the "### <Name>" header for a
+// chart, or -1 if the chart has no section (e.g. br-spi — ADR-5). It reuses the
+// exact name-normalization contract of tableutil.ParseTableForChart so section
+// matching stays consistent with the sibling README tooling.
+//
+// tableutil.ParseTableForChart returns the section header line as its first
+// return value (tableStart is measured from the section header downward; when a
+// section exists it returns >=0). To get the header index without depending on
+// a table being present, we replicate only its normalization + header scan.
+func sectionHeaderIndex(lines []string, chart string) int {
+	// Same normalization as tableutil: strip -helm, hyphens -> spaces, lower.
+	normalized := strings.ToLower(strings.TrimSuffix(chart, "-helm"))
+	normalized = strings.ReplaceAll(normalized, "-", " ")
+
+	for i, line := range lines {
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "### ") && strings.Contains(lower, normalized) {
+			return i
+		}
+	}
+	return -1
+}
+
+// ensureTableutilLinked references tableutil so the import is used even before
+// the section-creation step (ST-5-4) calls it directly. Remove once ST-5-4
+// wires ParseTableForChart in for real.
+var _ = tableutil.ParseTableForChart
+```
+
+> **Nota (REFACTOR em ST-5-4):** o `var _ = tableutil.ParseTableForChart` é um placeholder para o import não ficar "unused" neste passo. ST-5-4 usa `tableutil` de verdade (ou remove o import se não precisar). NÃO deixe o placeholder no merge final.
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestSectionHeaderIndex 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável) — bate com o README real
+```bash
+cd /home/gauchito/lerian/helm && grep -n '^### Matcher' README.md | head -1
+```
+Saída esperada: uma linha `160:### Matcher` (ou similar) — confirma que a seção existe e o matcher normalizado `matcher` casa.
+
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-3_OK"
+```
+Saída esperada: termina com `ST-5-3_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/section_test.go
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/markers.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-4-ensure-block-create-section-adr5-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-4-ensure-block-create-section-adr5-tdd.md
@@ -1,0 +1,203 @@
+# ST-5-4 — `ensureCompatBlock`: injetar markers em seção existente OU criar seção mínima (ADR-5) (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Função `ensureCompatBlock(lines []string, chart string, blockBody []string) ([]string, error)` que:
+1. Se os markers já existem → delega a `replaceCompatBlock` (ST-5-2).
+2. Senão, se a seção `### <Nome>` existe → insere um par de markers + body logo APÓS o cabeçalho da seção (sem tocar a prosa/tabela existente abaixo).
+3. Senão (ADR-5, ex.: `br-spi`) → cria uma seção mínima (`### <Título>` + markers + body) no fim do documento, sem inventar dados fora dos markers.
+Idempotente nos 3 caminhos.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestReplaceCompatBlock|TestSectionHeaderIndex' 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-5-2 e ST-5-3.)
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go` (add `ensureCompatBlock` + `sectionTitle`; remover o placeholder `var _ = tableutil...` de ST-5-3)
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/ensure_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes dos 3 caminhos + idempotência
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/ensure_test.go`:
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnsureCompatBlock(t *testing.T) {
+	body := []string{"| Version | Support |", "| :---: | :---: |", "| `1.0.0` | 🟢 |"}
+
+	t.Run("existing markers => replace path", func(t *testing.T) {
+		doc := strings.Split("### X\n\n<!-- BEGIN COMPAT:x-helm -->\nOLD\n<!-- END COMPAT:x-helm -->", "\n")
+		out, err := ensureCompatBlock(doc, "x-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := strings.Join(out, "\n")
+		if strings.Contains(s, "OLD") || !strings.Contains(s, "1.0.0") {
+			t.Errorf("replace path failed:\n%s", s)
+		}
+	})
+
+	t.Run("section exists, no markers => inject after header, prose kept", func(t *testing.T) {
+		doc := strings.Split("### Matcher\n\nExisting prose.\n\n#### Application Version Mapping\n\n| Chart Version | Matcher Version |\n| :---: | :---: |\n| `3.0.0` | 1.0.0 |", "\n")
+		out, err := ensureCompatBlock(doc, "matcher-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := strings.Join(out, "\n")
+		if !strings.Contains(s, "Existing prose.") {
+			t.Error("prose lost")
+		}
+		if !strings.Contains(s, "| Chart Version | Matcher Version |") {
+			t.Error("existing table lost")
+		}
+		if !strings.Contains(s, "<!-- BEGIN COMPAT:matcher-helm -->") {
+			t.Error("markers not injected")
+		}
+		if !strings.Contains(s, "1.0.0") {
+			t.Error("body not injected")
+		}
+		// Injected block must sit right after the header, before existing prose.
+		beginIdx := indexOfLine(out, "<!-- BEGIN COMPAT:matcher-helm -->")
+		proseIdx := indexOfLine(out, "Existing prose.")
+		if beginIdx == -1 || proseIdx == -1 || beginIdx > proseIdx {
+			t.Errorf("block not placed after header/before prose (begin=%d prose=%d)", beginIdx, proseIdx)
+		}
+	})
+
+	t.Run("no section (ADR-5 br-spi) => create minimal section at end", func(t *testing.T) {
+		doc := strings.Split("# Charts\n\n### Midaz Helm Chart\n\nprose", "\n")
+		out, err := ensureCompatBlock(doc, "br-spi-helm", body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := strings.Join(out, "\n")
+		if !strings.Contains(s, "### Br Spi") {
+			t.Errorf("minimal section title not created:\n%s", s)
+		}
+		if !strings.Contains(s, "<!-- BEGIN COMPAT:br-spi-helm -->") {
+			t.Error("markers not created")
+		}
+		if !strings.Contains(s, "prose") || !strings.Contains(s, "### Midaz Helm Chart") {
+			t.Error("existing content disturbed")
+		}
+	})
+
+	t.Run("idempotent across all paths", func(t *testing.T) {
+		doc := strings.Split("# Charts\n\n### Midaz Helm Chart\n\nprose", "\n")
+		once, _ := ensureCompatBlock(doc, "br-spi-helm", body)
+		twice, _ := ensureCompatBlock(once, "br-spi-helm", body)
+		if strings.Join(once, "\n") != strings.Join(twice, "\n") {
+			t.Fatalf("not idempotent:\n--once--\n%s\n--twice--\n%s", strings.Join(once, "\n"), strings.Join(twice, "\n"))
+		}
+	})
+}
+
+func indexOfLine(lines []string, want string) int {
+	for i, l := range lines {
+		if strings.TrimSpace(l) == want {
+			return i
+		}
+	}
+	return -1
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestEnsureCompatBlock 2>&1 | head -8
+```
+Saída esperada: `undefined: ensureCompatBlock` e `[build failed]`.
+
+### Passo 2 (GREEN) — Implementar ensureCompatBlock em markers.go
+Primeiro, REMOVA o placeholder de ST-5-3 (a linha `var _ = tableutil.ParseTableForChart` e o comentário acima dela). Se `tableutil` ficar sem uso, remova-o do import de `markers.go` (deixe só `fmt` e `strings`). Confirme com `go build`.
+
+Adicione ao final de `markers.go`:
+```go
+// sectionTitle renders the human title used when a chart has no README section
+// (ADR-5): strip -helm, hyphens -> spaces, Title Case. e.g. "br-spi-helm" ->
+// "Br Spi". Mirrors the tableutil normalization, then title-cases for display.
+func sectionTitle(chart string) string {
+	base := strings.TrimSuffix(chart, "-helm")
+	words := strings.Split(strings.ReplaceAll(base, "-", " "), " ")
+	for i, w := range words {
+		if w == "" {
+			continue
+		}
+		words[i] = strings.ToUpper(w[:1]) + w[1:]
+	}
+	return strings.Join(words, " ")
+}
+
+// ensureCompatBlock guarantees the chart's COMPAT block reflects blockBody,
+// choosing one of three paths (all idempotent):
+//  1. markers already present  -> replace their contents (replaceCompatBlock);
+//  2. section header present, no markers -> inject markers+body just after it;
+//  3. no section (ADR-5)       -> append a minimal section (title + block) at
+//     end of document, without touching existing prose.
+func ensureCompatBlock(lines []string, chart string, blockBody []string) ([]string, error) {
+	// Path 1: markers exist -> replace.
+	replaced, found, err := replaceCompatBlock(lines, chart, blockBody)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return replaced, nil
+	}
+
+	block := wrapBlock(chart, blockBody)
+
+	// Path 2: section exists -> inject right after the header line.
+	if idx := sectionHeaderIndex(lines, chart); idx != -1 {
+		out := make([]string, 0, len(lines)+len(block)+1)
+		out = append(out, lines[:idx+1]...) // through the "### ..." header
+		out = append(out, "")               // blank line after header
+		out = append(out, block...)
+		out = append(out, lines[idx+1:]...)
+		return out, nil
+	}
+
+	// Path 3: no section -> minimal section at end (ADR-5).
+	out := make([]string, 0, len(lines)+len(block)+3)
+	out = append(out, lines...)
+	out = append(out, "", "### "+sectionTitle(chart), "")
+	out = append(out, block...)
+	return out, nil
+}
+
+// wrapBlock frames blockBody with the BEGIN/END markers for a chart.
+func wrapBlock(chart string, blockBody []string) []string {
+	out := make([]string, 0, len(blockBody)+2)
+	out = append(out, beginMarker(chart))
+	out = append(out, blockBody...)
+	out = append(out, endMarker(chart))
+	return out
+}
+```
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestEnsureCompatBlock 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-4_OK"
+```
+Saída esperada: termina com `ST-5-4_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/ensure_test.go
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/markers.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-4-ensure-block-create-section-adr5-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-4-ensure-block-create-section-adr5-tdd.md
@@ -11,19 +11,19 @@ Idempotente nos 3 caminhos.
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestReplaceCompatBlock|TestSectionHeaderIndex' 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run 'TestReplaceCompatBlock|TestSectionHeaderIndex' 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-5-2 e ST-5-3.)
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/markers.go` (add `ensureCompatBlock` + `sectionTitle`; remover o placeholder `var _ = tableutil...` de ST-5-3)
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/ensure_test.go`
+- modify: `./.github/scripts/generate-compatibility/markers.go` (add `ensureCompatBlock` + `sectionTitle`; remover o placeholder `var _ = tableutil...` de ST-5-3)
+- create: `./.github/scripts/generate-compatibility/ensure_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes dos 3 caminhos + idempotência
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/ensure_test.go`:
+Crie `./.github/scripts/generate-compatibility/ensure_test.go`:
 ```go
 package main
 
@@ -114,7 +114,7 @@ func indexOfLine(lines []string, want string) int {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestEnsureCompatBlock 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestEnsureCompatBlock 2>&1 | head -8
 ```
 Saída esperada: `undefined: ensureCompatBlock` e `[build failed]`.
 
@@ -186,18 +186,18 @@ func wrapBlock(chart string, blockBody []string) []string {
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestEnsureCompatBlock 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestEnsureCompatBlock 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-4_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-4_OK"
 ```
 Saída esperada: termina com `ST-5-4_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/ensure_test.go
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/markers.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/ensure_test.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/markers.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-5-wire-readme-write-into-main-golden-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-5-wire-readme-write-into-main-golden-tdd.md
@@ -7,22 +7,22 @@ Criar `writeReadme(root string, doc CompatDoc) error` que lê `<root>/README.md`
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestEnsureCompatBlock|TestRenderCompatTable' 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run 'TestEnsureCompatBlock|TestRenderCompatTable' 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-5-1..ST-5-4.)
 
 ## Files
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme_test.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md`
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (chamar `writeReadme`)
+- create: `./.github/scripts/generate-compatibility/write_readme.go`
+- create: `./.github/scripts/generate-compatibility/write_readme_test.go`
+- create: `./.github/scripts/generate-compatibility/testdata/readme_irregular_in.md`
+- create: `./.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md`
+- modify: `./.github/scripts/generate-compatibility/main.go` (chamar `writeReadme`)
 
 ## Steps
 
 ### Passo 1 — Criar a fixture de entrada com layouts irregulares
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md` com este conteúdo EXATO:
+Crie `./.github/scripts/generate-compatibility/testdata/readme_irregular_in.md` com este conteúdo EXATO:
 ```markdown
 # Charts
 
@@ -55,7 +55,7 @@ Flowker prose.
 (Note: Matcher NÃO tem `-----------------` após sua tabela — vai direto para `### Flowker`. Plugin Fees tem linha em branco antes do separador. Estes são os boundaries irregulares reais do README.)
 
 ### Passo 2 (RED) — Golden test
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme_test.go`:
+Crie `./.github/scripts/generate-compatibility/write_readme_test.go`:
 ```go
 package main
 
@@ -150,12 +150,12 @@ func TestWriteReadme_Idempotent(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestWriteReadme 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestWriteReadme 2>&1 | head -8
 ```
 Saída esperada: `undefined: writeReadme` e `[build failed]`.
 
 ### Passo 3 (GREEN) — Implementar write_readme.go
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme.go`:
+Crie `./.github/scripts/generate-compatibility/write_readme.go`:
 ```go
 package main
 
@@ -198,7 +198,7 @@ func writeReadme(root string, doc CompatDoc) error {
 ```
 
 ### Passo 4 (GREEN) — Chamar writeReadme em main()
-Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`, após escrever o JSON (`os.WriteFile(outPath, ...)`) e antes do `fmt.Printf` final, adicione:
+Em `./.github/scripts/generate-compatibility/main.go`, após escrever o JSON (`os.WriteFile(outPath, ...)`) e antes do `fmt.Printf` final, adicione:
 ```go
 	if err := writeReadme(*root, doc); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR write README.md: %v\n", err)
@@ -208,27 +208,27 @@ Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`, 
 
 ### Passo 5 (GREEN) — Gerar o golden e revisar
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && UPDATE_GOLDEN=1 go test ./generate-compatibility/ -run TestWriteReadme_IrregularLayoutsGolden 2>&1 | tail -3 && echo "--- GOLDEN ---" && cat generate-compatibility/testdata/readme_irregular_golden.md
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && UPDATE_GOLDEN=1 go test ./generate-compatibility/ -run TestWriteReadme_IrregularLayoutsGolden 2>&1 | tail -3 && echo "--- GOLDEN ---" && cat generate-compatibility/testdata/readme_irregular_golden.md
 ```
 Saída esperada: `ok ...` e o golden impresso. REVISE À MÃO: o `-----------------` do Plugin Fees deve continuar presente; a tabela `| Chart Version | Matcher Version |` intacta; blocos COMPAT injetados logo após cada `### <header>`; `### Flowker` intacto.
 
 ### Passo 6 — Rodar o golden SEM update + idempotência
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestWriteReadme 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestWriteReadme 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...` (golden bate do disco; idempotência verde).
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-5_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-5_OK"
 ```
 Saída esperada: termina com `ST-5-5_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme_test.go \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md \
-      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/write_readme.go \
+      ./.github/scripts/generate-compatibility/write_readme_test.go \
+      ./.github/scripts/generate-compatibility/testdata/readme_irregular_in.md \
+      ./.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/main.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-5-wire-readme-write-into-main-golden-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-5-wire-readme-write-into-main-golden-tdd.md
@@ -1,0 +1,234 @@
+# ST-5-5 — Ligar a escrita do README no `main`/`buildDoc` + golden por layout irregular (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Criar `writeReadme(root string, doc CompatDoc) error` que lê `<root>/README.md`, para cada produto renderiza o body (ST-5-1) e aplica `ensureCompatBlock` (ST-5-4), e reescreve o arquivo UMA vez. Chamar em `main()` no modo write. Golden-test cobrindo os layouts irregulares reais: Matcher/BC Correios (sem separador final) e Plugin Fees/Plugin BR Pix Indirect BTG (linha em branco antes do `-----------------`), provando confinamento aos markers.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run 'TestEnsureCompatBlock|TestRenderCompatTable' 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-5-1..ST-5-4.)
+
+## Files
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme_test.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md`
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (chamar `writeReadme`)
+
+## Steps
+
+### Passo 1 — Criar a fixture de entrada com layouts irregulares
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md` com este conteúdo EXATO:
+```markdown
+# Charts
+
+### Plugin Fees Helm Chart
+
+Fees prose.
+
+#### Application Version Mapping
+
+| Chart Version | Fees Version | UI Version |
+| :---: | :---: | :---: |
+| `7.2.0` | 3.3.0 | `3.0.0` |
+
+-----------------
+
+### Matcher
+
+Matcher prose.
+
+#### Application Version Mapping
+
+| Chart Version | Matcher Version |
+| :---: | :---: |
+| `3.0.0` | 1.0.0 |
+
+### Flowker
+
+Flowker prose.
+```
+(Note: Matcher NÃO tem `-----------------` após sua tabela — vai direto para `### Flowker`. Plugin Fees tem linha em branco antes do separador. Estes são os boundaries irregulares reais do README.)
+
+### Passo 2 (RED) — Golden test
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme_test.go`:
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteReadme_IrregularLayoutsGolden(t *testing.T) {
+	in, err := os.ReadFile(filepath.Join("testdata", "readme_irregular_in.md"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	root := t.TempDir()
+	readmePath := filepath.Join(root, "README.md")
+	if err := os.WriteFile(readmePath, in, 0o644); err != nil {
+		t.Fatalf("seed README: %v", err)
+	}
+
+	doc := CompatDoc{
+		SchemaVersion: 1,
+		Products: map[string]Product{
+			"plugin-fees-helm": {Dir: "plugin-fees", Current: "7.2.0", Cycles: []Cycle{
+				{Cycle: "7.2", Latest: "7.2.0", Supported: true,
+					Requires: map[string]string{"midaz-helm": ">=8.4.0 <9.0.0"}},
+			}},
+			"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{
+				{Cycle: "3.0", Latest: "3.0.0", Supported: true},
+			}},
+		},
+	}
+
+	if err := writeReadme(root, doc); err != nil {
+		t.Fatalf("writeReadme: %v", err)
+	}
+
+	got, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "readme_irregular_golden.md")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("update golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (run UPDATE_GOLDEN=1 first): %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("README mismatch.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+
+	// Structural invariants that must hold regardless of golden bytes:
+	s := string(got)
+	if !strings.Contains(s, "-----------------") {
+		t.Error("Plugin Fees separator was destroyed")
+	}
+	if !strings.Contains(s, "| Chart Version | Matcher Version |") {
+		t.Error("Matcher existing mapping table was destroyed")
+	}
+	if !strings.Contains(s, "### Flowker") {
+		t.Error("Flowker section header lost")
+	}
+}
+
+// TestWriteReadme_Idempotent proves running twice yields identical bytes.
+func TestWriteReadme_Idempotent(t *testing.T) {
+	in, _ := os.ReadFile(filepath.Join("testdata", "readme_irregular_in.md"))
+	root := t.TempDir()
+	readmePath := filepath.Join(root, "README.md")
+	_ = os.WriteFile(readmePath, in, 0o644)
+
+	doc := CompatDoc{SchemaVersion: 1, Products: map[string]Product{
+		"matcher-helm": {Dir: "matcher", Current: "3.0.0", Cycles: []Cycle{{Cycle: "3.0", Latest: "3.0.0", Supported: true}}},
+	}}
+
+	_ = writeReadme(root, doc)
+	first, _ := os.ReadFile(readmePath)
+	_ = writeReadme(root, doc)
+	second, _ := os.ReadFile(readmePath)
+	if string(first) != string(second) {
+		t.Fatalf("writeReadme not idempotent:\n--first--\n%s\n--second--\n%s", first, second)
+	}
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestWriteReadme 2>&1 | head -8
+```
+Saída esperada: `undefined: writeReadme` e `[build failed]`.
+
+### Passo 3 (GREEN) — Implementar write_readme.go
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme.go`:
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// writeReadme rewrites <root>/README.md so every product's COMPAT block matches
+// the document. Products are processed in sorted name order for deterministic
+// output. Only content between (or newly wrapped in) markers changes; prose,
+// existing tables and irregular separators are preserved (risk #1 mitigation).
+func writeReadme(root string, doc CompatDoc) error {
+	readmePath := filepath.Join(root, "README.md")
+	data, err := os.ReadFile(readmePath)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+
+	names := make([]string, 0, len(doc.Products))
+	for name := range doc.Products {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		body := renderCompatTable(doc.Products[name])
+		lines, err = ensureCompatBlock(lines, name, body)
+		if err != nil {
+			return err
+		}
+	}
+
+	out := strings.Join(lines, "\n")
+	return os.WriteFile(readmePath, []byte(out), 0o644)
+}
+```
+
+### Passo 4 (GREEN) — Chamar writeReadme em main()
+Em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`, após escrever o JSON (`os.WriteFile(outPath, ...)`) e antes do `fmt.Printf` final, adicione:
+```go
+	if err := writeReadme(*root, doc); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR write README.md: %v\n", err)
+		os.Exit(1)
+	}
+```
+
+### Passo 5 (GREEN) — Gerar o golden e revisar
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && UPDATE_GOLDEN=1 go test ./generate-compatibility/ -run TestWriteReadme_IrregularLayoutsGolden 2>&1 | tail -3 && echo "--- GOLDEN ---" && cat generate-compatibility/testdata/readme_irregular_golden.md
+```
+Saída esperada: `ok ...` e o golden impresso. REVISE À MÃO: o `-----------------` do Plugin Fees deve continuar presente; a tabela `| Chart Version | Matcher Version |` intacta; blocos COMPAT injetados logo após cada `### <header>`; `### Flowker` intacto.
+
+### Passo 6 — Rodar o golden SEM update + idempotência
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestWriteReadme 2>&1 | tail -3
+```
+Saída esperada: `ok  ...` (golden bate do disco; idempotência verde).
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-5-5_OK"
+```
+Saída esperada: termina com `ST-5-5_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/write_readme_test.go \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_in.md \
+      /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/testdata/readme_irregular_golden.md
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-6-dry-run-disposable-clone-diff-review.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-6-dry-run-disposable-clone-diff-review.md
@@ -1,0 +1,69 @@
+# ST-5-6 — Dry-run em CLONE DESCARTÁVEL: revisar `git diff` do README real (TRD §10 passo 2)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Prova executiva do risco #1 antes de qualquer commit: rodar o gerador contra um CLONE DESCARTÁVEL do repo e inspecionar o `git diff` do `README.md`. Confirmar: (a) só o conteúdo entre markers muda; (b) prosa e separadores irregulares intactos; (c) `br-spi` ganha seção (ADR-5); (d) 2× = diff idêntico (idempotência). NADA é commitado. NADA no repo principal é tocado.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-5-5.)
+
+## Files
+- (nenhum arquivo do repo principal é modificado; tudo acontece num clone em /tmp)
+
+## Steps
+
+### Passo 1 — Criar o clone descartável
+```bash
+rm -rf /tmp/helm-dryrun && git clone --local /home/gauchito/lerian/helm /tmp/helm-dryrun && cd /tmp/helm-dryrun && git fetch --tags --force origin 2>/dev/null; echo "clone_ready=$?"
+```
+Saída esperada: `clone_ready=0`. (O `--local` copia o repo; `git clone` local traz as tags. Se o remoto não estiver acessível, o fetch pode falhar sem problema — as tags locais já vieram no clone.)
+
+### Passo 2 — Rodar o gerador no clone (write real, MAS no clone)
+```bash
+cd /tmp/helm-dryrun/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2> /tmp/dryrun.stderr; echo "exit=$?"
+```
+Saída esperada: `exit=0`.
+
+### Passo 3 — Revisar o diff do README: só entre markers
+```bash
+cd /tmp/helm-dryrun && git diff --unified=1 README.md | head -80
+```
+Revisão MANUAL (critérios de aceite):
+- Toda linha adicionada/removida está DENTRO de um par `<!-- BEGIN COMPAT:... -->` / `<!-- END COMPAT:... -->`, OU é a criação de uma seção nova (só para `br-spi`, ADR-5).
+- NENHUMA linha de prosa existente aparece como removida/alterada.
+- Os separadores `-----------------` (Plugin Fees, Plugin BR Pix Indirect BTG etc.) permanecem — não aparecem como removidos.
+
+### Passo 4 — Confirmar seção do br-spi criada (ADR-5)
+```bash
+cd /tmp/helm-dryrun && grep -n 'COMPAT:br-spi-helm' README.md && grep -n '### Br Spi' README.md
+```
+Saída esperada: linhas mostrando os markers `BEGIN/END COMPAT:br-spi-helm` e um cabeçalho `### Br Spi` (a seção mínima nova). Antes, `br-spi` não tinha seção.
+
+### Passo 5 — Idempotência: rodar 2× e comparar
+```bash
+cd /tmp/helm-dryrun && cp README.md /tmp/readme-run1.md && cd .github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/dev/null && cd /tmp/helm-dryrun && diff /tmp/readme-run1.md README.md && echo "README_IDEMPOTENT_OK"
+```
+Saída esperada: `README_IDEMPOTENT_OK` (segunda execução não muda nada).
+
+### Passo 6 — Contar seções corrompidas (deve ser 0)
+```bash
+cd /tmp/helm-dryrun && echo "headers antes vs depois:" && git show HEAD:README.md | grep -c '^### ' && grep -c '^### ' README.md
+```
+Saída esperada: o número DEPOIS = número ANTES + 1 (a seção nova do `br-spi`). Nenhum header existente sumiu.
+
+## Verification (copiável)
+```bash
+cd /tmp/helm-dryrun && CHANGED=$(git diff README.md | grep -E '^[-+]' | grep -vE '^[-+]{3}' | grep -v 'COMPAT:' | grep -vE 'BEGIN COMPAT|END COMPAT' | grep -c '🟢\|🔵\|🟡\|🟠\|🔴\|Version\|:---:\|`\|### Br Spi\|^[-+]$'); echo "linhas de diff fora do padrão esperado (aprox): revisar manualmente se >0"; echo "DRYRUN_DONE"
+```
+Saída esperada: `DRYRUN_DONE`. A heurística é auxiliar; a ACEITAÇÃO REAL é a revisão manual do Passo 3.
+
+## Rollback
+```bash
+rm -rf /tmp/helm-dryrun /tmp/readme-run1.md /tmp/dryrun.stderr
+```
+(O repo principal nunca foi tocado.)

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-6-dry-run-disposable-clone-diff-review.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-5/ST-5-6-dry-run-disposable-clone-diff-review.md
@@ -7,7 +7,7 @@ Prova executiva do risco #1 antes de qualquer commit: rodar o gerador contra um 
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-5-5.)
@@ -19,7 +19,7 @@ Saída esperada: `ok  ...`
 
 ### Passo 1 — Criar o clone descartável
 ```bash
-rm -rf /tmp/helm-dryrun && git clone --local /home/gauchito/lerian/helm /tmp/helm-dryrun && cd /tmp/helm-dryrun && git fetch --tags --force origin 2>/dev/null; echo "clone_ready=$?"
+rm -rf /tmp/helm-dryrun && git clone --local . /tmp/helm-dryrun && cd /tmp/helm-dryrun && git fetch --tags --force origin 2>/dev/null; echo "clone_ready=$?"
 ```
 Saída esperada: `clone_ready=0`. (O `--local` copia o repo; `git clone` local traz as tags. Se o remoto não estiver acessível, o fetch pode falhar sem problema — as tags locais já vieram no clone.)
 

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
@@ -3,7 +3,7 @@
 > **For Agents:** REQUIRED SUB-SKILL: executing-plans
 
 ## Goal
-Refatorar o `main` para uma função testável `run(args []string, stdout, stderr io.Writer) int` que devolve o exit code, e adicionar as flags do contrato (api-design §II): `--write` (default), `--check`, `--chart`, `--root` (default `../..`), `--output` (default `docs/compatibility.json`). Exit codes: 2 se `--write`+`--check` juntos (uso); 1 se `--root` inexistente (ambiente); 0 caso contrário (inclui WARN). `main()` vira um wrapper fino.
+Refatorar o `main` para uma função testável `run(args []string, stdout, stderr io.Writer) int` que devolve o exit code, e adicionar as flags do contrato (api-design §II): `--write` (default), `--check`, `--chart`, `--root` (default `../..`), `--output` (default `docs/compatibility.json`). Exit codes: **2 (uso)** se `--write`+`--check` juntos OU `--chart` desconhecido (nada é escrito nesse caso); **1 (operacional)** se `--root` inexistente/README ilegível; **0** caso contrário (inclui WARN). `main()` vira um wrapper fino.
 
 ## Prerequisites
 ```bash
@@ -63,6 +63,24 @@ func TestRun_ExitCodes(t *testing.T) {
 		code := run([]string{"--root", "/no/such/dir/xyz"}, &out, &errb)
 		if code != 1 {
 			t.Fatalf("exit = %d, want 1. stderr=%s", code, errb.String())
+		}
+	})
+
+	t.Run("unknown --chart => exit 2, nothing written", func(t *testing.T) {
+		root := seedRepo(t)
+		readmeBefore, _ := os.ReadFile(filepath.Join(root, "README.md"))
+		var out, errb bytes.Buffer
+		code := run([]string{"--root", root, "--chart", "does-not-exist"}, &out, &errb)
+		if code != 2 {
+			t.Fatalf("exit = %d, want 2. stderr=%s", code, errb.String())
+		}
+		// Neither artifact may be written when the selector is invalid.
+		if _, err := os.Stat(filepath.Join(root, "docs", "compatibility.json")); err == nil {
+			t.Fatal("JSON must NOT be written for unknown --chart")
+		}
+		readmeAfter, _ := os.ReadFile(filepath.Join(root, "README.md"))
+		if !bytes.Equal(readmeBefore, readmeAfter) {
+			t.Fatal("README must stay unchanged for unknown --chart")
 		}
 	})
 

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
@@ -94,9 +94,10 @@ func main() {
 }
 
 // run parses flags and executes the requested mode, returning the process exit
-// code (api-design §II.2): 0 success (incl. WARN), 1 operational error, 2 usage error
-// (unreadable root), 2 conflicting flags. stdout carries the operation result;
-// stderr carries diagnostics.
+// code (api-design §II.2): 0 success (incl. WARN); 1 operational error
+// (unreadable root, unwritable file, unreadable README); 2 usage error
+// (invalid/conflicting flags, unknown --chart). stdout carries the operation
+// result; stderr carries diagnostics.
 func run(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("generate-compatibility", flag.ContinueOnError)
 	fs.SetOutput(stderr)

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
@@ -1,0 +1,201 @@
+# ST-6-1 — Parsing de flags + exit codes 0/1/2 (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Refatorar o `main` para uma função testável `run(args []string, stdout, stderr io.Writer) int` que devolve o exit code, e adicionar as flags do contrato (api-design §II): `--write` (default), `--check`, `--chart`, `--root` (default `../..`), `--output` (default `docs/compatibility.json`). Exit codes: 2 se `--write`+`--check` juntos (uso); 1 se `--root` inexistente (ambiente); 0 caso contrário (inclui WARN). `main()` vira um wrapper fino.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete T-5.)
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/run_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes de exit code
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/run_test.go`:
+```go
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// seedRepo builds a minimal repo (charts/ + README.md) for run() tests.
+func seedRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeChart(t, root, "matcher", `apiVersion: v2
+name: matcher-helm
+type: application
+version: 3.0.0
+`)
+	readme := "# Charts\n\n### Matcher\n\nprose\n"
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(readme), 0o644); err != nil {
+		t.Fatalf("seed readme: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	return root
+}
+
+func TestRun_ExitCodes(t *testing.T) {
+	t.Run("conflicting --write and --check => exit 2", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := run([]string{"--write", "--check"}, &out, &errb)
+		if code != 2 {
+			t.Fatalf("exit = %d, want 2. stderr=%s", code, errb.String())
+		}
+	})
+
+	t.Run("missing --root => exit 1", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		code := run([]string{"--root", "/no/such/dir/xyz"}, &out, &errb)
+		if code != 1 {
+			t.Fatalf("exit = %d, want 1. stderr=%s", code, errb.String())
+		}
+	})
+
+	t.Run("valid write => exit 0", func(t *testing.T) {
+		root := seedRepo(t)
+		var out, errb bytes.Buffer
+		code := run([]string{"--root", root, "--output", "docs/compatibility.json"}, &out, &errb)
+		if code != 0 {
+			t.Fatalf("exit = %d, want 0. stderr=%s", code, errb.String())
+		}
+		if _, err := os.Stat(filepath.Join(root, "docs", "compatibility.json")); err != nil {
+			t.Fatalf("expected JSON written: %v", err)
+		}
+	})
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | head -8
+```
+Saída esperada: `undefined: run` e `[build failed]`.
+
+### Passo 2 (GREEN) — Refatorar main.go para `run`
+Substitua a função `main()` de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` por:
+```go
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run parses flags and executes the requested mode, returning the process exit
+// code (api-design §II.2): 0 success (incl. WARN), 1 environment/usage error
+// (unreadable root), 2 conflicting flags. stdout carries the operation result;
+// stderr carries diagnostics.
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("generate-compatibility", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	write := fs.Bool("write", false, "Write mode (default when no mode given)")
+	check := fs.Bool("check", false, "Check mode: detect drift without writing")
+	root := fs.String("root", "../..", "Repository root containing charts/")
+	chart := fs.String("chart", "", "Restrict README update to a single chart (JSON always full)")
+	output := fs.String("output", "docs/compatibility.json", "JSON destination, relative to --root")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "ERROR invalid flags: %v\n", err)
+		return 2
+	}
+
+	// Mode selection + conflict check.
+	if *write && *check {
+		fmt.Fprintln(stderr, "ERROR --write and --check are mutually exclusive")
+		return 2
+	}
+
+	// Environment check: root must be a readable directory with charts/.
+	if info, err := os.Stat(filepath.Join(*root, "charts")); err != nil || !info.IsDir() {
+		fmt.Fprintf(stderr, "ERROR --root %q has no readable charts/ directory\n", *root)
+		return 1
+	}
+
+	doc, err := buildDoc(*root, gitTagLister{root: *root})
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR %v\n", err)
+		return 1
+	}
+
+	if *check {
+		return runCheck(*root, *output, doc, stdout, stderr)
+	}
+	return runWrite(*root, *output, *chart, doc, stdout, stderr)
+}
+
+// runWrite writes the JSON and README (chart filter applies to README only; the
+// JSON is always regenerated in full for determinism — api-design §II.1).
+func runWrite(root, output, chart string, doc CompatDoc, stdout, stderr io.Writer) int {
+	data, err := renderJSON(doc)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR marshal compatibility.json: %v\n", err)
+		return 1
+	}
+	if err := os.WriteFile(filepath.Join(root, output), data, 0o644); err != nil {
+		fmt.Fprintf(stderr, "ERROR write %s: %v\n", output, err)
+		return 1
+	}
+
+	readmeDoc := doc
+	if chart != "" {
+		readmeDoc = filterProduct(doc, chart)
+	}
+	if err := writeReadme(root, readmeDoc); err != nil {
+		fmt.Fprintf(stderr, "ERROR write README.md: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "wrote %s and README.md (%d products)\n", output, len(doc.Products))
+	return 0
+}
+
+// filterProduct returns a copy of doc containing only the named product, so a
+// --chart run touches just that README block.
+func filterProduct(doc CompatDoc, chart string) CompatDoc {
+	filtered := CompatDoc{SchemaVersion: doc.SchemaVersion, GeneratedFrom: doc.GeneratedFrom, Products: map[string]Product{}}
+	if p, ok := doc.Products[chart]; ok {
+		filtered.Products[chart] = p
+	}
+	return filtered
+}
+```
+
+Adicione `"io"` ao bloco de imports de `main.go` (ordem: `errors`, `flag`, `fmt`, `io`, `os`, `path/filepath`).
+
+> **Nota:** `runCheck` é definido em ST-6-2. Para o GREEN deste passo, adicione um stub temporário AO FINAL de main.go:
+> ```go
+> // runCheck is implemented in ST-6-2; temporary stub keeps ST-6-1 compiling.
+> func runCheck(root, output string, doc CompatDoc, stdout, stderr io.Writer) int {
+> 	fmt.Fprintln(stdout, "ok")
+> 	return 0
+> }
+> ```
+> ST-6-2 substitui este stub pela implementação real.
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-6-1_OK"
+```
+Saída esperada: termina com `ST-6-1_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/run_test.go
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
@@ -7,19 +7,19 @@ Refatorar o `main` para uma função testável `run(args []string, stdout, stder
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete T-5.)
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go`
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/run_test.go`
+- modify: `./.github/scripts/generate-compatibility/main.go`
+- create: `./.github/scripts/generate-compatibility/run_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes de exit code
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/run_test.go`:
+Crie `./.github/scripts/generate-compatibility/run_test.go`:
 ```go
 package main
 
@@ -82,12 +82,12 @@ func TestRun_ExitCodes(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | head -8
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | head -8
 ```
 Saída esperada: `undefined: run` e `[build failed]`.
 
 ### Passo 2 (GREEN) — Refatorar main.go para `run`
-Substitua a função `main()` de `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` por:
+Substitua a função `main()` de `./.github/scripts/generate-compatibility/main.go` por:
 ```go
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
@@ -184,18 +184,18 @@ Adicione `"io"` ao bloco de imports de `main.go` (ordem: `errors`, `flag`, `fmt`
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-6-1_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-6-1_OK"
 ```
 Saída esperada: termina com `ST-6-1_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/run_test.go
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/run_test.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/main.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-1-flag-parsing-exit-codes-tdd.md
@@ -94,7 +94,7 @@ func main() {
 }
 
 // run parses flags and executes the requested mode, returning the process exit
-// code (api-design §II.2): 0 success (incl. WARN), 1 environment/usage error
+// code (api-design §II.2): 0 success (incl. WARN), 1 operational error, 2 usage error
 // (unreadable root), 2 conflicting flags. stdout carries the operation result;
 // stderr carries diagnostics.
 func run(args []string, stdout, stderr io.Writer) int {

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-2-check-mode-drift-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-2-check-mode-drift-tdd.md
@@ -1,0 +1,162 @@
+# ST-6-2 — Modo `--check`: detecta drift sem escrever, WARN + exit 0 (RED → GREEN)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Implementar `runCheck` (substituindo o stub de ST-6-1): gera JSON+README esperados EM MEMÓRIA, compara com o disco, e — se divergir — emite `WARN <chart>: compatibility block is stale` em stderr com **exit 0** (não bloqueia no v1, ADR-4). Em dia → `stdout` "ok", exit 0. NÃO escreve nada.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | tail -1
+```
+Saída esperada: `ok  ...`
+(Se falhar, complete ST-6-1.)
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (substituir stub `runCheck`)
+- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/check_test.go`
+
+## Steps
+
+### Passo 1 (RED) — Testes de drift/em-dia
+Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/check_test.go`:
+```go
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRun_Check(t *testing.T) {
+	t.Run("in-sync repo => ok, exit 0, no WARN", func(t *testing.T) {
+		root := seedRepo(t)
+		// First write so disk matches expectation.
+		var w1out, w1err bytes.Buffer
+		if code := run([]string{"--root", root, "--output", "docs/compatibility.json"}, &w1out, &w1err); code != 0 {
+			t.Fatalf("seed write exit=%d err=%s", code, w1err.String())
+		}
+		// Now check: should be clean.
+		var out, errb bytes.Buffer
+		code := run([]string{"--check", "--root", root}, &out, &errb)
+		if code != 0 {
+			t.Fatalf("check exit = %d, want 0. stderr=%s", code, errb.String())
+		}
+		if !strings.Contains(out.String(), "ok") {
+			t.Errorf("stdout should say ok, got %q", out.String())
+		}
+		if strings.Contains(errb.String(), "stale") {
+			t.Errorf("unexpected drift WARN: %s", errb.String())
+		}
+	})
+
+	t.Run("drift => WARN on stderr, still exit 0", func(t *testing.T) {
+		root := seedRepo(t)
+		// Do NOT write first: disk README has no COMPAT block => drift.
+		var out, errb bytes.Buffer
+		code := run([]string{"--check", "--root", root}, &out, &errb)
+		if code != 0 {
+			t.Fatalf("check exit = %d, want 0 (non-blocking v1). stderr=%s", code, errb.String())
+		}
+		if !strings.Contains(errb.String(), "stale") {
+			t.Errorf("expected drift WARN with 'stale', got stderr=%q", errb.String())
+		}
+	})
+}
+```
+
+Rode e capture a falha:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_Check 2>&1 | head -12
+```
+Saída esperada: FALHA nos asserts (o stub sempre imprime "ok" e nunca detecta drift) — ex.: `expected drift WARN with 'stale'`.
+
+### Passo 2 (GREEN) — Implementar runCheck de verdade
+Substitua o stub `runCheck` em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` por:
+```go
+// runCheck compares the expected JSON + README against what is on disk without
+// writing. Drift is reported as WARN on stderr but never fails the build in v1
+// (ADR-4): exit stays 0. A clean repo prints "ok".
+func runCheck(root, output string, doc CompatDoc, stdout, stderr io.Writer) int {
+	drift := false
+
+	// JSON drift.
+	expectedJSON, err := renderJSON(doc)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR marshal compatibility.json: %v\n", err)
+		return 1
+	}
+	actualJSON, err := os.ReadFile(filepath.Join(root, output))
+	if err != nil || string(actualJSON) != string(expectedJSON) {
+		fmt.Fprintf(stderr, "WARN %s: compatibility JSON is stale\n", output)
+		drift = true
+	}
+
+	// README drift: render expected README into a temp copy of the current one.
+	readmePath := filepath.Join(root, "README.md")
+	current, err := os.ReadFile(readmePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "ERROR read README.md: %v\n", err)
+		return 1
+	}
+	expectedLines := strings.Split(string(current), "\n")
+	names := sortedProductNames(doc)
+	for _, name := range names {
+		body := renderCompatTable(doc.Products[name])
+		expectedLines, err = ensureCompatBlock(expectedLines, name, body)
+		if err != nil {
+			fmt.Fprintf(stderr, "ERROR render README for %s: %v\n", name, err)
+			return 1
+		}
+	}
+	if strings.Join(expectedLines, "\n") != string(current) {
+		fmt.Fprintln(stderr, "WARN README.md: compatibility block is stale")
+		drift = true
+	}
+
+	if drift {
+		fmt.Fprintln(stdout, "drift detected (non-blocking v1)")
+	} else {
+		fmt.Fprintln(stdout, "ok")
+	}
+	return 0
+}
+
+// sortedProductNames returns the product keys in stable ascending order.
+func sortedProductNames(doc CompatDoc) []string {
+	names := make([]string, 0, len(doc.Products))
+	for name := range doc.Products {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+```
+
+Adicione `"sort"` e `"strings"` ao bloco de imports de `main.go` (se ainda não presentes). Ordem: `errors`, `flag`, `fmt`, `io`, `os`, `path/filepath`, `sort`, `strings`.
+
+> **Nota (dedupe REFACTOR):** `writeReadme` (ST-5-5) já tem o loop de `ensureCompatBlock` sobre nomes ordenados. Considere extrair um helper `renderReadmeLines(current []string, doc) ([]string, error)` reusado por `writeReadme` e `runCheck`. Faça isso no REFACTOR se o code review pedir; não é obrigatório para o GREEN.
+
+### Passo 3 — Rodar os testes
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_Check 2>&1 | tail -3
+```
+Saída esperada: `ok  ...`.
+
+## Verification (copiável) — check contra o repo real
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --check --root ../.. ; echo "exit=$?"
+```
+Saída esperada: `exit=0`. stdout diz `ok` (se README/JSON já gerados e commitados) ou `drift detected (non-blocking v1)` com WARN em stderr (se ainda não gerados). NUNCA exit≠0.
+
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-6-2_OK"
+```
+Saída esperada: termina com `ST-6-2_OK`.
+
+## Rollback
+```bash
+rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/check_test.go
+cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-2-check-mode-drift-tdd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-6/ST-6-2-check-mode-drift-tdd.md
@@ -7,19 +7,19 @@ Implementar `runCheck` (substituindo o stub de ST-6-1): gera JSON+README esperad
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | tail -1
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRun_ExitCodes 2>&1 | tail -1
 ```
 Saída esperada: `ok  ...`
 (Se falhar, complete ST-6-1.)
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` (substituir stub `runCheck`)
-- create: `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/check_test.go`
+- modify: `./.github/scripts/generate-compatibility/main.go` (substituir stub `runCheck`)
+- create: `./.github/scripts/generate-compatibility/check_test.go`
 
 ## Steps
 
 ### Passo 1 (RED) — Testes de drift/em-dia
-Crie `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/check_test.go`:
+Crie `./.github/scripts/generate-compatibility/check_test.go`:
 ```go
 package main
 
@@ -68,12 +68,12 @@ func TestRun_Check(t *testing.T) {
 
 Rode e capture a falha:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_Check 2>&1 | head -12
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRun_Check 2>&1 | head -12
 ```
 Saída esperada: FALHA nos asserts (o stub sempre imprime "ok" e nunca detecta drift) — ex.: `expected drift WARN with 'stale'`.
 
 ### Passo 2 (GREEN) — Implementar runCheck de verdade
-Substitua o stub `runCheck` em `/home/gauchito/lerian/helm/.github/scripts/generate-compatibility/main.go` por:
+Substitua o stub `runCheck` em `./.github/scripts/generate-compatibility/main.go` por:
 ```go
 // runCheck compares the expected JSON + README against what is on disk without
 // writing. Drift is reported as WARN on stderr but never fails the build in v1
@@ -140,23 +140,23 @@ Adicione `"sort"` e `"strings"` ao bloco de imports de `main.go` (se ainda não 
 
 ### Passo 3 — Rodar os testes
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go test ./generate-compatibility/ -run TestRun_Check 2>&1 | tail -3
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go test ./generate-compatibility/ -run TestRun_Check 2>&1 | tail -3
 ```
 Saída esperada: `ok  ...`.
 
 ## Verification (copiável) — check contra o repo real
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --check --root ../.. ; echo "exit=$?"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --check --root ../.. ; echo "exit=$?"
 ```
 Saída esperada: `exit=0`. stdout diz `ok` (se README/JSON já gerados e commitados) ou `drift detected (non-blocking v1)` com WARN em stderr (se ainda não gerados). NUNCA exit≠0.
 
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-6-2_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go vet ./generate-compatibility/ && go test ./generate-compatibility/ && echo "ST-6-2_OK"
 ```
 Saída esperada: termina com `ST-6-2_OK`.
 
 ## Rollback
 ```bash
-rm -f /home/gauchito/lerian/helm/.github/scripts/generate-compatibility/check_test.go
-cd /home/gauchito/lerian/helm/.github/scripts && git checkout generate-compatibility/main.go 2>/dev/null || true
+rm -f ./.github/scripts/generate-compatibility/check_test.go
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && git checkout generate-compatibility/main.go 2>/dev/null || true
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-7/ST-7-1-backfill-testedwith-annotations.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-7/ST-7-1-backfill-testedwith-annotations.md
@@ -7,13 +7,13 @@ Preencher a annotation `lerian.studio/compatibility` com `testedWith` DERIVÁVEL
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --check --root ../.. ; echo "exit=$?"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --check --root ../.. ; echo "exit=$?"
 ```
 Saída esperada: `exit=0` (complete T-6 se falhar).
 
 Confirme a branch (não `main`):
 ```bash
-cd /home/gauchito/lerian/helm && git branch --show-current
+cd "$(git rev-parse --show-toplevel)" && git branch --show-current
 ```
 Saída esperada: uma branch de feature. Se estiver em `main`, crie com `git switch -c feat/compat-matrix-backfill`.
 
@@ -24,14 +24,14 @@ Saída esperada: uma branch de feature. Se estiver em `main`, crie com `git swit
 
 ### Passo 1 — Listar candidatos e annotations atuais
 ```bash
-cd /home/gauchito/lerian/helm && for d in charts/*/; do n=$(grep -m1 '^name:' "$d/Chart.yaml" | awk '{print $2}'); echo "== $d ($n) =="; grep -q 'lerian.studio/compatibility' "$d/Chart.yaml" && echo "  JA TEM" || echo "  (sem annotation)"; done
+cd "$(git rev-parse --show-toplevel)" && for d in charts/*/; do n=$(grep -m1 '^name:' "$d/Chart.yaml" | awk '{print $2}'); echo "== $d ($n) =="; grep -q 'lerian.studio/compatibility' "$d/Chart.yaml" && echo "  JA TEM" || echo "  (sem annotation)"; done
 ```
 Saída esperada: uma linha por chart indicando `JA TEM` ou `(sem annotation)`. Anote os que dependem de `midaz-helm` (plugins, fees, pix, bank-transfer, payments, reporter etc.).
 
 ### Passo 2 — Descobrir a versão testada de cada dependência
 Para cada chart candidato, a versão em `testedWith` é a `version:` ATUAL do chart-alvo (o release corrente). Ex.: midaz:
 ```bash
-cd /home/gauchito/lerian/helm && grep -m1 '^version:' charts/midaz/Chart.yaml
+cd "$(git rev-parse --show-toplevel)" && grep -m1 '^version:' charts/midaz/Chart.yaml
 ```
 Saída esperada: `version: 8.6.0` (ou a atual). Use esse valor como `testedWith[midaz-helm]`.
 
@@ -54,27 +54,27 @@ Repita para cada chart candidato, ajustando o(s) produto(s)-alvo e a versão tes
 ### Passo 4 — Validar YAML embutido de cada annotation editada
 Após cada edição, rode o gerador em modo write num destino /tmp e confira que NÃO surgiu WARN de V1/V4/V5 para aquele chart:
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-backfill.json 2>&1 >/dev/null | grep -E 'V1|V3|V4|V5' || echo "NO_ANNOTATION_WARN"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output docs/compat-backfill.json 2>&1 >/dev/null | grep -E 'V1|V3|V4|V5' || echo "NO_ANNOTATION_WARN"
 ```
 Saída esperada: `NO_ANNOTATION_WARN` (nenhuma violação de regra). Se aparecer `WARN <chart>: V...`, corrija a annotation daquele chart (indentação/aspas/versão).
 
 ### Passo 5 — Regenerar as saídas de verdade (README + JSON) no repo
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/tmp/backfill.stderr; echo "exit=$?"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/tmp/backfill.stderr; echo "exit=$?"
 ```
 Saída esperada: `exit=0`. Revise `git diff docs/compatibility.json README.md` — os cycles N dos charts editados agora carregam `testedWith`.
 
 ## Verification (copiável) — 100% dos candidatos com testedWith + check verde
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --check --root ../.. ; echo "check_exit=$?"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go run ./generate-compatibility --check --root ../.. ; echo "check_exit=$?"
 ```
 Saída esperada: `check_exit=0` e stdout `ok` (README e JSON já regenerados e batendo). Confirme também:
 ```bash
-cd /home/gauchito/lerian/helm && python3 -c "import json; d=json.load(open('docs/compatibility.json')); tw=[k for k,v in d['products'].items() if v.get('cycles') and v['cycles'][0].get('testedWith')]; print('with_testedWith:', len(tw)); print(tw)"
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import json; d=json.load(open('docs/compatibility.json')); tw=[k for k,v in d['products'].items() if v.get('cycles') and v['cycles'][0].get('testedWith')]; print('with_testedWith:', len(tw)); print(tw)"
 ```
 Saída esperada: uma lista com todos os charts que você editou (contagem > 0).
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm && git checkout charts/ docs/compatibility.json README.md
+cd "$(git rev-parse --show-toplevel)" && git checkout charts/ docs/compatibility.json README.md
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-7/ST-7-1-backfill-testedwith-annotations.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-7/ST-7-1-backfill-testedwith-annotations.md
@@ -1,0 +1,80 @@
+# ST-7-1 — Backfill de `testedWith` nas annotations (PR de teste)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Preencher a annotation `lerian.studio/compatibility` com `testedWith` DERIVÁVEL do release atual nos charts que dependem de outro produto Lerian (ex.: plugins que dependem de `midaz-helm`). `requires` fica opcional/vazio no v1 (backlog TODO-1). Objetivo: a matriz nasce populada (métrica M3), validada com `--check` ANTES de abrir o PR real (TRD §10 passo 5). Rodar num branch de teste.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --check --root ../.. ; echo "exit=$?"
+```
+Saída esperada: `exit=0` (complete T-6 se falhar).
+
+Confirme a branch (não `main`):
+```bash
+cd /home/gauchito/lerian/helm && git branch --show-current
+```
+Saída esperada: uma branch de feature. Se estiver em `main`, crie com `git switch -c feat/compat-matrix-backfill`.
+
+## Files
+- modify: `charts/<chart>/Chart.yaml` (bloco `annotations`) para cada chart que declara dependência de produto Lerian.
+
+## Steps
+
+### Passo 1 — Listar candidatos e annotations atuais
+```bash
+cd /home/gauchito/lerian/helm && for d in charts/*/; do n=$(grep -m1 '^name:' "$d/Chart.yaml" | awk '{print $2}'); echo "== $d ($n) =="; grep -q 'lerian.studio/compatibility' "$d/Chart.yaml" && echo "  JA TEM" || echo "  (sem annotation)"; done
+```
+Saída esperada: uma linha por chart indicando `JA TEM` ou `(sem annotation)`. Anote os que dependem de `midaz-helm` (plugins, fees, pix, bank-transfer, payments, reporter etc.).
+
+### Passo 2 — Descobrir a versão testada de cada dependência
+Para cada chart candidato, a versão em `testedWith` é a `version:` ATUAL do chart-alvo (o release corrente). Ex.: midaz:
+```bash
+cd /home/gauchito/lerian/helm && grep -m1 '^version:' charts/midaz/Chart.yaml
+```
+Saída esperada: `version: 8.6.0` (ou a atual). Use esse valor como `testedWith[midaz-helm]`.
+
+### Passo 3 — Editar UMA annotation (exemplo: plugin-fees)
+No `charts/plugin-fees/Chart.yaml`, localize o bloco:
+```yaml
+annotations:
+  lerian.studio/chart-type: multi-component
+```
+E transforme em (mantendo a chave existente, ADICIONANDO a nova — atenção à indentação do block scalar `|`):
+```yaml
+annotations:
+  lerian.studio/chart-type: multi-component
+  lerian.studio/compatibility: |
+    testedWith:
+      midaz-helm: "8.6.0"
+```
+Repita para cada chart candidato, ajustando o(s) produto(s)-alvo e a versão testada conforme o Passo 2. NÃO preencha `requires` no v1.
+
+### Passo 4 — Validar YAML embutido de cada annotation editada
+Após cada edição, rode o gerador em modo write num destino /tmp e confira que NÃO surgiu WARN de V1/V4/V5 para aquele chart:
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output /tmp/compat-backfill.json 2>&1 >/dev/null | grep -E 'V1|V3|V4|V5' || echo "NO_ANNOTATION_WARN"
+```
+Saída esperada: `NO_ANNOTATION_WARN` (nenhuma violação de regra). Se aparecer `WARN <chart>: V...`, corrija a annotation daquele chart (indentação/aspas/versão).
+
+### Passo 5 — Regenerar as saídas de verdade (README + JSON) no repo
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --root ../.. --output docs/compatibility.json 2>/tmp/backfill.stderr; echo "exit=$?"
+```
+Saída esperada: `exit=0`. Revise `git diff docs/compatibility.json README.md` — os cycles N dos charts editados agora carregam `testedWith`.
+
+## Verification (copiável) — 100% dos candidatos com testedWith + check verde
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go run ./generate-compatibility --check --root ../.. ; echo "check_exit=$?"
+```
+Saída esperada: `check_exit=0` e stdout `ok` (README e JSON já regenerados e batendo). Confirme também:
+```bash
+cd /home/gauchito/lerian/helm && python3 -c "import json; d=json.load(open('docs/compatibility.json')); tw=[k for k,v in d['products'].items() if v.get('cycles') and v['cycles'][0].get('testedWith')]; print('with_testedWith:', len(tw)); print(tw)"
+```
+Saída esperada: uma lista com todos os charts que você editou (contagem > 0).
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm && git checkout charts/ docs/compatibility.json README.md
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-1-build-binary-and-fetch-tags.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-1-build-binary-and-fetch-tags.md
@@ -7,13 +7,13 @@ Preparar o terreno no `release.yml`: (1) compilar o binário `generate-compatibi
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go build -o /tmp/gc-bin ./generate-compatibility && echo "BUILD_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go build -o /tmp/gc-bin ./generate-compatibility && echo "BUILD_OK"
 ```
 Saída esperada: `BUILD_OK` (a ferramenta compila; complete T-1..T-6 se falhar).
 
 Confirme o step "Build scripts" atual:
 ```bash
-cd /home/gauchito/lerian/helm && sed -n '136,140p' .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && sed -n '136,140p' .github/workflows/release.yml
 ```
 Saída esperada:
 ```
@@ -24,7 +24,7 @@ Saída esperada:
 ```
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/workflows/release.yml` (step "Build scripts" + novo fetch de tags)
+- modify: `./.github/workflows/release.yml` (step "Build scripts" + novo fetch de tags)
 
 ## Steps
 
@@ -48,17 +48,17 @@ Justificativa: N vem do Chart.yaml (ADR-3), mas N-1..N-3 vêm das tags `<dir>-v*
 
 ### Passo 3 — Validar sintaxe do YAML do workflow
 ```bash
-cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')"
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')"
 ```
 Saída esperada: `YAML_OK`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm && grep -q 'go build -o generate-compatibility-bin ./generate-compatibility' .github/workflows/release.yml && grep -q 'Fetch tags for compatibility window' .github/workflows/release.yml && echo "ST-8-1_OK"
+cd "$(git rev-parse --show-toplevel)" && grep -q 'go build -o generate-compatibility-bin ./generate-compatibility' .github/workflows/release.yml && grep -q 'Fetch tags for compatibility window' .github/workflows/release.yml && echo "ST-8-1_OK"
 ```
 Saída esperada: `ST-8-1_OK`.
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm && git checkout .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && git checkout .github/workflows/release.yml
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-1-build-binary-and-fetch-tags.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-1-build-binary-and-fetch-tags.md
@@ -1,0 +1,64 @@
+# ST-8-1 — Build do binário `generate-compatibility` + `git fetch --tags --force` no release.yml
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Preparar o terreno no `release.yml`: (1) compilar o binário `generate-compatibility` no step "Build scripts" existente (release.yml:136-139), e (2) garantir o histórico de tags para a janela N-1..N-3 com `git fetch --tags --force`. Ainda NÃO gera/commita (isso é ST-8-2/8-3). Só adiciona insumos, sem alterar o fluxo do semantic-release.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go build -o /tmp/gc-bin ./generate-compatibility && echo "BUILD_OK"
+```
+Saída esperada: `BUILD_OK` (a ferramenta compila; complete T-1..T-6 se falhar).
+
+Confirme o step "Build scripts" atual:
+```bash
+cd /home/gauchito/lerian/helm && sed -n '136,140p' .github/workflows/release.yml
+```
+Saída esperada:
+```
+      - name: Build scripts
+        run: |
+          cd .github/scripts
+          go build -o update-chart-version-readme-bin ./update-chart-version-readme
+```
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/workflows/release.yml` (step "Build scripts" + novo fetch de tags)
+
+## Steps
+
+### Passo 1 — Adicionar o build do novo binário
+No `release.yml`, no step "Build scripts" (linhas ~136-139), substitua o bloco `run:` por:
+```yaml
+      - name: Build scripts
+        run: |
+          cd .github/scripts
+          go build -o update-chart-version-readme-bin ./update-chart-version-readme
+          go build -o generate-compatibility-bin ./generate-compatibility
+```
+
+### Passo 2 — Garantir histórico de tags para a janela
+Adicione um step logo APÓS "Build scripts" (antes de "Generate .releaserc file"):
+```yaml
+      - name: Fetch tags for compatibility window
+        run: git fetch --tags --force
+```
+Justificativa: N vem do Chart.yaml (ADR-3), mas N-1..N-3 vêm das tags `<dir>-v*`; o checkout com `fetch-depth: 0` já traz o histórico, e `--force` garante tags atualizadas mesmo em re-runs.
+
+### Passo 3 — Validar sintaxe do YAML do workflow
+```bash
+cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')"
+```
+Saída esperada: `YAML_OK`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm && grep -q 'go build -o generate-compatibility-bin ./generate-compatibility' .github/workflows/release.yml && grep -q 'Fetch tags for compatibility window' .github/workflows/release.yml && echo "ST-8-1_OK"
+```
+Saída esperada: `ST-8-1_OK`.
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm && git checkout .github/workflows/release.yml
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-2-writeback-step-2B-skip-ci-actor-guard.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-2-writeback-step-2B-skip-ci-actor-guard.md
@@ -1,90 +1,20 @@
-# ST-8-2 — Step dedicado 2B pós-release: gera + commita com `[skip ci]`, guard de actor, rebase
+# ST-8-2 — [SUPERADO] Step dedicado 2B pós-release
 
-> ⚠️ **SUPERADO — não implementar.** A decisão de write-back foi revertida de **2B (step dedicado)** para **2A (commit único via `@semantic-release/git`)** — ver ADR-1b atualizado e §5 do TRD. O motivo: 2B gera dois commits no mesmo release (colisão de push). A implementação real está no `prepareCmd` + `assets` do semantic-release (nenhum step dedicado, nenhum `git pull --rebase`). Este arquivo fica só como registro histórico do caminho não seguido.
+> ⛔ **SUPERADO — NÃO IMPLEMENTAR. Documento histórico, não executável.**
+>
+> A decisão de write-back foi **revertida de 2B (step dedicado) para 2A (commit único via `@semantic-release/git`)**. Este subtask descrevia a 2B e **não deve ser seguido**. O marcador `For Agents` e os passos executáveis foram removidos de propósito para que nenhum agente/dev o execute por engano.
 
-> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+## Por que foi abandonado (2B → 2A)
 
-## Goal
-Adicionar o STEP DEDICADO (Opção 2B, ADR-1b) ao `release.yml`, APÓS o Semantic Release, que regenera a matriz e commita por conta própria — reusando o App-token (`steps.app-token.outputs.token`) e a chave GPG já importada no job (crazy-max/ghaction-import-gpg, release.yml:124-134). Implementa as 3 camadas anti-loop (paths-ignore já cobre README/docs; `[skip ci]`; guard de actor) e trata os 2 commits do mesmo release com `git pull --rebase` + commit-só-se-diff.
+A 2B adicionaria um **step dedicado após o Semantic Release** que gerava a matriz e fazia o **próprio commit/push**. Problema fatal: isso produz **dois commits no mesmo release** (o do `@semantic-release/git` + o do step), com risco real de colisão no push e necessidade de `git pull --rebase` num worktree sujo. Ver ADR-1b (atualizado) e §5 do TRD.
 
-## Prerequisites
-```bash
-cd "$(git rev-parse --show-toplevel)" && grep -q 'go build -o generate-compatibility-bin' .github/workflows/release.yml && echo "PREREQ_OK"
-```
-Saída esperada: `PREREQ_OK` (ST-8-1 concluído).
+## O que vale de verdade (fluxo 2A implementado)
 
-Confirme os âncoras reutilizados:
-```bash
-cd "$(git rev-parse --show-toplevel)" && sed -n '23p;54,58p' .github/workflows/release.yml
-```
-Saída esperada: linha 23 = o guard `if: github.actor != 'lerian-studio-midaz-push-bot[bot]'`; linhas 54-58 = o step `Generate GitHub App Token` (`id: app-token`).
+A geração roda **dentro** do release que já existe, sem segundo commit:
 
-## Files
-- modify: `./.github/workflows/release.yml` (novo step após "Semantic Release", dentro do job `release-helm-chart`)
+- No `prepareCmd` do semantic-release: `generate-compatibility --root . --chart $COMPAT_CHART --write` **substitui** a antiga `update-chart-version-readme`.
+- `docs/compatibility.json` entra nos `assets` do `@semantic-release/git`, junto de `Chart.yaml` e `README.md` → **um único commit** de release.
+- `git fetch --tags --force` antes, para o histórico N-1..N-3 e as datas Released.
+- Anti-loop herdado do mecanismo existente: `paths-ignore` (`README.md`, `**/docs/**`), `[skip ci]` no commit do release, guard de actor `github.actor != 'lerian-studio-midaz-push-bot[bot]'`.
 
-## Steps
-
-### Passo 1 — Inserir o step 2B após o Semantic Release
-No `release.yml`, IMEDIATAMENTE após o step "Semantic Release" (que termina em ~linha 180) e antes de "Install oras" (~linha 183), insira:
-```yaml
-      - name: Write-back compatibility matrix
-        if: >-
-          steps.semantic_changelog.outputs.new_release_published == 'true'
-          && github.actor != 'lerian-studio-midaz-push-bot[bot]'
-        env:
-          GIT_AUTHOR_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-        run: |
-          set -euo pipefail
-
-          # Regenerate the full matrix (README blocks + docs/compatibility.json).
-          # N comes from Chart.yaml; N-1..N-3 from the tags fetched in ST-8-1.
-          ./.github/scripts/generate-compatibility-bin --root . --output docs/compatibility.json
-
-          # Commit only if the generator actually changed something.
-          if git diff --quiet -- README.md docs/compatibility.json; then
-            echo "No compatibility drift to commit."
-            exit 0
-          fi
-
-          # Two commits land on the same release (semantic-release + this one):
-          # rebase onto the just-pushed release commit before committing.
-          git pull --rebase origin "${{ github.ref_name }}"
-
-          git add README.md docs/compatibility.json
-          # [skip ci] + the actor guard above are 2 of the 3 anti-loop layers;
-          # paths-ignore (README.md, **/docs/**) is the third (release.yml:8-14).
-          git commit -m "chore: update compatibility matrix [skip ci]"
-          git push origin "HEAD:${{ github.ref_name }}"
-        working-directory: ${{ github.workspace }}
-```
-
-Notas de ancoragem:
-- O commit herda a config GPG global importada em release.yml:124-134 (`git_commit_gpgsign: true`), ficando **verified**. NÃO reimportar GPG.
-- O push usa o remote já autenticado com o App-token (checkout em release.yml:60-64 usou `token: ${{ steps.app-token.outputs.token }}`).
-- `working-directory` é a raiz do repo (o binário foi gerado em `.github/scripts/` no ST-8-1, mas invocamos pelo caminho relativo `./.github/scripts/generate-compatibility-bin`).
-
-### Passo 2 — Validar sintaxe do YAML
-```bash
-cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')"
-```
-Saída esperada: `YAML_OK`.
-
-### Passo 3 — Conferir as 3 camadas anti-loop presentes
-```bash
-cd "$(git rev-parse --show-toplevel)" && echo "1) paths-ignore README/docs:" && sed -n '8,14p' .github/workflows/release.yml | grep -Ec "README.md|docs" && echo "2) skip ci (>=2: back-merge + write-back):" && grep -c 'skip ci' .github/workflows/release.yml && echo "3) actor guards (>=2):" && grep -c "github.actor != 'lerian-studio-midaz-push-bot" .github/workflows/release.yml
-```
-Saída esperada: item 1 retorna `2` (README.md e docs ignorados); item 2 retorna `>= 2`; item 3 retorna `>= 2` (o guard do job em :23 + o do step 2B).
-
-## Verification (copiável)
-```bash
-cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')" && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && grep -q 'git pull --rebase origin' .github/workflows/release.yml && echo "ST-8-2_OK"
-```
-Saída esperada: `YAML_OK` seguido de `ST-8-2_OK`.
-
-## Rollback
-```bash
-cd "$(git rev-parse --show-toplevel)" && git checkout .github/workflows/release.yml
-```
+Para os subtasks **executáveis** da integração real, ver os demais ST-8-* (build/fetch, `--check` no PR, allowlist de scope) — nenhum deles cria step dedicado nem faz rebase.

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-2-writeback-step-2B-skip-ci-actor-guard.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-2-writeback-step-2B-skip-ci-actor-guard.md
@@ -1,0 +1,88 @@
+# ST-8-2 — Step dedicado 2B pós-release: gera + commita com `[skip ci]`, guard de actor, rebase
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Adicionar o STEP DEDICADO (Opção 2B, ADR-1b) ao `release.yml`, APÓS o Semantic Release, que regenera a matriz e commita por conta própria — reusando o App-token (`steps.app-token.outputs.token`) e a chave GPG já importada no job (crazy-max/ghaction-import-gpg, release.yml:124-134). Implementa as 3 camadas anti-loop (paths-ignore já cobre README/docs; `[skip ci]`; guard de actor) e trata os 2 commits do mesmo release com `git pull --rebase` + commit-só-se-diff.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm && grep -q 'go build -o generate-compatibility-bin' .github/workflows/release.yml && echo "PREREQ_OK"
+```
+Saída esperada: `PREREQ_OK` (ST-8-1 concluído).
+
+Confirme os âncoras reutilizados:
+```bash
+cd /home/gauchito/lerian/helm && sed -n '23p;54,58p' .github/workflows/release.yml
+```
+Saída esperada: linha 23 = o guard `if: github.actor != 'lerian-studio-midaz-push-bot[bot]'`; linhas 54-58 = o step `Generate GitHub App Token` (`id: app-token`).
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/workflows/release.yml` (novo step após "Semantic Release", dentro do job `release-helm-chart`)
+
+## Steps
+
+### Passo 1 — Inserir o step 2B após o Semantic Release
+No `release.yml`, IMEDIATAMENTE após o step "Semantic Release" (que termina em ~linha 180) e antes de "Install oras" (~linha 183), insira:
+```yaml
+      - name: Write-back compatibility matrix
+        if: >-
+          steps.semantic_changelog.outputs.new_release_published == 'true'
+          && github.actor != 'lerian-studio-midaz-push-bot[bot]'
+        env:
+          GIT_AUTHOR_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+        run: |
+          set -euo pipefail
+
+          # Regenerate the full matrix (README blocks + docs/compatibility.json).
+          # N comes from Chart.yaml; N-1..N-3 from the tags fetched in ST-8-1.
+          ./.github/scripts/generate-compatibility-bin --root . --output docs/compatibility.json
+
+          # Commit only if the generator actually changed something.
+          if git diff --quiet -- README.md docs/compatibility.json; then
+            echo "No compatibility drift to commit."
+            exit 0
+          fi
+
+          # Two commits land on the same release (semantic-release + this one):
+          # rebase onto the just-pushed release commit before committing.
+          git pull --rebase origin "${{ github.ref_name }}"
+
+          git add README.md docs/compatibility.json
+          # [skip ci] + the actor guard above are 2 of the 3 anti-loop layers;
+          # paths-ignore (README.md, **/docs/**) is the third (release.yml:8-14).
+          git commit -m "chore: update compatibility matrix [skip ci]"
+          git push origin "HEAD:${{ github.ref_name }}"
+        working-directory: ${{ github.workspace }}
+```
+
+Notas de ancoragem:
+- O commit herda a config GPG global importada em release.yml:124-134 (`git_commit_gpgsign: true`), ficando **verified**. NÃO reimportar GPG.
+- O push usa o remote já autenticado com o App-token (checkout em release.yml:60-64 usou `token: ${{ steps.app-token.outputs.token }}`).
+- `working-directory` é a raiz do repo (o binário foi gerado em `.github/scripts/` no ST-8-1, mas invocamos pelo caminho relativo `./.github/scripts/generate-compatibility-bin`).
+
+### Passo 2 — Validar sintaxe do YAML
+```bash
+cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')"
+```
+Saída esperada: `YAML_OK`.
+
+### Passo 3 — Conferir as 3 camadas anti-loop presentes
+```bash
+cd /home/gauchito/lerian/helm && echo "1) paths-ignore README/docs:" && sed -n '8,14p' .github/workflows/release.yml | grep -Ec "README.md|docs" && echo "2) skip ci (>=2: back-merge + write-back):" && grep -c 'skip ci' .github/workflows/release.yml && echo "3) actor guards (>=2):" && grep -c "github.actor != 'lerian-studio-midaz-push-bot" .github/workflows/release.yml
+```
+Saída esperada: item 1 retorna `2` (README.md e docs ignorados); item 2 retorna `>= 2`; item 3 retorna `>= 2` (o guard do job em :23 + o do step 2B).
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')" && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && grep -q 'git pull --rebase origin' .github/workflows/release.yml && echo "ST-8-2_OK"
+```
+Saída esperada: `YAML_OK` seguido de `ST-8-2_OK`.
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm && git checkout .github/workflows/release.yml
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-2-writeback-step-2B-skip-ci-actor-guard.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-2-writeback-step-2B-skip-ci-actor-guard.md
@@ -1,5 +1,7 @@
 # ST-8-2 — Step dedicado 2B pós-release: gera + commita com `[skip ci]`, guard de actor, rebase
 
+> ⚠️ **SUPERADO — não implementar.** A decisão de write-back foi revertida de **2B (step dedicado)** para **2A (commit único via `@semantic-release/git`)** — ver ADR-1b atualizado e §5 do TRD. O motivo: 2B gera dois commits no mesmo release (colisão de push). A implementação real está no `prepareCmd` + `assets` do semantic-release (nenhum step dedicado, nenhum `git pull --rebase`). Este arquivo fica só como registro histórico do caminho não seguido.
+
 > **For Agents:** REQUIRED SUB-SKILL: executing-plans
 
 ## Goal
@@ -7,18 +9,18 @@ Adicionar o STEP DEDICADO (Opção 2B, ADR-1b) ao `release.yml`, APÓS o Semanti
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm && grep -q 'go build -o generate-compatibility-bin' .github/workflows/release.yml && echo "PREREQ_OK"
+cd "$(git rev-parse --show-toplevel)" && grep -q 'go build -o generate-compatibility-bin' .github/workflows/release.yml && echo "PREREQ_OK"
 ```
 Saída esperada: `PREREQ_OK` (ST-8-1 concluído).
 
 Confirme os âncoras reutilizados:
 ```bash
-cd /home/gauchito/lerian/helm && sed -n '23p;54,58p' .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && sed -n '23p;54,58p' .github/workflows/release.yml
 ```
 Saída esperada: linha 23 = o guard `if: github.actor != 'lerian-studio-midaz-push-bot[bot]'`; linhas 54-58 = o step `Generate GitHub App Token` (`id: app-token`).
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/workflows/release.yml` (novo step após "Semantic Release", dentro do job `release-helm-chart`)
+- modify: `./.github/workflows/release.yml` (novo step após "Semantic Release", dentro do job `release-helm-chart`)
 
 ## Steps
 
@@ -66,23 +68,23 @@ Notas de ancoragem:
 
 ### Passo 2 — Validar sintaxe do YAML
 ```bash
-cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')"
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')"
 ```
 Saída esperada: `YAML_OK`.
 
 ### Passo 3 — Conferir as 3 camadas anti-loop presentes
 ```bash
-cd /home/gauchito/lerian/helm && echo "1) paths-ignore README/docs:" && sed -n '8,14p' .github/workflows/release.yml | grep -Ec "README.md|docs" && echo "2) skip ci (>=2: back-merge + write-back):" && grep -c 'skip ci' .github/workflows/release.yml && echo "3) actor guards (>=2):" && grep -c "github.actor != 'lerian-studio-midaz-push-bot" .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && echo "1) paths-ignore README/docs:" && sed -n '8,14p' .github/workflows/release.yml | grep -Ec "README.md|docs" && echo "2) skip ci (>=2: back-merge + write-back):" && grep -c 'skip ci' .github/workflows/release.yml && echo "3) actor guards (>=2):" && grep -c "github.actor != 'lerian-studio-midaz-push-bot" .github/workflows/release.yml
 ```
 Saída esperada: item 1 retorna `2` (README.md e docs ignorados); item 2 retorna `>= 2`; item 3 retorna `>= 2` (o guard do job em :23 + o do step 2B).
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')" && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && grep -q 'git pull --rebase origin' .github/workflows/release.yml && echo "ST-8-2_OK"
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('YAML_OK')" && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && grep -q 'git pull --rebase origin' .github/workflows/release.yml && echo "ST-8-2_OK"
 ```
 Saída esperada: `YAML_OK` seguido de `ST-8-2_OK`.
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm && git checkout .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && git checkout .github/workflows/release.yml
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-3-check-warning-in-standard-workflow.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-3-check-warning-in-standard-workflow.md
@@ -7,18 +7,18 @@ Adicionar ao `helm-chart-standard.yml` um step que roda `generate-compatibility 
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm && test -f .github/workflows/helm-chart-standard.yml && echo "WF_EXISTS"
+cd "$(git rev-parse --show-toplevel)" && test -f .github/workflows/helm-chart-standard.yml && echo "WF_EXISTS"
 ```
 Saída esperada: `WF_EXISTS`. Se não existir, PARE e reporte (nome do workflow pode diferir; procure com `ls .github/workflows/ | grep -i standard`).
 
 Inspecione o trigger `paths` atual:
 ```bash
-cd /home/gauchito/lerian/helm && sed -n '1,40p' .github/workflows/helm-chart-standard.yml
+cd "$(git rev-parse --show-toplevel)" && sed -n '1,40p' .github/workflows/helm-chart-standard.yml
 ```
 Anote a estrutura de `on:`/`paths:` e onde ficam os steps do job de validação.
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/.github/workflows/helm-chart-standard.yml` (trigger `paths` + novo step de check)
+- modify: `./.github/workflows/helm-chart-standard.yml` (trigger `paths` + novo step de check)
 
 ## Steps
 
@@ -44,17 +44,17 @@ Justificativa: `--check` já retorna exit 0 no v1 mesmo com drift; `continue-on-
 
 ### Passo 3 — Validar sintaxe
 ```bash
-cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/helm-chart-standard.yml')); print('YAML_OK')"
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/helm-chart-standard.yml')); print('YAML_OK')"
 ```
 Saída esperada: `YAML_OK`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm && grep -q 'generate-compatibility --check' .github/workflows/helm-chart-standard.yml && grep -q 'generate-compatibility' .github/workflows/helm-chart-standard.yml && echo "ST-8-3_OK"
+cd "$(git rev-parse --show-toplevel)" && grep -q 'generate-compatibility --check' .github/workflows/helm-chart-standard.yml && grep -q 'generate-compatibility' .github/workflows/helm-chart-standard.yml && echo "ST-8-3_OK"
 ```
 Saída esperada: `ST-8-3_OK`.
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm && git checkout .github/workflows/helm-chart-standard.yml
+cd "$(git rev-parse --show-toplevel)" && git checkout .github/workflows/helm-chart-standard.yml
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-3-check-warning-in-standard-workflow.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-3-check-warning-in-standard-workflow.md
@@ -1,0 +1,60 @@
+# ST-8-3 — `--check` como warning no PR (`helm-chart-standard.yml`) + trigger path
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Adicionar ao `helm-chart-standard.yml` um step que roda `generate-compatibility --check` como WARNING no PR (não falha o build — ADR-4, exit 0), e incluir `.github/scripts/generate-compatibility/**` no trigger `paths` do workflow. Assim o CI detecta drift sem bloquear (espírito Ring).
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm && test -f .github/workflows/helm-chart-standard.yml && echo "WF_EXISTS"
+```
+Saída esperada: `WF_EXISTS`. Se não existir, PARE e reporte (nome do workflow pode diferir; procure com `ls .github/workflows/ | grep -i standard`).
+
+Inspecione o trigger `paths` atual:
+```bash
+cd /home/gauchito/lerian/helm && sed -n '1,40p' .github/workflows/helm-chart-standard.yml
+```
+Anote a estrutura de `on:`/`paths:` e onde ficam os steps do job de validação.
+
+## Files
+- modify: `/home/gauchito/lerian/helm/.github/workflows/helm-chart-standard.yml` (trigger `paths` + novo step de check)
+
+## Steps
+
+### Passo 1 — Adicionar o path ao trigger
+No bloco `on: pull_request: paths:` (ou equivalente), adicione a entrada (mantendo as existentes):
+```yaml
+      - '.github/scripts/generate-compatibility/**'
+```
+Se o workflow já dispara para `.github/scripts/**` de forma ampla, este passo é no-op — confirme e siga.
+
+### Passo 2 — Adicionar o step de check (warning, não bloqueante)
+No job que roda os validadores Go (onde já há `go run ./validate-helm-charts ...` ou similar), adicione um step:
+```yaml
+      - name: Compatibility matrix drift check (warning)
+        working-directory: .github/scripts
+        continue-on-error: true
+        run: |
+          # v1: --check emits WARN on stderr and exits 0 on drift (ADR-4).
+          # continue-on-error is defensive: this step must never fail the PR.
+          go run ./generate-compatibility --check --root ../..
+```
+Justificativa: `--check` já retorna exit 0 no v1 mesmo com drift; `continue-on-error: true` é cinto-e-suspensório para garantir que nunca bloqueie o build.
+
+### Passo 3 — Validar sintaxe
+```bash
+cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/helm-chart-standard.yml')); print('YAML_OK')"
+```
+Saída esperada: `YAML_OK`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm && grep -q 'generate-compatibility --check' .github/workflows/helm-chart-standard.yml && grep -q 'generate-compatibility' .github/workflows/helm-chart-standard.yml && echo "ST-8-3_OK"
+```
+Saída esperada: `ST-8-3_OK`.
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm && git checkout .github/workflows/helm-chart-standard.yml
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-4-pr-title-scope-allowlist.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-4-pr-title-scope-allowlist.md
@@ -28,6 +28,8 @@ cd "$(git rev-parse --show-toplevel)" && for s in ci charts doc; do grep -qiE "(
 ```
 Saída esperada: idealmente todos `PRESENTE`. Anote os que faltam.
 
+> Nota: esta verificação é por busca textual (suficiente para um subtask de planejamento — confirma que o token existe na allowlist). Para checagem estrutural rigorosa (garantir que o token está de fato sob a chave `scopes:` da action, e não em outro lugar do YAML), use `yq '.jobs.*.steps[].with.scopes' .github/workflows/pr-title.yml` no lugar do grep.
+
 ### Passo 3 — Adicionar os scopes faltantes (só se algum FALTA)
 Se algum scope apareceu como `FALTA`, edite a lista de `scopes` no `pr-title.yml` adicionando-o. Exemplo (formato depende da action; NÃO invente — case ao que o Passo 1 mostrou). Se a lista for multi-linha do tipo:
 ```yaml

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-4-pr-title-scope-allowlist.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-4-pr-title-scope-allowlist.md
@@ -1,0 +1,58 @@
+# ST-8-4 — Garantir scope permitido no `pr-title.yml` para os PRs da feature
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Confirmar (e, se faltar, adicionar) que os scopes usados pelos PRs desta entrega (`ci`, `charts`, `doc`) estão na allowlist do `pr-title.yml` — o CI rejeita título de PR com scope fora da lista (regra do repo: Conventional Commits com scope obrigatório). Sem isso, os PRs de T-7/T-8/T-9 falham no lint de título.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm && test -f .github/workflows/pr-title.yml && echo "WF_EXISTS" || ls .github/workflows/ | grep -i 'pr-title\|semantic\|title'
+```
+Saída esperada: `WF_EXISTS` (ou o nome real do workflow de validação de título).
+
+## Files
+- modify (se necessário): `/home/gauchito/lerian/helm/.github/workflows/pr-title.yml` (allowlist de scopes)
+
+## Steps
+
+### Passo 1 — Inspecionar a allowlist atual de scopes
+```bash
+cd /home/gauchito/lerian/helm && grep -nA20 -iE 'scopes|scope' .github/workflows/pr-title.yml | head -40
+```
+Saída esperada: o bloco que define os scopes aceitos (pode estar em `with: scopes:` do `amannn/action-semantic-pull-request` ou similar). Anote quais scopes já existem.
+
+### Passo 2 — Verificar se `ci`, `charts`, `doc` estão presentes
+```bash
+cd /home/gauchito/lerian/helm && for s in ci charts doc; do grep -qiE "(^|[^a-z])$s([^a-z]|$)" .github/workflows/pr-title.yml && echo "$s: PRESENTE" || echo "$s: FALTA"; done
+```
+Saída esperada: idealmente todos `PRESENTE`. Anote os que faltam.
+
+### Passo 3 — Adicionar os scopes faltantes (só se algum FALTA)
+Se algum scope apareceu como `FALTA`, edite a lista de `scopes` no `pr-title.yml` adicionando-o. Exemplo (formato depende da action; NÃO invente — case ao que o Passo 1 mostrou). Se a lista for multi-linha do tipo:
+```yaml
+          scopes: |
+            midaz
+            charts
+            ci
+```
+adicione a(s) linha(s) faltante(s) mantendo a indentação exata.
+
+Se o workflow NÃO restringe scope (só valida o `type`), este passo é no-op — registre isso e siga.
+
+### Passo 4 — Validar sintaxe (se editou)
+```bash
+cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-title.yml')); print('YAML_OK')"
+```
+Saída esperada: `YAML_OK`.
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm && for s in ci charts doc; do grep -qiE "(^|[^a-z])$s([^a-z]|$)" .github/workflows/pr-title.yml && echo "$s ok"; done; echo "ST-8-4_DONE"
+```
+Saída esperada: `ci ok`, `charts ok`, `doc ok` (para os que se aplicam) seguido de `ST-8-4_DONE`. Se o workflow não restringe scope, registre "no-op" e prossiga.
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm && git checkout .github/workflows/pr-title.yml
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-4-pr-title-scope-allowlist.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-4-pr-title-scope-allowlist.md
@@ -7,24 +7,24 @@ Confirmar (e, se faltar, adicionar) que os scopes usados pelos PRs desta entrega
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm && test -f .github/workflows/pr-title.yml && echo "WF_EXISTS" || ls .github/workflows/ | grep -i 'pr-title\|semantic\|title'
+cd "$(git rev-parse --show-toplevel)" && test -f .github/workflows/pr-title.yml && echo "WF_EXISTS" || ls .github/workflows/ | grep -i 'pr-title\|semantic\|title'
 ```
 Saída esperada: `WF_EXISTS` (ou o nome real do workflow de validação de título).
 
 ## Files
-- modify (se necessário): `/home/gauchito/lerian/helm/.github/workflows/pr-title.yml` (allowlist de scopes)
+- modify (se necessário): `./.github/workflows/pr-title.yml` (allowlist de scopes)
 
 ## Steps
 
 ### Passo 1 — Inspecionar a allowlist atual de scopes
 ```bash
-cd /home/gauchito/lerian/helm && grep -nA20 -iE 'scopes|scope' .github/workflows/pr-title.yml | head -40
+cd "$(git rev-parse --show-toplevel)" && grep -nA20 -iE 'scopes|scope' .github/workflows/pr-title.yml | head -40
 ```
 Saída esperada: o bloco que define os scopes aceitos (pode estar em `with: scopes:` do `amannn/action-semantic-pull-request` ou similar). Anote quais scopes já existem.
 
 ### Passo 2 — Verificar se `ci`, `charts`, `doc` estão presentes
 ```bash
-cd /home/gauchito/lerian/helm && for s in ci charts doc; do grep -qiE "(^|[^a-z])$s([^a-z]|$)" .github/workflows/pr-title.yml && echo "$s: PRESENTE" || echo "$s: FALTA"; done
+cd "$(git rev-parse --show-toplevel)" && for s in ci charts doc; do grep -qiE "(^|[^a-z])$s([^a-z]|$)" .github/workflows/pr-title.yml && echo "$s: PRESENTE" || echo "$s: FALTA"; done
 ```
 Saída esperada: idealmente todos `PRESENTE`. Anote os que faltam.
 
@@ -42,17 +42,17 @@ Se o workflow NÃO restringe scope (só valida o `type`), este passo é no-op �
 
 ### Passo 4 — Validar sintaxe (se editou)
 ```bash
-cd /home/gauchito/lerian/helm && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-title.yml')); print('YAML_OK')"
+cd "$(git rev-parse --show-toplevel)" && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-title.yml')); print('YAML_OK')"
 ```
 Saída esperada: `YAML_OK`.
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm && for s in ci charts doc; do grep -qiE "(^|[^a-z])$s([^a-z]|$)" .github/workflows/pr-title.yml && echo "$s ok"; done; echo "ST-8-4_DONE"
+cd "$(git rev-parse --show-toplevel)" && for s in ci charts doc; do grep -qiE "(^|[^a-z])$s([^a-z]|$)" .github/workflows/pr-title.yml && echo "$s ok"; done; echo "ST-8-4_DONE"
 ```
 Saída esperada: `ci ok`, `charts ok`, `doc ok` (para os que se aplicam) seguido de `ST-8-4_DONE`. Se o workflow não restringe scope, registre "no-op" e prossiga.
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm && git checkout .github/workflows/pr-title.yml
+cd "$(git rev-parse --show-toplevel)" && git checkout .github/workflows/pr-title.yml
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-5-validate-writeback-no-real-push.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-5-validate-writeback-no-real-push.md
@@ -7,12 +7,12 @@ Prova executiva do step 2B ANTES de qualquer push real (DoD obrigatório do TRD 
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm/.github/scripts && go build -o /tmp/gc-bin ./generate-compatibility && echo "BUILD_OK"
+cd "$(git rev-parse --show-toplevel)/.github/scripts" && go build -o /tmp/gc-bin ./generate-compatibility && echo "BUILD_OK"
 ```
 Saída esperada: `BUILD_OK`.
 
 ```bash
-cd /home/gauchito/lerian/helm && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && echo "STEP_EXISTS"
+cd "$(git rev-parse --show-toplevel)" && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && echo "STEP_EXISTS"
 ```
 Saída esperada: `STEP_EXISTS` (ST-8-2 concluído).
 
@@ -24,7 +24,7 @@ Saída esperada: `STEP_EXISTS` (ST-8-2 concluído).
 ### Passo 1 — Montar remote bare local + clone de trabalho
 ```bash
 rm -rf /tmp/helm-bare.git /tmp/helm-wb && \
-git clone --bare /home/gauchito/lerian/helm /tmp/helm-bare.git && \
+git clone --bare . /tmp/helm-bare.git && \
 git clone /tmp/helm-bare.git /tmp/helm-wb && \
 cd /tmp/helm-wb && git fetch --tags --force 2>/dev/null; echo "setup=$?"
 ```
@@ -81,7 +81,7 @@ Saída esperada: `dry_run_exit=0` e o git lista o range de commits que SERIA emp
 
 ### Passo 7 — Confirmar que o repo REAL não foi tocado
 ```bash
-cd /home/gauchito/lerian/helm && git status --porcelain | head; echo "real_repo_clean_check_done"
+cd "$(git rev-parse --show-toplevel)" && git status --porcelain | head; echo "real_repo_clean_check_done"
 ```
 Saída esperada: nenhuma linha referente a esta simulação (o trabalho todo foi em /tmp).
 

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-5-validate-writeback-no-real-push.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-5-validate-writeback-no-real-push.md
@@ -1,0 +1,98 @@
+# ST-8-5 — Validar o write-back SEM push real (TRD §10 passo 4 — o mais arriscado)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Prova executiva do step 2B ANTES de qualquer push real (DoD obrigatório do TRD §10 passo 4). Simular localmente, num CLONE DESCARTÁVEL com um "remote" bare local, o encadeamento "semantic-release commit + nosso commit": conferir (a) `git pull --rebase` + commit-só-se-diff funcionam com 2 commits no mesmo release; (b) o commit fica **GPG-verified** (localmente: assinado, dado que a chave exista); (c) `git push --dry-run` sucede; (d) a mensagem tem `[skip ci]`. Nenhuma alteração no repo real, nenhum push para o GitHub.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm/.github/scripts && go build -o /tmp/gc-bin ./generate-compatibility && echo "BUILD_OK"
+```
+Saída esperada: `BUILD_OK`.
+
+```bash
+cd /home/gauchito/lerian/helm && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && echo "STEP_EXISTS"
+```
+Saída esperada: `STEP_EXISTS` (ST-8-2 concluído).
+
+## Files
+- (nenhum arquivo do repo real é modificado; tudo em /tmp)
+
+## Steps
+
+### Passo 1 — Montar remote bare local + clone de trabalho
+```bash
+rm -rf /tmp/helm-bare.git /tmp/helm-wb && \
+git clone --bare /home/gauchito/lerian/helm /tmp/helm-bare.git && \
+git clone /tmp/helm-bare.git /tmp/helm-wb && \
+cd /tmp/helm-wb && git fetch --tags --force 2>/dev/null; echo "setup=$?"
+```
+Saída esperada: `setup=0`. Agora `/tmp/helm-wb` tem `origin` = `/tmp/helm-bare.git` (um remote real, mas local e descartável).
+
+### Passo 2 — Configurar identidade e (se disponível) assinatura GPG no clone
+```bash
+cd /tmp/helm-wb && git config user.name "CI Test" && git config user.email "gauchito@lerian.studio" && \
+KEY=$(git config --global user.signingkey || true); \
+if [ -n "$KEY" ]; then git config commit.gpgsign true; git config user.signingkey "$KEY"; echo "GPG_ON key=$KEY"; else echo "GPG_OFF (sem chave global; valida-se só o fluxo, não a assinatura)"; fi
+```
+Saída esperada: `GPG_ON key=...` (se houver chave global — o commit será assinado) ou `GPG_OFF ...` (valida o fluxo; a assinatura real acontece no CI com a chave importada). NÃO sobrescrever identidade global (regra [[feedback_git_identity]]); só config LOCAL do clone.
+
+### Passo 3 — Simular o commit do semantic-release (1º commit do release)
+```bash
+cd /tmp/helm-wb && echo "# fake release bump" >> charts/matcher/Chart.yaml && \
+git add charts/matcher/Chart.yaml && \
+git commit -m "chore(matcher): release 3.0.1 [skip ci]" >/dev/null && \
+git push origin HEAD:main >/dev/null 2>&1; echo "release_commit_pushed=$?"
+```
+Saída esperada: `release_commit_pushed=0` (o "semantic-release" commitou e empurrou pro remote bare).
+
+### Passo 4 — Executar o MIOLO do step 2B (as mesmas linhas do release.yml)
+```bash
+cd /tmp/helm-wb && set -e && \
+/tmp/gc-bin --root . --output docs/compatibility.json && \
+if git diff --quiet -- README.md docs/compatibility.json; then echo "NO_DRIFT (nada a commitar — ok se já gerado antes)"; else \
+  git pull --rebase origin main && \
+  git add README.md docs/compatibility.json && \
+  git commit -m "chore: update compatibility matrix [skip ci]" && \
+  echo "WB_COMMIT_CREATED"; fi
+```
+Saída esperada: `WB_COMMIT_CREATED` (havia drift → nosso commit foi criado sobre o commit do release, via rebase, sem conflito). Se sair `NO_DRIFT`, force um drift apagando o bloco: veja Passo 4b.
+
+### Passo 4b — (só se saiu NO_DRIFT) forçar drift e repetir
+```bash
+cd /tmp/helm-wb && test -f docs/compatibility.json && rm -f docs/compatibility.json && \
+/tmp/gc-bin --root . --output docs/compatibility.json && \
+git add README.md docs/compatibility.json && git commit -m "chore: update compatibility matrix [skip ci]" && echo "WB_COMMIT_CREATED"
+```
+Saída esperada: `WB_COMMIT_CREATED`.
+
+### Passo 5 — Conferir `[skip ci]` e (se GPG on) assinatura
+```bash
+cd /tmp/helm-wb && echo "--- mensagem ---" && git log -1 --pretty=%B && echo "--- assinatura (N=não assinado, G=boa) ---" && git log -1 --pretty='%G?'
+```
+Saída esperada: a mensagem contém `[skip ci]`; `%G?` retorna `G` (assinatura boa) se GPG estava ON, ou `N` se OFF (esperado localmente sem chave — a verificação real é no CI).
+
+### Passo 6 — `git push --dry-run` (NÃO empurra de verdade)
+```bash
+cd /tmp/helm-wb && git push --dry-run origin HEAD:main; echo "dry_run_exit=$?"
+```
+Saída esperada: `dry_run_exit=0` e o git lista o range de commits que SERIA empurrado (ex.: `abc..def  HEAD -> main`) — sem efetuar o push. Confirma que o rebase deixou o histórico limpo e "empurrável".
+
+### Passo 7 — Confirmar que o repo REAL não foi tocado
+```bash
+cd /home/gauchito/lerian/helm && git status --porcelain | head; echo "real_repo_clean_check_done"
+```
+Saída esperada: nenhuma linha referente a esta simulação (o trabalho todo foi em /tmp).
+
+## Verification (copiável)
+```bash
+cd /tmp/helm-wb && git log -1 --pretty=%B | grep -q '\[skip ci\]' && git push --dry-run origin HEAD:main >/dev/null 2>&1 && echo "ST-8-5_OK"
+```
+Saída esperada: `ST-8-5_OK`.
+
+## Rollback
+```bash
+rm -rf /tmp/helm-bare.git /tmp/helm-wb /tmp/gc-bin
+```
+(O repo real e o GitHub nunca foram tocados.)

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-6-verify-no-ci-loop-on-bot-push.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-6-verify-no-ci-loop-on-bot-push.md
@@ -1,0 +1,62 @@
+# ST-8-6 — Confirmar que o push do bot NÃO re-dispara o workflow (3 camadas comprovadas)
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Verificar ESTATICAMENTE (por leitura do workflow) e, quando o PR real rodar, OBSERVACIONALMENTE, que o push do bot no step 2B não gera um novo run de release — provando as 3 camadas anti-loop (paths-ignore, `[skip ci]`, guard de actor). Esta é a última salvaguarda antes de liberar T-8 para `main`.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && echo "STEP_EXISTS"
+```
+Saída esperada: `STEP_EXISTS`.
+
+## Files
+- (nenhum; apenas verificação/leitura)
+
+## Steps
+
+### Passo 1 — Camada 1: paths-ignore cobre README.md e docs
+```bash
+cd /home/gauchito/lerian/helm && sed -n '3,15p' .github/workflows/release.yml
+```
+Saída esperada: bloco `on: push:` com `paths-ignore:` contendo `'README.md'` e `'**/docs/**'`. Como o step 2B só altera esses dois caminhos, o push do bot casa o `paths-ignore` → NÃO dispara `release.yml`.
+
+### Passo 2 — Camada 2: `[skip ci]` na mensagem do commit 2B
+```bash
+cd /home/gauchito/lerian/helm && grep -n 'chore: update compatibility matrix \[skip ci\]' .github/workflows/release.yml
+```
+Saída esperada: uma linha com a mensagem contendo `[skip ci]`. Muitos workflows/Actions respeitam `[skip ci]` no head commit para não iniciar runs.
+
+### Passo 3 — Camada 3: guard de actor no job e no step
+```bash
+cd /home/gauchito/lerian/helm && echo "job guard (:23):" && sed -n '23p' .github/workflows/release.yml && echo "step 2B guard:" && grep -n "github.actor != 'lerian-studio-midaz-push-bot\[bot\]'" .github/workflows/release.yml
+```
+Saída esperada: o job `get-changed-paths` tem `if: github.actor != 'lerian-studio-midaz-push-bot[bot]'` (:23) — então mesmo que um push do bot passasse pelos filtros de path, o job não roda. E o próprio step 2B repete o guard (não commita quando o ator é o bot).
+
+### Passo 4 — Sanidade: as 3 camadas são independentes (qualquer uma quebra o loop)
+Documente a conclusão da revisão estática:
+- Camada 1 (paths-ignore): impede o trigger por conteúdo alterado.
+- Camada 2 ([skip ci]): impede o start do run.
+- Camada 3 (actor guard): impede o job de rodar mesmo se as duas anteriores falharem.
+Basta UMA para quebrar o loop; as três juntas dão defesa em profundidade.
+
+### Passo 5 — (Observacional, no PR/release real) confirmar zero re-trigger
+Após o merge que ativa o step (feito pelo usuário — NÃO pela IA), quando um release real ocorrer, verifique que o push do bot não iniciou novo run:
+```bash
+cd /home/gauchito/lerian/helm && gh run list --workflow release.yml --limit 5 --json displayTitle,event,headBranch,createdAt,conclusion 2>/dev/null || echo "gh indisponível (ver reference_gh_servers_night); reexecutar depois"
+```
+Saída esperada: entre os runs recentes, o commit `chore: update compatibility matrix [skip ci]` NÃO aparece como gatilho de um novo run de `release.yml`. (Se `gh` estiver indisponível à noite, deixar pendente e reexecutar.)
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm && \
+  L1=$(sed -n '8,14p' .github/workflows/release.yml | grep -Ec "README.md|docs") && \
+  L2=$(grep -c 'update compatibility matrix \[skip ci\]' .github/workflows/release.yml) && \
+  L3=$(grep -c "github.actor != 'lerian-studio-midaz-push-bot" .github/workflows/release.yml) && \
+  echo "L1=$L1 L2=$L2 L3=$L3" && [ "$L1" -ge 2 ] && [ "$L2" -ge 1 ] && [ "$L3" -ge 2 ] && echo "ST-8-6_OK"
+```
+Saída esperada: `L1=2 L2=1 L3=2` (ou maiores) seguido de `ST-8-6_OK`.
+
+## Rollback
+Nada a reverter (só leitura/verificação).

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-6-verify-no-ci-loop-on-bot-push.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-8/ST-8-6-verify-no-ci-loop-on-bot-push.md
@@ -7,7 +7,7 @@ Verificar ESTATICAMENTE (por leitura do workflow) e, quando o PR real rodar, OBS
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && echo "STEP_EXISTS"
+cd "$(git rev-parse --show-toplevel)" && grep -q 'Write-back compatibility matrix' .github/workflows/release.yml && echo "STEP_EXISTS"
 ```
 Saída esperada: `STEP_EXISTS`.
 
@@ -18,19 +18,19 @@ Saída esperada: `STEP_EXISTS`.
 
 ### Passo 1 — Camada 1: paths-ignore cobre README.md e docs
 ```bash
-cd /home/gauchito/lerian/helm && sed -n '3,15p' .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && sed -n '3,15p' .github/workflows/release.yml
 ```
 Saída esperada: bloco `on: push:` com `paths-ignore:` contendo `'README.md'` e `'**/docs/**'`. Como o step 2B só altera esses dois caminhos, o push do bot casa o `paths-ignore` → NÃO dispara `release.yml`.
 
 ### Passo 2 — Camada 2: `[skip ci]` na mensagem do commit 2B
 ```bash
-cd /home/gauchito/lerian/helm && grep -n 'chore: update compatibility matrix \[skip ci\]' .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && grep -n 'chore: update compatibility matrix \[skip ci\]' .github/workflows/release.yml
 ```
 Saída esperada: uma linha com a mensagem contendo `[skip ci]`. Muitos workflows/Actions respeitam `[skip ci]` no head commit para não iniciar runs.
 
 ### Passo 3 — Camada 3: guard de actor no job e no step
 ```bash
-cd /home/gauchito/lerian/helm && echo "job guard (:23):" && sed -n '23p' .github/workflows/release.yml && echo "step 2B guard:" && grep -n "github.actor != 'lerian-studio-midaz-push-bot\[bot\]'" .github/workflows/release.yml
+cd "$(git rev-parse --show-toplevel)" && echo "job guard (:23):" && sed -n '23p' .github/workflows/release.yml && echo "step 2B guard:" && grep -n "github.actor != 'lerian-studio-midaz-push-bot\[bot\]'" .github/workflows/release.yml
 ```
 Saída esperada: o job `get-changed-paths` tem `if: github.actor != 'lerian-studio-midaz-push-bot[bot]'` (:23) — então mesmo que um push do bot passasse pelos filtros de path, o job não roda. E o próprio step 2B repete o guard (não commita quando o ator é o bot).
 
@@ -44,13 +44,13 @@ Basta UMA para quebrar o loop; as três juntas dão defesa em profundidade.
 ### Passo 5 — (Observacional, no PR/release real) confirmar zero re-trigger
 Após o merge que ativa o step (feito pelo usuário — NÃO pela IA), quando um release real ocorrer, verifique que o push do bot não iniciou novo run:
 ```bash
-cd /home/gauchito/lerian/helm && gh run list --workflow release.yml --limit 5 --json displayTitle,event,headBranch,createdAt,conclusion 2>/dev/null || echo "gh indisponível (ver reference_gh_servers_night); reexecutar depois"
+cd "$(git rev-parse --show-toplevel)" && gh run list --workflow release.yml --limit 5 --json displayTitle,event,headBranch,createdAt,conclusion 2>/dev/null || echo "gh indisponível (ver reference_gh_servers_night); reexecutar depois"
 ```
 Saída esperada: entre os runs recentes, o commit `chore: update compatibility matrix [skip ci]` NÃO aparece como gatilho de um novo run de `release.yml`. (Se `gh` estiver indisponível à noite, deixar pendente e reexecutar.)
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm && \
+cd "$(git rev-parse --show-toplevel)" && \
   L1=$(sed -n '8,14p' .github/workflows/release.yml | grep -Ec "README.md|docs") && \
   L2=$(grep -c 'update compatibility matrix \[skip ci\]' .github/workflows/release.yml) && \
   L3=$(grep -c "github.actor != 'lerian-studio-midaz-push-bot" .github/workflows/release.yml) && \

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-9/ST-9-1-document-annotation-contract.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-9/ST-9-1-document-annotation-contract.md
@@ -7,18 +7,18 @@ Adicionar uma subseção NOVA em `docs/helm-chart-standard.md` formalizando a an
 
 ## Prerequisites
 ```bash
-cd /home/gauchito/lerian/helm && test -f docs/helm-chart-standard.md && grep -c 'lerian.studio/chart-type' docs/helm-chart-standard.md
+cd "$(git rev-parse --show-toplevel)" && test -f docs/helm-chart-standard.md && grep -c 'lerian.studio/chart-type' docs/helm-chart-standard.md
 ```
 Saída esperada: o arquivo existe e retorna um número `>= 1` (a doc já menciona o precedente `chart-type`). Se o arquivo não existir, PARE e reporte ao orquestrador (path pode ter mudado).
 
 ## Files
-- modify: `/home/gauchito/lerian/helm/docs/helm-chart-standard.md` (adicionar subseção ao final da seção de annotations)
+- modify: `./docs/helm-chart-standard.md` (adicionar subseção ao final da seção de annotations)
 
 ## Steps
 
 ### Passo 1 — Localizar onde inserir (após a doc de `chart-type`)
 ```bash
-cd /home/gauchito/lerian/helm && grep -n 'lerian.studio/chart-type' docs/helm-chart-standard.md
+cd "$(git rev-parse --show-toplevel)" && grep -n 'lerian.studio/chart-type' docs/helm-chart-standard.md
 ```
 Saída esperada: número(s) de linha da menção existente. Insira a nova subseção logo APÓS o fim do bloco que documenta `chart-type` (próximo cabeçalho `##`/`###`).
 
@@ -102,17 +102,17 @@ annotations:
 
 ### Passo 3 — Conferir que não quebrou markdown existente
 ```bash
-cd /home/gauchito/lerian/helm && grep -c '^### Annotation `lerian.studio/compatibility`' docs/helm-chart-standard.md
+cd "$(git rev-parse --show-toplevel)" && grep -c '^### Annotation `lerian.studio/compatibility`' docs/helm-chart-standard.md
 ```
 Saída esperada: `1` (a subseção foi inserida exatamente uma vez).
 
 ## Verification (copiável)
 ```bash
-cd /home/gauchito/lerian/helm && grep -q 'testedWith' docs/helm-chart-standard.md && grep -q 'block scalar' docs/helm-chart-standard.md && echo "ST-9-1_OK"
+cd "$(git rev-parse --show-toplevel)" && grep -q 'testedWith' docs/helm-chart-standard.md && grep -q 'block scalar' docs/helm-chart-standard.md && echo "ST-9-1_OK"
 ```
 Saída esperada: `ST-9-1_OK`.
 
 ## Rollback
 ```bash
-cd /home/gauchito/lerian/helm && git checkout docs/helm-chart-standard.md
+cd "$(git rev-parse --show-toplevel)" && git checkout docs/helm-chart-standard.md
 ```

--- a/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-9/ST-9-1-document-annotation-contract.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/subtasks/T-9/ST-9-1-document-annotation-contract.md
@@ -1,0 +1,118 @@
+# ST-9-1 — Documentar o contrato da annotation em `helm-chart-standard.md`
+
+> **For Agents:** REQUIRED SUB-SKILL: executing-plans
+
+## Goal
+Adicionar uma subseção NOVA em `docs/helm-chart-standard.md` formalizando a annotation `lerian.studio/compatibility`: gramática (api-design §I.2), opcionalidade de `requires` no v1, e exemplos válido/inválido (api-design §I.4). NÃO altera regras existentes do contrato. Paralela — pode rodar a qualquer momento após T-2 estabilizar a gramática.
+
+## Prerequisites
+```bash
+cd /home/gauchito/lerian/helm && test -f docs/helm-chart-standard.md && grep -c 'lerian.studio/chart-type' docs/helm-chart-standard.md
+```
+Saída esperada: o arquivo existe e retorna um número `>= 1` (a doc já menciona o precedente `chart-type`). Se o arquivo não existir, PARE e reporte ao orquestrador (path pode ter mudado).
+
+## Files
+- modify: `/home/gauchito/lerian/helm/docs/helm-chart-standard.md` (adicionar subseção ao final da seção de annotations)
+
+## Steps
+
+### Passo 1 — Localizar onde inserir (após a doc de `chart-type`)
+```bash
+cd /home/gauchito/lerian/helm && grep -n 'lerian.studio/chart-type' docs/helm-chart-standard.md
+```
+Saída esperada: número(s) de linha da menção existente. Insira a nova subseção logo APÓS o fim do bloco que documenta `chart-type` (próximo cabeçalho `##`/`###`).
+
+### Passo 2 — Inserir a subseção
+Adicione o seguinte trecho markdown na posição identificada (ajuste o nível de cabeçalho `###`/`####` para casar com a hierarquia local):
+```markdown
+### Annotation `lerian.studio/compatibility`
+
+Declara a compatibilidade cruzada e a combinação testada de um chart. É
+**opcional**: um chart sem esta annotation é tratado como "sem compatibilidade
+declarada" (a matriz mostra só a janela de suporte derivada, sem coluna
+"Requires").
+
+O valor é uma **string** contendo um documento YAML embutido (block scalar `|`),
+porque Helm exige `annotations` do tipo `map[string]string`.
+
+#### Gramática (v1)
+
+```
+compatibility := requires? testedWith?
+requires       := "requires:"   map<productKey, semverRange>   # OPCIONAL no v1
+testedWith     := "testedWith:" map<productKey, exactVersion>  # preenchido no v1
+productKey     := nome do chart publicado (ex.: "midaz-helm", "plugin-access-manager")
+semverRange    := constraint Masterminds (ex.: ">=8.4.0 <9.0.0", "~8.4", "^8.4.0", "8.x || 9.x")
+exactVersion   := versão semver exata (ex.: "8.6.0", "1.2.1-beta.11")
+```
+
+- `requires` pode ser omitido no v1 (relação técnica; quando presente, vira a
+  coluna "Requires <produto>" no README).
+- `testedWith` é a combinação validada no release (informativo). Derivável do
+  release; preenchido no v1.
+- Chaves desconhecidas são ignoradas com aviso (forward-compat aditiva).
+
+#### Exemplo — completo
+
+```yaml
+annotations:
+  lerian.studio/chart-type: multi-component
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: ">=8.4.0 <9.0.0"
+    testedWith:
+      midaz-helm: "8.6.0"
+```
+
+#### Exemplo — só `testedWith` (caso típico do v1)
+
+```yaml
+  lerian.studio/compatibility: |
+    testedWith:
+      midaz-helm: "8.6.0"
+```
+
+#### Exemplos inválidos (geram WARN, não bloqueiam no v1)
+
+```yaml
+# range não parseável (V4)
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm: "maior que 8"
+```
+
+```yaml
+# produto inexistente (V3)
+  lerian.studio/compatibility: |
+    requires:
+      midaz-ledger: ">=8.0.0"
+```
+
+```yaml
+# YAML quebrado — falta os dois-pontos (V1)
+  lerian.studio/compatibility: |
+    requires:
+      midaz-helm ">=8.4.0"
+```
+
+> **v1 é não-bloqueante:** violações V1–V5 são emitidas como `WARN` pela
+> ferramenta `generate-compatibility` (exit 0). A promoção a erro bloqueante é
+> fase futura (backlog TODO-4).
+```
+
+### Passo 3 — Conferir que não quebrou markdown existente
+```bash
+cd /home/gauchito/lerian/helm && grep -c '^### Annotation `lerian.studio/compatibility`' docs/helm-chart-standard.md
+```
+Saída esperada: `1` (a subseção foi inserida exatamente uma vez).
+
+## Verification (copiável)
+```bash
+cd /home/gauchito/lerian/helm && grep -q 'testedWith' docs/helm-chart-standard.md && grep -q 'block scalar' docs/helm-chart-standard.md && echo "ST-9-1_OK"
+```
+Saída esperada: `ST-9-1_OK`.
+
+## Rollback
+```bash
+cd /home/gauchito/lerian/helm && git checkout docs/helm-chart-standard.md
+```

--- a/docs/pre-dev/helm-version-compatibility-matrix/tasks.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/tasks.md
@@ -1,0 +1,143 @@
+# Task Breakdown — Matriz de Compatibilidade (v1)
+
+| | |
+|---|---|
+| gate | 7 — Task Breakdown |
+| date | 2026-07-22 |
+| confidence | 88 / 100 |
+| refs | todos os docs de `docs/pre-dev/helm-version-compatibility-matrix/` + `docs/PROJECT_RULES.md` |
+
+> **Regra transversal (DoD de toda tarefa):** seguir a estratégia de teste do **TRD §10** — nada vai pra `main` sem validação executiva. Risco #1 recorrente: **corromper o README de todos os charts de uma vez**. Toda tarefa que toca geração roda em **clone descartável** antes de qualquer commit real, e é **idempotente** (2× = mesmo byte).
+
+**Caminho crítico:** T-1 → T-2 → T-3 → (T-4 ‖ T-5) → T-6 → T-8. T-7 depende de T-6. T-9 é paralela.
+
+---
+
+## T-1 — Ferramenta gera JSON de versões (esqueleto executável)
+- **Deliverable:** binário `generate-compatibility` que roda, lê a versão atual (`Chart.yaml.version`) de todos os charts e emite um `compatibility.json` só com `current` por produto. Demoável: `go run ./generate-compatibility --root ../..` produz JSON válido.
+- **Scope inclui:** esqueleto CLI + `go.mod` add `Masterminds/semver/v3 v3.2.1` + iteração de charts (helper estilo `chartDirectories()`) + leitura de `version`. **Exclui:** annotation (T-2), janela (T-3), README (T-5).
+- **Success criteria:**
+  - `go build ./generate-compatibility` compila com Go 1.21.
+  - `go.sum` atualizado; `Masterminds/semver/v3` = **v3.2.1** exato (não v3.4+).
+  - Saída: JSON com `schemaVersion:1` + `products{<chart>:{dir,current}}` pra todos os ~21 charts.
+  - Determinístico: 2 execuções = bytes idênticos.
+- **Value:** técnico — base executável de que tudo depende.
+- **Deps:** Requires: —. Blocks: T-2,T-3,T-4.
+- **Effort:** S (3 pts, ~2d). **Risco:** baixo. **Teste:** unit (iteração/parse version) + rodar contra o repo real e inspecionar JSON.
+
+## T-2 — Ferramenta entende a annotation de compatibilidade
+- **Deliverable:** a ferramenta lê `lerian.studio/compatibility`, parseia `requires`/`testedWith` (two-step unmarshal) e reflete no JSON; annotation ausente/malformada → JSON válido + WARN.
+- **Scope inclui:** struct `CompatAnnotation`, two-step unmarshal, regras V1–V6 como WARN, campos `requires`/`testedWith` no JSON. **Exclui:** janela de suporte (T-3), validação bloqueante (backlog TODO-4).
+- **Success criteria:**
+  - Annotation válida completa → `requires`+`testedWith` no JSON do produto.
+  - Só `testedWith` → só ele aparece.
+  - Ausente → produto sem esses campos, sem erro.
+  - Malformada (YAML quebrado, range inválido, produto inexistente) → **WARN em stderr, exit 0**, JSON dos demais intacto.
+- **Value:** cliente/máquina passam a ver compatibilidade cruzada declarada.
+- **Deps:** Requires: T-1. Blocks: T-4,T-5.
+- **Effort:** M (5 pts, ~3d). **Risco:** médio (parsing frágil) → mitiga com table-driven cobrindo V1–V6.
+
+## T-3 — Ferramenta calcula a janela de suporte N..N-3
+- **Deliverable:** para cada produto, `cycles[]` ordenado desc com `cycle`/`latest`/`supported`, onde **N=Chart.yaml.version** e N-1..N-3 das tags git; degradação graciosa.
+- **Scope inclui:** derivação de tags (`<dir>-v*`), segregar pre-releases, agrupar por `Major().Minor()`, top-4 minors, `supported=false` p/ N-4+, casos 0/<4 tags. **Exclui:** datas de EOL (backlog TODO-5).
+- **Success criteria:**
+  - midaz (N=8.6.0) → cycles 8.6(sup)…8.3(sup), 8.2 e anteriores `supported:false`.
+  - Chart com 0 tags (br-spi) → só o ciclo N, sem erro (+INFO).
+  - Chart com <4 minors → só as existentes.
+  - Pre-release (`beta.11`) **não** vira ciclo próprio; ordena corretamente.
+  - **N nunca depende das tags** (fetch stale ⇒ janela parcial, nunca N errado).
+- **Value:** cliente vê exatamente o que está sob suporte.
+- **Deps:** Requires: T-1. Blocks: T-4,T-5.
+- **Effort:** M (8 pts, ~4d). **Risco:** médio-alto (semver/pre-release/tags removidas) → table-driven exaustivo é o coração do teste.
+
+## T-4 — `compatibility.json` completo e consumível
+- **Deliverable:** JSON final schemaVersion:1 unindo T-2+T-3 (products→cycles com requires/testedWith), **sem `tier`**, determinístico, gravado em `docs/compatibility.json`.
+- **Scope inclui:** serialização ordenada, `--output`, exemplo do data-model §B.4 reproduzível. **Exclui:** README (T-5), campos extras do console (backlog TODO-3).
+- **Success criteria:**
+  - JSON bate com o schema do data-model (B.1–B.3); **sem** campo `tier`.
+  - Chaves e arrays em ordem estável; 2× = idêntico.
+  - Valida contra um JSON Schema de referência (opcional mas recomendado).
+- **Value:** entrega a interface de máquina (US-5) — console/ferramentas podem consumir.
+- **Deps:** Requires: T-2,T-3. Blocks: T-8.
+- **Effort:** S (3 pts, ~2d). **Risco:** baixo.
+
+## T-5 — README mostra a matriz por produto (o entregável ao cliente)
+- **Deliverable:** bloco entre `<!-- BEGIN/END COMPAT:<chart> -->` no README de cada produto, tabela com badge de tier (🟢N…🔴EOL), coluna "Requer" quando declarada, EOL como linha-resumo. **É o valor visível ao cliente (US-1,US-2,US-4).**
+- **Scope inclui:** reuso de `tableutil`, markers idempotentes, respeitar boundaries irregulares (2–6 colunas; Matcher/BC Correios sem separador), **ADR-5: criar seção mínima p/ br-spi** (sem seção hoje). **Exclui:** edição de prosa existente.
+- **Success criteria:**
+  - Só o conteúdo entre markers muda; prosa/separadores intactos (diff review).
+  - Todos os ~21 charts (incl. br-spi) têm bloco COMPAT; 0 seções corrompidas.
+  - Idempotente (2× = mesmo README).
+  - Badges e coluna "Requer" corretos vs. o JSON.
+- **Value:** ⭐ o cliente lê e decide migração em segundos.
+- **Deps:** Requires: T-2,T-3. Blocks: T-8.
+- **Effort:** L (13 pts, ~1-2sem — é o mais arriscado). **Risco:** ALTO (corromper README em massa) → **obrigatório**: testar em clone descartável, golden-files por chart cobrindo os layouts irregulares, review de diff antes de qualquer commit.
+
+## T-6 — Modos de operação e verificação de drift
+- **Deliverable:** contrato CLI completo: `--write`(default)/`--check`/`--chart`/`--root`/`--output`, exit codes 0/1/2, mensagens WARN/INFO/ERROR estáveis. `--check` detecta drift sem escrever.
+- **Scope inclui:** parsing de flags, `--check` (gera em memória, compara, WARN+exit0), separação stdout/stderr, exit 1 (ambiente) / 2 (uso). **Exclui:** promover `--check` a bloqueante (backlog TODO-4).
+- **Success criteria:**
+  - `--check` em repo em dia → "ok" exit 0; com drift → WARN exit 0.
+  - `--write`+`--check` juntos → exit 2.
+  - `--root` inexistente → exit 1.
+  - `--chart X` → só toca o bloco de X (JSON regenera inteiro).
+- **Value:** CI ganha detecção de drift (espírito Ring) sem bloquear.
+- **Deps:** Requires: T-4,T-5. Blocks: T-8. Optional: T-7.
+- **Effort:** M (5 pts, ~3d). **Risco:** médio.
+
+## T-7 — Todos os produtos nascem com `testedWith` preenchido (backfill)
+- **Deliverable:** as ~21 annotations `lerian.studio/compatibility` recebem `testedWith` derivável do release atual; `requires` fica opcional/vazio (v1).
+- **Scope inclui:** preencher só o derivável, num **PR de teste** validado antes do real. **Exclui:** preencher `requires` (backlog TODO-1, via agent Ring no futuro).
+- **Success criteria:**
+  - 100% dos produtos ativos com `testedWith` (métrica M3).
+  - `generate-compatibility --check` verde após o backfill.
+  - Cada annotation é YAML válido (V1) e passa V2–V5.
+- **Value:** matriz nasce populada no dia 1 (não vazia).
+- **Deps:** Requires: T-6. Blocks: —.
+- **Effort:** M (5 pts, ~3d). **Risco:** médio (21 edições) → rodar `--check` antes de abrir PR.
+
+## T-8 — Geração automática no release (write-back 2B)
+- **Deliverable:** `release.yml` regenera e commita a matriz automaticamente ao publicar um chart; `helm-chart-standard.yml` roda `--check` como warning no PR.
+- **Scope inclui:** build do binário, `git fetch --tags --force`, **step dedicado 2B** pós-release (commit GPG reusando infra, `[skip ci]`, guard de actor, tratamento de 2 commits/rebase), add do path ao trigger do standard, scope no pr-title. **Exclui:** gate bloqueante.
+- **Success criteria:**
+  - Publicar um chart → README+JSON atualizados **automaticamente**, commit **GPG-verified**.
+  - Push do bot **NÃO** re-dispara o workflow (3 camadas comprovadas).
+  - `--check` aparece como warning no PR, não falha o build.
+  - **Validado sem push real primeiro** (TRD §10 passo 4: `--dry-run`, branch de teste).
+- **Value:** zero manutenção manual (US-3,US-4; métrica M2).
+- **Deps:** Requires: T-6 (e T-7 idealmente antes, p/ 1º commit já populado). Blocks: —.
+- **Effort:** M (8 pts, ~4d). **Risco:** ALTO (loop de CI / commit unverified / colisão de commits) → validação sem push real é DoD obrigatório.
+
+## T-9 — Contrato da annotation documentado (paralela)
+- **Deliverable:** subseção nova em `docs/helm-chart-standard.md` formalizando `lerian.studio/compatibility` (gramática, opcionalidade de `requires` no v1, exemplos válido/inválido do api-design §I.4).
+- **Success criteria:** dev consegue escrever uma annotation válida só lendo a doc; não altera regras existentes do contrato.
+- **Value:** dev sabe declarar sem adivinhar (mitiga erro manual até o agent Ring — TODO-1b).
+- **Deps:** Requires: T-2 (gramática estável). Blocks: —. **Effort:** S (2 pts, ~1d). **Risco:** baixo.
+
+---
+
+## Sequência de entrega
+| Fase | Tarefas | Entrega demoável |
+|---|---|---|
+| 1 | T-1 | JSON com versões atuais roda |
+| 2 | T-2, T-3 (paralelas após T-1) | JSON com compatibilidade + janela de suporte |
+| 3 | T-4 ‖ T-5 | JSON final + README visível ao cliente |
+| 4 | T-6 | modos --write/--check |
+| 5 | T-7 | matriz populada |
+| 6 | T-8 | automação no release |
+| ∥ | T-9 | doc (a qualquer momento após T-2) |
+
+---
+
+## Gate 7 — Validação
+| Categoria | Status |
+|---|---|
+| Todos os componentes do TRD (C-1..C-4) cobertos | ✅ (T-1..T-6) |
+| Toda tarefa entrega software funcionando/demoável | ✅ |
+| Nenhuma tarefa > 2 semanas | ✅ (max = T-5 L) |
+| Critérios de sucesso testáveis | ✅ |
+| Dependências mapeadas + caminho crítico | ✅ |
+| Estratégia de teste por tarefa (TRD §10) | ✅ |
+| Riscos + mitigação (T-5/T-8 alto risco cedo priorizados) | ✅ |
+
+**Resultado: ✅ PASS → Gate 8 (Subtasks)**

--- a/docs/pre-dev/helm-version-compatibility-matrix/tasks.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/tasks.md
@@ -62,13 +62,13 @@
 - **Effort:** S (3 pts, ~2d). **Risco:** baixo.
 
 ## T-5 — README mostra a matriz por produto (o entregável ao cliente)
-- **Deliverable:** bloco entre `<!-- BEGIN/END COMPAT:<chart> -->` no README de cada produto, tabela com badge de tier (🟢N…🔴EOL), coluna "Requer" quando declarada, EOL como linha-resumo. **É o valor visível ao cliente (US-1,US-2,US-4).**
+- **Deliverable:** bloco entre `<!-- BEGIN/END COMPAT:<chart> -->` no README de cada produto, tabela com badge de tier (🟢N…🔴EOL), coluna "Requires" quando declarada, EOL como linha-resumo. **É o valor visível ao cliente (US-1,US-2,US-4).**
 - **Scope inclui:** reuso de `tableutil`, markers idempotentes, respeitar boundaries irregulares (2–6 colunas; Matcher/BC Correios sem separador), **ADR-5: criar seção mínima p/ br-spi** (sem seção hoje). **Exclui:** edição de prosa existente.
 - **Success criteria:**
   - Só o conteúdo entre markers muda; prosa/separadores intactos (diff review).
   - Todos os ~21 charts (incl. br-spi) têm bloco COMPAT; 0 seções corrompidas.
   - Idempotente (2× = mesmo README).
-  - Badges e coluna "Requer" corretos vs. o JSON.
+  - Badges e coluna "Requires" corretos vs. o JSON.
 - **Value:** ⭐ o cliente lê e decide migração em segundos.
 - **Deps:** Requires: T-2,T-3. Blocks: T-8.
 - **Effort:** L (13 pts, ~1-2sem — é o mais arriscado). **Risco:** ALTO (corromper README em massa) → **obrigatório**: testar em clone descartável, golden-files por chart cobrindo os layouts irregulares, review de diff antes de qualquer commit.

--- a/docs/pre-dev/helm-version-compatibility-matrix/trd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/trd.md
@@ -90,8 +90,8 @@ annotations:
   lerian.studio/compatibility: |                   # NOVO — string YAML embutida
     requires:            # OPCIONAL no v1 — relação técnica (validada, vira coluna "Requires")
       midaz-helm: ">=8.4.0 <9.0.0"
-    testedWith:          # preenchido no v1 (derivável) — informativo
-      midaz-helm: "8.6.0"
+    # testedWith: NÃO usado no v1 (removido — ver BACKLOG). A ferramenta aceita
+    # o campo p/ forward-compat, mas ele volta só na v2, preenchido via E2E.
 ```
 - Chave em reverse-DNS namespaced (segue precedente `lerian.studio/chart-type`; alinhado a Artifact Hub).
 - Valores de `requires` são **ranges semver Masterminds** (`>=x <y`, `~`, `^`, `||`).

--- a/docs/pre-dev/helm-version-compatibility-matrix/trd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/trd.md
@@ -1,0 +1,222 @@
+# TRD — Matriz de Compatibilidade de Versões dos Charts (v1)
+
+## Metadata
+
+| Campo | Valor |
+|---|---|
+| feature | helm-version-compatibility-matrix |
+| gate | 3 — TRD |
+| date | 2026-07-22 |
+| deployment.model | CI/CD tooling (build-time; **não** é runtime/serviço) |
+| tech_stack.primary | Go (CLI/ferramental) |
+| tech_stack.standards_loaded | golang.md, devops.md |
+| project_rules | Ausente (`docs/PROJECT_RULES.md` não existe — repo de charts, não serviço). Gate 6 pode criar um mínimo se necessário. |
+| confidence | 86 / 100 (padrão existente no repo; complexidade moderada; risco baixo e mitigado) |
+
+> **Nota sobre abstração de tecnologia:** o gate TRD normalmente exige abstrair nomes de produto. Aqui a feature **é ferramental de build de um repositório concreto** — o "produto" é o próprio repo `LerianStudio/helm`, e o stack (Go, a lib `tableutil`, os workflows, a lib semver) já foi decidido com o usuário e ancorado no `research.md`. Abstrair "Go" para "linguagem compilada" seria teatro e prejudicaria a execução. Portanto este TRD **nomeia** as ferramentas do repo, mas mantém a disciplina do gate onde ela agrega: fronteiras de componente, contratos, ADRs, quality attributes e riscos. As **versões exatas** de dependências novas são formalizadas no Gate 6 (Dependency Map).
+
+Referências: [research.md](research.md) · [prd.md](prd.md) · [feature-map.md](feature-map.md)
+
+---
+
+## 1. Estilo Arquitetural
+
+**Ferramenta CLI determinística única (batch generator), no modelo das ferramentas irmãs já existentes em `.github/scripts/`.** Espelha `generate-values-schemas/main.go`: invocada com `--root ../..`, lê o estado do repo, escreve arquivos determinísticos, sem estado próprio nem rede (exceto tags git, já presentes no checkout).
+
+**Decisão-chave:** **não** estender `validate-helm-charts`. O research (Surpresa 1) mostrou que a tabela do README é produzida por ferramentas separadas (`update-chart-version-readme` + lib `tableutil`), não pelo validador. Portanto a nova capacidade vira uma **ferramenta irmã** — mantém responsabilidade única e não acopla geração a validação.
+
+---
+
+## 2. Componentes (fronteiras e responsabilidades)
+
+Novo diretório: `.github/scripts/generate-compatibility/` (`package main`), + reuso de `tableutil`. Componentes lógicos internos (mapeiam os domínios A→B→C→D do feature-map):
+
+### C-1 — Chart Reader (Domínio A)
+- **Responsabilidade:** iterar charts e ler o estado declarado.
+- **Entrada:** `--root`. Itera via helper equivalente a `chartDirectories()` (validate-helm-charts/main.go:292-307).
+- **Parse:** `gopkg.in/yaml.v3` (já no módulo). Struct própria lê `version`, `appVersion`, `annotations`, `dependencies`. O valor de `annotations["lerian.studio/compatibility"]` é **string YAML embutida** → **two-step unmarshal** (parse externo → pega string → `yaml.Unmarshal([]byte(raw), &compat)`).
+- **Saída:** `ChartState{ Name, Dir, Version(=N), AppVersion, Compat{requires, testedWith}, Deps }`.
+- **Owns:** interpretação do Chart.yaml. **Provides:** estado normalizado para C-2/C-3.
+
+### C-2 — Support Window Resolver (Domínio B)
+- **Responsabilidade:** classificar cada versão em Full/Security/Extended×2/EOL.
+- **Regra do N (decisão crítica):** `N = ChartState.Version` (do Chart.yaml, **autoridade absoluta**). `N-1..N-3` = as 3 minors distintas imediatamente inferiores, derivadas das **tags git** `<dir>-v<semver>` (filtro `<dir>-v*`).
+- **Processamento semver:** `Masterminds/semver/v3`. Segregar pre-releases (`-beta.N`) **antes** de computar minors; agrupar por `Major().Minor()`; ordenar via `semver.Collection`; pegar as top-4 minors distintas ≤ N. `requires`/ranges avaliados com `NewConstraint().Check()`.
+- **Degradação (FR-7):** `<4` minors → só as que existem; `0` tags → só a linha N (do Chart.yaml). Fetch de tags stale **nunca** altera N (NFR-3).
+- **Owns:** a política N..N-3. **Consumes:** C-1 + tags. **Provides:** `[]VersionRow{ version, minorCycle, tier, isEOL }`.
+
+### C-3 — Renderers (Domínio C)
+- **C-3a Markdown/README:** reusa `tableutil.ParseTableForChart`/`FormatTable`. Escreve **entre markers** `<!-- BEGIN COMPAT:<chart> -->` / `<!-- END COMPAT:<chart> -->` (padrão terraform-docs: só toca entre markers, idempotente). Tabela com badge de tier (🟢N 🔵N-1 🟡N-2 🟠N-3 🔴EOL), coluna "Requer &lt;produto&gt;" **só quando** `requires` declarado, EOL como **linha-resumo única**. Respeita boundaries irregulares (2–6 colunas; Matcher/BC Correios sem separador final; `br-spi` sem seção → **pula ou cria seção**, ver ADR-5).
+- **C-3b JSON:** escreve `docs/compatibility.json`, `schemaVersion: 1`, modelado em endoflife.date (linha por ciclo minor + campo de suporte). Determinístico (chaves ordenadas), espelha `generate-values-schemas`.
+- **Owns:** formato das saídas. **Consumes:** C-1+C-2. **Provides:** artefatos.
+
+### C-4 — Orchestration & Warnings (Domínio D)
+- **Modos:** `--write` (padrão, gera) e `--check` (drift: gera em memória, compara com o disco, **exit 0 + warning** se divergir — não falha no v1). Flags espelham as irmãs (`--root`, `--charts`, `--output` p/ JSON).
+- **Warnings (FR-6, não-bloqueante):** annotation malformada, `requires` apontando produto/range inexistente, drift. Emitidos em stderr como `WARN`, **exit 0** no v1. Nunca vira violação `--strict` do validador.
+- **Owns:** invocação e sinalização.
+
+---
+
+## 3. Fluxos de Dados
+
+**Geração (write) — no release:**
+```
+release.yml (chart X publicado)
+  → git fetch --tags --force            [garante histórico p/ N-1..N-3]
+  → generate-compatibility --write --charts X
+      C-1 lê Chart.yaml de X (+ N = version)
+      C-2 resolve janela (N do Chart.yaml, N-1..N-3 das tags)
+      C-3a reescreve bloco COMPAT:X no README.md (via tableutil, entre markers)
+      C-3b regenera docs/compatibility.json (todos os charts; determinístico)
+  → semantic-release commita [README.md, docs/compatibility.json] no release commit
+      (assets do @semantic-release/git; commit GPG; msg com [skip ci])
+```
+
+**Verificação (check) — no PR:**
+```
+helm-chart-standard.yml (PR toca charts/**)
+  → generate-compatibility --check
+      compara saída esperada vs. disco → WARN em drift (exit 0 no v1)
+```
+
+---
+
+## 4. Contrato da Annotation (interface pública — data model detalhado no Gate 5)
+
+`Chart.yaml`:
+```yaml
+annotations:
+  lerian.studio/chart-type: multi-component        # existente
+  lerian.studio/compatibility: |                   # NOVO — string YAML embutida
+    requires:            # OPCIONAL no v1 — relação técnica (validada, vira coluna "Requer")
+      midaz-helm: ">=8.4.0 <9.0.0"
+    testedWith:          # preenchido no v1 (derivável) — informativo
+      midaz-helm: "8.6.0"
+```
+- Chave em reverse-DNS namespaced (segue precedente `lerian.studio/chart-type`; alinhado a Artifact Hub).
+- Valores de `requires` são **ranges semver Masterminds** (`>=x <y`, `~`, `^`, `||`).
+- Ausência da annotation ou de `requires` é **válida** (v1): chart sem seção "Requer".
+
+---
+
+## 5. Write-back & Loop Prevention (integração CI)
+
+**Decisão do usuário: Opção 2B — step dedicado** (não pegar carona nos `assets` do semantic-release). Racional: separar responsabilidades, geração com vida própria (permite gatilhos futuros fora do release), mesmo custando mais YAML. A infra de GPG/token da pipe **é reutilizada**, não recriada.
+
+Step novo em `release.yml`, **após** o Semantic Release, que gera e commita a matriz por conta própria:
+- **Reusa** o App-token (`steps.app-token.outputs.token`) e a identidade/chave GPG CI já importadas no job (`crazy-max/ghaction-import-gpg`) — não reimportar.
+- Commit GPG-assinado (mantém commits *verified* — regra de git identity do usuário).
+- Bot: `lerian-studio-midaz-push-bot[bot]`.
+
+App-token **dispara CI** → **3 camadas anti-loop obrigatórias** no step:
+1. **`paths-ignore`** — `README.md` e `**/docs/**` já ignorados no trigger do release (`:8-14`) → escrever a matriz **não re-dispara**.
+2. **`[skip ci]`** na mensagem do commit gerado.
+3. **Guard de actor** — `if: github.actor != 'lerian-studio-midaz-push-bot[bot]'`.
+
+**Cuidado técnico (2B):** dois commits no mesmo release (o do semantic-release + este) → o step deve rodar `git pull --rebase` (ou commitar só se houver diff) antes do push pra evitar colisão. Testar esse encadeamento (ver §10).
+
+---
+
+## 6. Quality Attributes
+
+| Atributo | Alvo | Como |
+|---|---|---|
+| Idempotência (NFR-4) | 2 execuções = mesmo byte | markers + saída determinística (chaves/linhas ordenadas) |
+| Não-regressão (NFR-2) | 0 corrupção de conteúdo | escrita confinada entre markers via `tableutil`; testes de boundary irregular |
+| Confiabilidade do N (NFR-3) | 0 "N errado" | N vem do Chart.yaml, nunca das tags |
+| Determinismo | reprodutível offline | sem rede além de tags git locais |
+| Performance | trivial | ~21 charts; execução < 1s; não é caminho crítico |
+| Sem manutenção manual (NFR-1) | 0 edições manuais | conteúdo entre markers é sempre sobrescrito |
+
+**Testes (golang.md):** table-driven para C-2 (janela: casos 0/1/2/3/4+ minors, pre-releases, tags de charts removidos), C-3a (boundaries irregulares, chart sem seção, markers ausentes), parse de annotation malformada. Determinismo verificado rodando 2×.
+
+---
+
+## 7. ADRs
+
+**ADR-1: Auto-commit por bot vs. padrão Ring "humano commita".**
+- Contexto: devops.md do Ring proíbe auto-commit de artefatos gerados (humano roda `make generate` e commita; CI só valida). Mas o repo helm **já opera** com auto-commit via `@semantic-release/git` + push-bot no release.
+- Decisão: **seguir o padrão do repo** (auto-commit no release), não o do Ring, para esta feature. (Decisão 1 = A, confirmada pelo usuário.)
+- Rationale: a saída depende de `version`/tags que só existem no momento do release; exigir regeneração manual local reintroduz o drift que a feature elimina. O repo já resolveu loop-prevention para esse padrão (3 camadas).
+- Consequência: divergência consciente do standard, documentada. O modo `--check` (drift warning no PR) preserva o espírito Ring de "CI detecta desatualização" sem bloquear.
+
+**ADR-1b: Write-back via step dedicado (2B), não via assets do semantic-release (2A).**
+- Contexto: duas formas de commitar as saídas — somar aos `assets` do semantic-release (2A, ~4 linhas) ou um step próprio pós-release (2B, ~15 linhas).
+- Decisão: **2B — step dedicado** (confirmada pelo usuário), reusando token+GPG já existentes no job.
+- Rationale: separação de responsabilidades e geração com vida própria (habilita gatilhos futuros, ex. cron, fora do release), ao custo de mais YAML. GPG/token não são recriados, são reutilizados.
+- Consequência: precisa tratar 2 commits no mesmo release (rebase/commit-only-if-diff antes do push). Coberto por teste (§10).
+
+**ADR-2: Ferramenta irmã, não flag do validador.**
+- Contexto: validador ≠ gerador de README (Surpresa 1 do research).
+- Decisão: novo `generate-compatibility` no mesmo módulo Go, espelhando `generate-values-schemas`.
+- Consequência: responsabilidade única; validador segue `--strict`-puro; gerador nunca falha CI no v1.
+
+**ADR-3: N do Chart.yaml, histórico das tags.**
+- Contexto: tags locais estão atrás do Chart.yaml (Surpresa 2).
+- Decisão: N = `Chart.yaml.version`; N-1..N-3 = tags.
+- Consequência: janela sempre tem N correto mesmo com fetch incompleto; robustez > pureza.
+
+**ADR-4: v1 avisa, não bloqueia.**
+- Decisão: warnings em stderr, exit 0; nada entra em `--strict`.
+- Consequência: baseline de contrato segue vazio; CI não trava; gate bloqueante é fase futura.
+
+**ADR-5: Charts sem seção no README (ex.: `br-spi`).**
+- Contexto: 20 seções README vs 21 dirs.
+- Decisão: se não há `### <Nome>`, o gerador **cria** a seção mínima (título + bloco COMPAT entre markers) no lugar canônico; NÃO inventa dados fora dos markers.
+- Consequência: cobertura 100% dos produtos ativos (M3) sem editar prosa existente.
+
+---
+
+## 8. Riscos técnicos
+
+| Risco | Mitigação |
+|---|---|
+| `tableutil` não cobrir todos os layouts irregulares | testes por-chart de boundary antes do backfill; ADR-5 p/ seção ausente |
+| Ordenação semver errada em pre-releases | segregar pre-releases antes; lib Masterminds (não `sort -V`) |
+| Tag de chart removido poluir janela | filtro `<dir>-v*` + só considerar dirs existentes |
+| `git fetch --tags` falhar no CI | N vem do Chart.yaml (ADR-3) → degrada p/ janela parcial, não erro |
+| Loop de CI pelo bot | 3 camadas (ADR-1) |
+
+---
+
+## 9. Mudanças fora do código Go
+
+- `docs/helm-chart-standard.md`: **nova subseção** formalizando `lerian.studio/compatibility` (schema, opcionalidade de `requires` no v1). Não altera regras existentes.
+- `helm-chart-standard.yml`: adicionar step `generate-compatibility --check` (warning) e o path `.github/scripts/generate-compatibility/**` ao trigger.
+- `release.yml`: adicionar binário ao build + `git fetch --tags --force` + **step dedicado pós-release (2B)** que gera e commita (README + `docs/compatibility.json`) reusando token/GPG do job, com as 3 camadas anti-loop e tratamento de 2 commits.
+- `pr-title.yml`: garantir scope permitido para os PRs desta entrega (ex.: `charts`/`ci`/`doc`).
+- `go.mod`: adicionar `Masterminds/semver/v3` (versão exata no Gate 6).
+
+---
+
+## 10. Estratégia de Teste ANTES do commit real (lembrete do usuário :D)
+
+⚠️ **Regra dura: nada de push "de verdade" sem validar executivamente primeiro.** O maior risco desta feature é o gerador **corromper o README** de todos os charts de uma vez, ou o step de write-back gerar loop/commit unverified. Ordem de validação, do mais barato ao mais arriscado:
+
+1. **Unit (Go, offline):** `go test ./...` no módulo — table-driven para C-2 (janela) e C-3a (boundaries irregulares). Cobre a lógica sem tocar git/CI.
+2. **Dry-run local do gerador:** rodar `generate-compatibility --write` num **clone descartável** e inspecionar o `git diff` do README + JSON. Confirmar: (a) só o conteúdo entre markers muda; (b) prosa e separadores irregulares intactos; (c) `br-spi` ganha seção (ADR-5); (d) roda 2× = diff idêntico (idempotência).
+3. **Modo `--check`:** rodar contra o repo real e confirmar que aponta drift corretamente **sem escrever nada**.
+4. **Write-back (o mais arriscado):** validar o step 2B **sem push real** primeiro —
+   - testar o encadeamento "semantic-release commit + nosso commit" num fork/branch de teste ou com `git push --dry-run`;
+   - confirmar commit **GPG-verified** (não unverified);
+   - confirmar que o `[skip ci]` + guard de actor realmente impedem o re-trigger (observar que o push do bot NÃO dispara novo run).
+5. **Backfill:** aplicar `testedWith` nas ~21 annotations em **um PR de teste** e rodar o `helm-chart-standard.yml --check` antes de abrir o PR real.
+
+Só depois de 1–5 verdes é que o fluxo vai para a `main`. (Alinhado a [[feedback_test_changed_artifacts]] e [[feedback_ask_before_push]].)
+
+## Gate 3 — Validação
+
+| Categoria | Status |
+|---|---|
+| Todos os domínios do feature-map mapeados p/ componentes (A→C-1, B→C-2, C→C-3, D→C-4) | ✅ |
+| Fronteiras de componente claras, responsabilidade única | ✅ |
+| Contratos definidos (annotation, VersionRow, JSON schemaVersion) | ✅ |
+| Data ownership explícito (C-1 dono do Chart.yaml, C-2 dona da política) | ✅ |
+| Quality attributes atingíveis com alvos | ✅ |
+| Integração CI + loop-prevention endereçada | ✅ |
+| ADRs para as 3 surpresas + divergência de standard | ✅ (ADR-1..5) |
+| Sem pendências de correctness (N, boundaries, degradação) | ✅ |
+
+**Resultado: ✅ PASS → Gate 4 (API Design)**
+
+> **PAUSA PARA REVISÃO DO USUÁRIO** (conforme opção 2 escolhida). Gates 4–8 são mais mecânicos dado este TRD.

--- a/docs/pre-dev/helm-version-compatibility-matrix/trd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/trd.md
@@ -10,7 +10,7 @@
 | deployment.model | CI/CD tooling (build-time; **não** é runtime/serviço) |
 | tech_stack.primary | Go (CLI/ferramental) |
 | tech_stack.standards_loaded | golang.md, devops.md |
-| project_rules | Ausente (`docs/PROJECT_RULES.md` não existe — repo de charts, não serviço). Gate 6 pode criar um mínimo se necessário. |
+| project_rules | `docs/PROJECT_RULES.md` (criado no Gate 6 — mínimo, escopado ao ferramental; repo de charts, não serviço). |
 | confidence | 86 / 100 (padrão existente no repo; complexidade moderada; risco baixo e mitigado) |
 
 > **Nota sobre abstração de tecnologia:** o gate TRD normalmente exige abstrair nomes de produto. Aqui a feature **é ferramental de build de um repositório concreto** — o "produto" é o próprio repo `LerianStudio/helm`, e o stack (Go, a lib `tableutil`, os workflows, a lib semver) já foi decidido com o usuário e ancorado no `research.md`. Abstrair "Go" para "linguagem compilada" seria teatro e prejudicaria a execução. Portanto este TRD **nomeia** as ferramentas do repo, mas mantém a disciplina do gate onde ela agrega: fronteiras de componente, contratos, ADRs, quality attributes e riscos. As **versões exatas** de dependências novas são formalizadas no Gate 6 (Dependency Map).
@@ -101,19 +101,17 @@ annotations:
 
 ## 5. Write-back & Loop Prevention (integração CI)
 
-**Decisão do usuário: Opção 2B — step dedicado** (não pegar carona nos `assets` do semantic-release). Racional: separar responsabilidades, geração com vida própria (permite gatilhos futuros fora do release), mesmo custando mais YAML. A infra de GPG/token da pipe **é reutilizada**, não recriada.
+**DECISÃO FINAL: Opção 2A — commit único via `@semantic-release/git`** (revisão posterior à 2B; ver ADR-1b atualizado). Motivo da mudança: a 2B geraria **dois commits** no mesmo release (o do semantic-release + o do step dedicado), com risco real de colisão no push. A 2A elimina isso — a geração pega carona no commit que o release **já faz**.
 
-Step novo em `release.yml`, **após** o Semantic Release, que gera e commita a matriz por conta própria:
-- **Reusa** o App-token (`steps.app-token.outputs.token`) e a identidade/chave GPG CI já importadas no job (`crazy-max/ghaction-import-gpg`) — não reimportar.
-- Commit GPG-assinado (mantém commits *verified* — regra de git identity do usuário).
-- Bot: `lerian-studio-midaz-push-bot[bot]`.
+Como foi implementado em `release.yml`:
+- No `prepareCmd` do semantic-release, `generate-compatibility --root . --chart $COMPAT_CHART --write` **substitui** a antiga `update-chart-version-readme` (que fazia um subconjunto — só a versão atual). Nossa ferramenta faz tudo que ela fazia + a matriz.
+- `docs/compatibility.json` é adicionado aos `assets` do `@semantic-release/git`, junto de `Chart.yaml` e `README.md` → **um único commit** de release carrega os três.
+- Step `git fetch --tags --force` antes, para o histórico N-1..N-3 e as datas Released.
+- Commit é o do semantic-release: já **GPG-assinado** (verified) e com `[skip ci]`.
 
-App-token **dispara CI** → **3 camadas anti-loop obrigatórias** no step:
-1. **`paths-ignore`** — `README.md` e `**/docs/**` já ignorados no trigger do release (`:8-14`) → escrever a matriz **não re-dispara**.
-2. **`[skip ci]`** na mensagem do commit gerado.
-3. **Guard de actor** — `if: github.actor != 'lerian-studio-midaz-push-bot[bot]'`.
+Anti-loop (mantido, agora herdado do mecanismo existente): `paths-ignore` (`README.md`, `**/docs/**`), `[skip ci]` no commit do release, e o guard de actor `github.actor != 'lerian-studio-midaz-push-bot[bot]'`. **Sem segundo commit → sem risco de colisão.**
 
-**Cuidado técnico (2B):** dois commits no mesmo release (o do semantic-release + este) → o step deve rodar `git pull --rebase` (ou commitar só se houver diff) antes do push pra evitar colisão. Testar esse encadeamento (ver §10).
+O `--check` (drift) roda no PR via `helm-chart-standard.yml`, não-bloqueante.
 
 ---
 
@@ -140,11 +138,12 @@ App-token **dispara CI** → **3 camadas anti-loop obrigatórias** no step:
 - Rationale: a saída depende de `version`/tags que só existem no momento do release; exigir regeneração manual local reintroduz o drift que a feature elimina. O repo já resolveu loop-prevention para esse padrão (3 camadas).
 - Consequência: divergência consciente do standard, documentada. O modo `--check` (drift warning no PR) preserva o espírito Ring de "CI detecta desatualização" sem bloquear.
 
-**ADR-1b: Write-back via step dedicado (2B), não via assets do semantic-release (2A).**
+**ADR-1b: Write-back via commit único do semantic-release (2A) — REVISADO de 2B para 2A.**
 - Contexto: duas formas de commitar as saídas — somar aos `assets` do semantic-release (2A, ~4 linhas) ou um step próprio pós-release (2B, ~15 linhas).
-- Decisão: **2B — step dedicado** (confirmada pelo usuário), reusando token+GPG já existentes no job.
-- Rationale: separação de responsabilidades e geração com vida própria (habilita gatilhos futuros, ex. cron, fora do release), ao custo de mais YAML. GPG/token não são recriados, são reutilizados.
-- Consequência: precisa tratar 2 commits no mesmo release (rebase/commit-only-if-diff antes do push). Coberto por teste (§10).
+- Decisão inicial (2B) foi **revertida**: ao implementar, ficou claro que 2B gera **dois commits** no mesmo release (semantic-release + step dedicado) com risco real de colisão no push. Isso pesou mais que o ganho de "separação de responsabilidades".
+- **Decisão final: 2A** — `generate-compatibility` roda no `prepareCmd` (substituindo `update-chart-version-readme`) e `docs/compatibility.json` entra nos `assets`. **Um commit só**, o que o release já fazia.
+- Rationale: elimina a colisão de dois commits; menos YAML; herda GPG + `[skip ci]` + anti-loop já existentes. A flexibilidade da 2B (gatilhos fora do release) era teórica e sem uso no v1 — reintroduzível depois se necessário.
+- Consequência: a geração fica acoplada ao ciclo do semantic-release (aceitável). A ferramenta-irmã `update-chart-version-readme` deixa de ser chamada no release (nossa faz superconjunto).
 
 **ADR-2: Ferramenta irmã, não flag do validador.**
 - Contexto: validador ≠ gerador de README (Surpresa 1 do research).

--- a/docs/pre-dev/helm-version-compatibility-matrix/trd.md
+++ b/docs/pre-dev/helm-version-compatibility-matrix/trd.md
@@ -46,7 +46,7 @@ Novo diretório: `.github/scripts/generate-compatibility/` (`package main`), + r
 - **Owns:** a política N..N-3. **Consumes:** C-1 + tags. **Provides:** `[]VersionRow{ version, minorCycle, tier, isEOL }`.
 
 ### C-3 — Renderers (Domínio C)
-- **C-3a Markdown/README:** reusa `tableutil.ParseTableForChart`/`FormatTable`. Escreve **entre markers** `<!-- BEGIN COMPAT:<chart> -->` / `<!-- END COMPAT:<chart> -->` (padrão terraform-docs: só toca entre markers, idempotente). Tabela com badge de tier (🟢N 🔵N-1 🟡N-2 🟠N-3 🔴EOL), coluna "Requer &lt;produto&gt;" **só quando** `requires` declarado, EOL como **linha-resumo única**. Respeita boundaries irregulares (2–6 colunas; Matcher/BC Correios sem separador final; `br-spi` sem seção → **pula ou cria seção**, ver ADR-5).
+- **C-3a Markdown/README:** reusa `tableutil.ParseTableForChart`/`FormatTable`. Escreve **entre markers** `<!-- BEGIN COMPAT:<chart> -->` / `<!-- END COMPAT:<chart> -->` (padrão terraform-docs: só toca entre markers, idempotente). Tabela com badge de tier (🟢N 🔵N-1 🟡N-2 🟠N-3 🔴EOL), coluna "Requires &lt;produto&gt;" **só quando** `requires` declarado, EOL como **linha-resumo única**. Respeita boundaries irregulares (2–6 colunas; Matcher/BC Correios sem separador final; `br-spi` sem seção → **pula ou cria seção**, ver ADR-5).
 - **C-3b JSON:** escreve `docs/compatibility.json`, `schemaVersion: 1`, modelado em endoflife.date (linha por ciclo minor + campo de suporte). Determinístico (chaves ordenadas), espelha `generate-values-schemas`.
 - **Owns:** formato das saídas. **Consumes:** C-1+C-2. **Provides:** artefatos.
 
@@ -88,14 +88,14 @@ helm-chart-standard.yml (PR toca charts/**)
 annotations:
   lerian.studio/chart-type: multi-component        # existente
   lerian.studio/compatibility: |                   # NOVO — string YAML embutida
-    requires:            # OPCIONAL no v1 — relação técnica (validada, vira coluna "Requer")
+    requires:            # OPCIONAL no v1 — relação técnica (validada, vira coluna "Requires")
       midaz-helm: ">=8.4.0 <9.0.0"
     testedWith:          # preenchido no v1 (derivável) — informativo
       midaz-helm: "8.6.0"
 ```
 - Chave em reverse-DNS namespaced (segue precedente `lerian.studio/chart-type`; alinhado a Artifact Hub).
 - Valores de `requires` são **ranges semver Masterminds** (`>=x <y`, `~`, `^`, `||`).
-- Ausência da annotation ou de `requires` é **válida** (v1): chart sem seção "Requer".
+- Ausência da annotation ou de `requires` é **válida** (v1): chart sem seção "Requires".
 
 ---
 


### PR DESCRIPTION
## O que é

Automação da **matriz de compatibilidade de versões** dos Helm charts. Gera, por chart, uma tabela de suporte (janela N..N-3 seguindo o contrato LTS) no README + um `docs/compatibility.json` legível por máquina — tudo derivado automaticamente, sem manutenção manual.

**Piloto:** apenas o chart `tracer` foi onboardado nesta entrega (single-service, valida o fluxo de ponta a ponta). Os demais charts seguem inalterados até serem migrados.

## Como fica no README

A ferramenta **enriquece a tabela `#### Application Version Mapping` que já existe** (substitui in-place, entre marcadores `<!-- BEGIN/END COMPAT -->`), sem duplicar nem tocar a prosa ao redor.

### Antes (só a versão atual)

```
| Chart Version | Tracer Version |
| :---: | :---: |
| `2.1.0` | 1.0.0 |
```

### Depois (janela de suporte N..N-3 + datas)

| Chart Version | Tracer Version | Released | Support |
| :---: | :---: | :---: | :---: |
| `2.1.0` | 1.0.0 | 2026-06-18 | 🟢 Full (N) |
| `2.0.0` | — | 2026-06-09 | 🔵 Security (N-1) |
| `1.0.0` | — | 2026-01-30 | 🟡 Extended (N-2) |

### Exemplo com dependência declarada (potencial da coluna "Requires")

Quando um chart declara `requires` na annotation `lerian.studio/compatibility`, a tabela ganha uma coluna **por dependência**. Ex. de um `plugin-fees` que dependesse de `midaz` e `plugin-access-manager`:

| Chart Version | Fees Version | UI Version | Released | Support | Requires midaz-helm | Requires plugin-access-manager |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| `7.2.0` | 3.3.0 | — | 2026-07-17 | 🟢 Full (N) | >=8.4.0 <9.0.0 | >=8.0.0 <9.0.0 |
| `7.1.0` | — | — | 2026-07-08 | 🔵 Security (N-1) | — | — |
| `≤ 5.4.0` | — | — | — | 🔴 EOL | — | — |

> Anotação que o dev escreve para o caso acima:
> ```yaml
> annotations:
>   lerian.studio/chart-type: multi-component
>   lerian.studio/compatibility: |
>     requires:
>       midaz-helm: ">=8.4.0 <9.0.0"
>       plugin-access-manager: ">=8.0.0 <9.0.0"
> ```
> No v1 nenhum chart declara `requires` ainda → a coluna "Requires" nasce ausente e é preenchida gradualmente pelos devs (e via testes E2E na v2).

## Colunas

- **Support**: janela derivada de `Chart.yaml.version` (N autoritativo) + tags git (N-1..N-3). Vale para todos os charts, automático.
- **Released**: data da tag git (`creatordate`).
- **<App> Version**: lida de `{componente}.image.tag` no `values.yaml` (só a linha N; históricas ficam `—`).
- **Requires <produto>**: só aparece quando o chart declara `requires`.

## Mudanças

- **`.github/scripts/generate-compatibility/`**: nova ferramenta Go (espelha `generate-values-schemas`). Adiciona `Masterminds/semver/v3 v3.2.1` (piso Go 1.21).
- **`tableutil/appversions.go`**: extração de app-version por `{componente}.image.tag` **compartilhada** com `update-chart-version-readme` (dedup).
- **`release.yml`**: no `prepareCmd` do semantic-release, `generate-compatibility` **substitui** `update-chart-version-readme`; adiciona `git fetch --tags` e o `docs/compatibility.json` aos assets → **commit único** do release (sem 2º commit, sem loop de CI).
- **`helm-chart-standard.yml`**: step `--check` de drift **não-bloqueante** no PR.
- **`docs/pre-dev/`**: planejamento Ring completo (research→subtasks) + BACKLOG (itens v2: preenchimento de `requires` via agent/E2E, visibilidade de WARN, datas de EOL).

## Validado

- `go test` verde (generate-compatibility + tableutil); idempotente (2× = mesmo byte); substituição da tabela in-place sem duplicar.
- Corretude da janela: N vem do Chart.yaml (tags beta acima de N descartadas); degradação graciosa para charts com <4 minors ou 0 tags.
- `prepareCmd` simulado da raiz + commit dos assets em dry-run.
- **RISCO-A descartado por teste**: o shared-workflow `app-sync` só faz `yq -i .appVersion` — a annotation de compatibilidade sobrevive (diff provou byte-idêntico).

## Ressalvas / atenção no merge

- Abrir o PR **não** dispara release; o `helm-chart-standard.yml --check` é não-bloqueante.
- O comportamento real do `semantic-release` (orquestração de plugins) só se confirma no **primeiro release após o merge** — vale acompanhar. Se o `prepareCmd` falhar, o release aborta antes de commitar (erro visível e reversível, não corrompe nada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


