### PR TITLE
fix(plugin-br-pix-indirect-btg): guard replicas when autoscaling enabled

### DIFF
--- a/charts/plugin-br-pix-indirect-btg/templates/inbound/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/inbound/deployment.yaml
@@ -8,7 +8,9 @@ spec:
   revisionHistoryLimit: {{ .Values.inbound.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.inbound.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.inbound.autoscaling.enabled }}
   replicas: {{ .Values.inbound.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "inbound.selectorLabels" (dict "context" . "name" .Values.inbound.name) | nindent 6 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/outbound/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/outbound/deployment.yaml
@@ -8,7 +8,9 @@ spec:
   revisionHistoryLimit: {{ .Values.outbound.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.outbound.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.outbound.autoscaling.enabled }}
   replicas: {{ .Values.outbound.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "outbound.selectorLabels" (dict "context" . "name" .Values.outbound.name) | nindent 6 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/pix/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/pix/deployment.yaml
@@ -11,7 +11,9 @@ spec:
   revisionHistoryLimit: {{ .Values.pix.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.pix.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.pix.autoscaling.enabled }}
   replicas: {{ .Values.pix.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "plugin-br-pix-indirect-btg.selectorLabels" (dict "context" . "name" .Values.pix.name) | nindent 6 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/reconciliation/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/reconciliation/deployment.yaml
@@ -8,7 +8,9 @@ spec:
   revisionHistoryLimit: {{ .Values.reconciliation.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.reconciliation.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.reconciliation.autoscaling.enabled }}
   replicas: {{ .Values.reconciliation.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "reconciliation.selectorLabels" (dict "context" . "name" .Values.reconciliation.name) | nindent 6 }}

--- a/charts/plugin-br-pix-indirect-btg/templates/schedule/deployment.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/schedule/deployment.yaml
@@ -8,7 +8,9 @@ spec:
   revisionHistoryLimit: {{ .Values.schedule.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.schedule.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.schedule.autoscaling.enabled }}
   replicas: {{ .Values.schedule.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "schedule.selectorLabels" (dict "context" . "name" .Values.schedule.name) | nindent 6 }}


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Plugin BR PIX Indirect BTG

## Summary

Fixes a **Server-Side Apply field-ownership conflict on `.spec.replicas`** that breaks every `helm upgrade` (reported from production, chart 3.4.0 / app 1.7.6, Rancher/Fleet SSA).

The Deployment templates rendered `spec.replicas` **unconditionally**, even with `autoscaling.enabled: true`. When the chart's own HPA is active, `kube-controller-manager` owns `.spec.replicas` via the `scale` subresource. Under SSA (Rancher/Fleet, ArgoCD), Helm and the HPA then contend for the same field and the apply is rejected:

```
conflict with "kube-controller-manager" with subresource "scale" using apps/v1: .spec.replicas
```

The automatic rollback fails the same way, leaving the release stuck in `failed`. The bug is intermittent only because SSA raises a conflict *just* when the HPA has scaled away from the declared `replicaCount` — a co-owned equal value applies cleanly, which is why some upgrades "pass" by timing.

## Fix

Wrap `replicas` in `{{- if not .Values.<component>.autoscaling.enabled }}` across all five Deployments (pix, inbound, outbound, reconciliation, schedule), so the field is omitted whenever that component's HPA owns it. Standard HPA-chart practice (Bitnami, kube-prometheus-stack).

## Testing

- [x] `helm template` verified in both states:
  - `autoscaling.enabled=true` → `spec.replicas` **absent** (HPA is sole owner → no SSA conflict)
  - `autoscaling.enabled=false` → `spec.replicas` = declared `replicaCount`
- [x] Per-component behavior confirmed (reconciliation/schedule, autoscaling off by default, keep `replicas`).

## Checklist

- [x] I have tested these changes locally.
- [x] This PR modifies **only one chart**.
- [x] I did **not** hand-edit `Chart.yaml` `version`, `CHANGELOG.md`, or the README version matrix (CI owns these; `fix` → patch `3.5.1`).

## Additional Notes

Root cause is a missing conditional (not a wrong-scope one). A repo-wide sweep found the same pattern in 6 other charts — those will follow as separate one-chart-per-PR fixes. The `lerian-common` `_deployment.tpl` does **not** emit `replicas`, so charts on the shared template are unaffected.
