### PR TITLE
fix(common): default SD_TLS_SKIP_VERIFY to false

### DIFF
--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -53,7 +53,7 @@ global.serviceDiscovery (all optional except address when enabled):
    would produce a duplicate key. This helper only adds the derived siblings. */ -}}
 SD_ADDRESS: {{ $sd.address | quote }}
 SD_TLS: {{ $sd.tls | default false | quote }}
-SD_TLS_SKIP_VERIFY: {{ $sd.tlsSkipVerify | default true | quote }}
+SD_TLS_SKIP_VERIFY: {{ $sd.tlsSkipVerify | default false | quote }}
 SD_WORKLOAD: {{ $sd.workload | default "" | quote }}
 SD_PREFER_VIEW: {{ $sd.preferView | default "internal" | quote }}
 SD_INTERNAL_ADDRESS: {{ include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace) | quote }}


### PR DESCRIPTION
## What

Changes the `serviceDiscovery` helper default for `SD_TLS_SKIP_VERIFY` from `true` to `false` in `charts/lerian-common/templates/_service_discovery.tpl`, and bumps `lerian-common-helm` to `1.2.1`.

## Why

With `| default true`, any consumer that enables service-discovery TLS **without** explicitly overriding `tlsSkipVerify` gets `SD_TLS_SKIP_VERIFY=true`, silently disabling certificate verification (MITM risk). Worse, sprig's `default` treats an explicit `false` as empty, so even a consumer that sets `tlsSkipVerify: false` still rendered `true`.

Now verification is on by default; operators who intentionally skip it must set `tlsSkipVerify: true` explicitly.

## Context

Split out of #1741 (midaz productization) per the repo policy of scoping `lerian-common` changes to their own PR. The midaz PR sets `serviceDiscovery.tlsSkipVerify: false` in its values; that becomes effective once this merges and #1741 rebases. midaz is currently the only consumer of `serviceDiscovery.env` (none on main), so the blast radius is limited.

## Backward compatibility

Consumers already setting `tlsSkipVerify: true` are unaffected. Only the implicit default changes.