### PR TITLE
fix(midaz): tracer migrations use dedicated image, not app image

### DIFF
--- a/charts/midaz/values.yaml
+++ b/charts/midaz/values.yaml
@@ -564,8 +564,11 @@ tracer:
     # -- Enable or disable the tracer migrations PreSync Job
     enabled: true
     image:
-      # -- Repository for the tracer migrations image
-      repository: ghcr.io/lerianstudio/midaz-tracer
+      # -- Repository for the tracer migrations image (dedicated migration
+      # binary, NOT the app image -- the app image has no migration command
+      # and would run its full HTTP server/workers until activeDeadlineSeconds
+      # kills it, never completing the Job)
+      repository: ghcr.io/lerianstudio/midaz-tracer-migrations
       # -- Image tag (populated by the release pipeline via gitops_yaml_key_mappings;
       #    falls back to .Chart.AppVersion when empty)
       tag: ""


### PR DESCRIPTION
## Root cause

`tracer.migrations.image.repository` pointed at `ghcr.io/lerianstudio/midaz-tracer` -- the FULL app image (PR #1751 fixed the missing `midaz-` prefix, but not the fact it's still the wrong image). That image has no migration-only entrypoint: it boots the complete tracer HTTP server + rule sync worker and never exits. Confirmed live in `anacleto-midaz-chaos-dev-st`/`anacleto-midaz-fuzzing-dev-st` after merging #1751 + bumping the alpha -- the migrate Job stayed `Running` (app fully booted, logs show `starting HTTP server`) until `activeDeadlineSeconds` (300s) killed it, ArgoCD recreated it, and it looped forever.

## Fix

`tracer.migrations.image.repository` -> `ghcr.io/lerianstudio/midaz-tracer-migrations`, the dedicated migrations binary.

This matches what L. Bedatty already had configured for benedita/dev-st (`environments/benedita/helmfile/applications/dev-st/midaz/values.yaml`, commit 588c47220) -- the chart default was just never aligned with that.

## Verification

- Confirmed `ghcr.io/lerianstudio/midaz-tracer-migrations:4.0.0-beta.13` exists and is pullable with the existing `ghcr-credential` secret: spun up a throwaway pod in `midaz-chaos-dev-st`, pulled successfully in ~8s, deleted immediately after.
- `helm template charts/midaz -f .github/configs/helm-render-values/midaz.yaml --set-string tracer.enabled=true --set-string tracer.migrations.enabled=true` -> `image: ghcr.io/lerianstudio/midaz-tracer-migrations:3.8.0`

## Scope

Stacked on `fix/tracer-ledger-pdb-migration-job-selector-collision` (carries every fix since Fri 24/07 through #1751, merged 27/07 14:49) -- an alpha built from this branch includes all of it. No merge performed; alpha to be generated manually as before.

Requested by: @fredcamaral