### PR TITLE
fix(midaz): align RabbitMQ seed definitions with ledger queue/exchange names

### DIFF
--- a/charts/midaz/files/rabbitmq/load_definitions.json
+++ b/charts/midaz/files/rabbitmq/load_definitions.json
@@ -54,7 +54,7 @@
       "durable": true
     },
     {
-      "name": "transaction.transaction_balance_operation.queue",
+      "name": "transaction.transaction_balance_operation.ledger.queue",
       "vhost": "/",
       "durable": true
     }
@@ -67,7 +67,7 @@
       "durable": true
     },
     {
-      "name": "transaction.transaction_balance_operation.exchange",
+      "name": "transaction.transaction_balance_operation.ledger.exchange",
       "vhost": "/",
       "type": "direct",
       "durable": true
@@ -88,11 +88,11 @@
       "routing_key": "transaction.balance_create.key"
     },
     {
-      "source": "transaction.transaction_balance_operation.exchange",
+      "source": "transaction.transaction_balance_operation.ledger.exchange",
       "vhost": "/",
-      "destination": "transaction.transaction_balance_operation.queue",
+      "destination": "transaction.transaction_balance_operation.ledger.queue",
       "destination_type": "queue",
-      "routing_key": "transaction.transaction_balance_operation.key"
+      "routing_key": "transaction.transaction_balance_operation.ledger.key"
     }
   ]
 }


### PR DESCRIPTION
## Root cause

`charts/midaz/files/rabbitmq/load_definitions.json` (loaded at RabbitMQ boot via `management.load_definitions`) creates:
- `transaction.transaction_balance_operation.queue`
- `transaction.transaction_balance_operation.exchange`
- routing key `transaction.transaction_balance_operation.key`

But the ledger ConfigMap (`RABBITMQ_TRANSACTION_BALANCE_OPERATION_*`, set in every environment's `values.yaml` -- benedita, anacleto/chaos, anacleto/fuzzing) expects the `.ledger.` segment:
- `transaction.transaction_balance_operation.ledger.queue`
- `transaction.transaction_balance_operation.ledger.exchange`
- routing key `transaction.transaction_balance_operation.ledger.key`

Confirmed live in `anacleto-midaz-chaos-dev-st` / `anacleto-midaz-fuzzing-dev-st`: the queue/exchange the ledger is configured to use does not exist on the broker at all under that name (seed never created it). This explains the `404 NOT_FOUND` previously seen on the chaos environment's consumer.

## Timeline (git-archaeology)

- `2025-01-20` (`8768a8e1`) -- `load_definitions.json` created in this chart with the queue/exchange names WITHOUT `.ledger.`
- `2025-02-20` (`167c80a8`) -- last touch to this file, name still without `.ledger.`
- `2026-01-14` -- `lerian-internal-gitops` commit `e4af0d497` (environments/firmino/helmfile/applications/dev/midaz/values.yaml) adds the ledger ConfigMap keys WITH `.ledger.`, enabling `RABBITMQ_TRANSACTION_ASYNC`. That naming was mirrored into every descendant environment (benedita, anacleto chaos/fuzzing) but `load_definitions.json` here was never updated to match.
- The two names have been out of sync for ~6 months. It only surfaced as a visible failure now because the ledger previously never got far enough in these environments to exercise this queue (blocked by the tracer/ledger migrate Job issues fixed earlier in this branch).

## Fix

Renamed queue, exchange, and routing key in `load_definitions.json` to include `.ledger.`, matching the ledger ConfigMap exactly.

## Verification

`helm template charts/midaz -f .github/configs/helm-render-values/midaz.yaml --show-only templates/rabbitmq_load_definitions.yaml`, decoded the rendered Secret's `load_definition.json` -- all three RabbitMQ objects (queue, exchange, binding routing key) now carry `.ledger.`, matching the ledger ConfigMap.

`helm lint` -- 0 charts failed.

## Scope

Stacked on `fix/tracer-ledger-pdb-migration-job-selector-collision` (`e358baac` -- carries every fix through PR #1753) so an alpha built from this branch includes all prior fixes plus this one. No merge performed; alpha to be generated manually as before.

Requested by: @fredcamaral