### PR TITLE
fix(pipe): render-gate resolves file:// local chart dependencies

### DIFF
--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -1101,6 +1101,16 @@ func buildRenderRows(root string, chartSelection map[string]bool, sampleValuesDi
 			return nil, err
 		}
 
+		// Local library dependencies referenced via `file://<relpath>` (e.g.
+		// lerian-common) live outside the copied chart, so `helm dependency
+		// build` cannot resolve them in the isolated temp workspace. Materialize
+		// each such sibling at the same relative location so the file:// path
+		// resolves exactly as it does in the source tree.
+		if err := materializeLocalDependencies(root, chartDir, tmpRoot, tmpChart, deps); err != nil {
+			_ = os.RemoveAll(tmpRoot)
+			return nil, err
+		}
+
 		helmEnv, err := isolatedHelmEnv(tmpRoot)
 		if err != nil {
 			_ = os.RemoveAll(tmpRoot)
@@ -1515,6 +1525,51 @@ func writeRenderInventory(path string, rows []renderRow) error {
 		return err
 	}
 	return os.WriteFile(path, []byte(builder.String()), 0o644)
+}
+
+// materializeLocalDependencies copies each `file://<relpath>` dependency source
+// into the temp workspace at the same relative path the chart references, so an
+// isolated `helm dependency build` resolves local library charts (e.g.
+// lerian-common) exactly as it would in the repository tree. Missing sources are
+// left to `helm dependency build` to report as a normal missing-dependency.
+func materializeLocalDependencies(root, chartDir, tmpRoot, tmpChart string, deps []chartDependency) error {
+	for _, dependency := range deps {
+		repository := strings.TrimSpace(dependency.Repository)
+		if !strings.HasPrefix(repository, "file://") {
+			continue
+		}
+		relPath := strings.TrimPrefix(repository, "file://")
+		srcDir := filepath.Clean(filepath.Join(chartDir, relPath))
+		// Containment: a crafted `file://../../..` path in Chart.yaml must not let
+		// the copy read outside the repository tree or write outside the isolated
+		// render workspace. Legitimate local libraries (e.g. file://../lerian-common)
+		// still resolve to a sibling under root/tmpRoot and pass the check.
+		if !withinDir(root, srcDir) {
+			return fmt.Errorf("local dependency %q resolves outside the repository root (%s)", repository, srcDir)
+		}
+		if !dirExists(srcDir) {
+			continue
+		}
+		destDir := filepath.Clean(filepath.Join(tmpChart, relPath))
+		if !withinDir(tmpRoot, destDir) {
+			return fmt.Errorf("local dependency %q resolves outside the render workspace (%s)", repository, destDir)
+		}
+		if err := copyDir(srcDir, destDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// withinDir reports whether target is base itself or nested under it (after path
+// cleaning), used to contain `file://` dependency paths so a crafted Chart.yaml
+// cannot escape the repo/workspace via `..` traversal.
+func withinDir(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 func copyDir(src, dst string) error {

--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -1539,6 +1539,13 @@ func materializeLocalDependencies(root, chartDir, tmpRoot, tmpChart string, deps
 			continue
 		}
 		relPath := strings.TrimPrefix(repository, "file://")
+		// Reject absolute paths (e.g. file:///tmp/lib → "/tmp/lib"): Helm resolves
+		// them verbatim at render time, escaping the repo, whereas filepath.Join
+		// below would fold the leading slash and pass the containment check — a
+		// mismatch that would let an absolute dependency read outside root.
+		if filepath.IsAbs(relPath) {
+			return fmt.Errorf("local dependency %q uses an absolute path, which is not supported", repository)
+		}
 		srcDir := filepath.Clean(filepath.Join(chartDir, relPath))
 		// Containment: a crafted `file://../../..` path in Chart.yaml must not let
 		// the copy read outside the repository tree or write outside the isolated

--- a/.github/scripts/validate-helm-charts/main_test.go
+++ b/.github/scripts/validate-helm-charts/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A file:///tmp/lib dependency yields an absolute relPath ("/tmp/lib"). Helm
+// resolves it verbatim at render time (outside the repo), so it must be rejected
+// before the containment check — which filepath.Join would otherwise let pass by
+// folding the leading slash into chartDir.
+func TestMaterializeLocalDependencies_RejectsAbsolutePath(t *testing.T) {
+	deps := []chartDependency{{Name: "lib", Repository: "file:///tmp/lib"}}
+	err := materializeLocalDependencies("/repo", "/repo/charts/x", "/tmp/render", "/tmp/render/x", deps)
+	if err == nil {
+		t.Fatal("expected error for absolute file:// dependency, got nil")
+	}
+	if !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("expected absolute-path error, got: %v", err)
+	}
+}
+
+func TestWithinDir(t *testing.T) {
+	cases := []struct {
+		name         string
+		base, target string
+		want         bool
+	}{
+		{"base itself", "/repo", "/repo", true},
+		{"nested", "/repo", "/repo/charts/lib", true},
+		{"parent traversal", "/repo", "/repo/../etc", false},
+		{"sibling absolute", "/repo", "/etc", false},
+	}
+	for _, c := range cases {
+		if got := withinDir(c.base, c.target); got != c.want {
+			t.Errorf("%s: withinDir(%q,%q)=%v want %v", c.name, c.base, c.target, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What
Adds `materializeLocalDependencies` (+ a `withinDir` containment check) to the chart-standard **render gate** validator (`.github/scripts/validate-helm-charts/main.go`), so it stages each `file://../<lib>` dependency source into the temp render workspace before `helm dependency build`.

## Why
The render gate copies only the chart-under-test into a temp dir. Charts that declare a **local** `file://../lerian-common` dependency — the productized charts (`plugin-access-manager`, `reporter`, `midaz`) — therefore failed `helm dependency build` (the sibling lib chart wasn't in the workspace), turning their **Validate Helm chart standard** check red.

This fix is extracted from the midaz productization PR (#1741) into its own PR so it can land on `main` independently and **unblock the render gate for every chart consuming `lerian-common` via `file://`** (e.g. #1745 access-manager, currently red).

## Safety
`withinDir` rejects any resolved dependency source that escapes the repo root, or any destination that escapes the render workspace (path-traversal hardening).

## Verified
`go build`/`go vet` clean; render gate on `plugin-access-manager` (which uses `file://../lerian-common`) → `plugin-access-manager: ok (render-ok)`.