### PR TITLE
fix(reporter): guard replicas when autoscaling enabled

### DIFF
--- a/charts/reporter/templates/manager/deployment.yaml
+++ b/charts/reporter/templates/manager/deployment.yaml
@@ -14,7 +14,9 @@ spec:
   revisionHistoryLimit: {{ .Values.manager.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.manager.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.manager.autoscaling.enabled }}
   replicas: {{ .Values.manager.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "plugin-manager.selectorLabels" (dict "context" . "name" .Values.manager.name) | nindent 6 }}

--- a/charts/reporter/templates/worker/deployment.yaml
+++ b/charts/reporter/templates/worker/deployment.yaml
@@ -19,7 +19,9 @@ spec:
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if not .Values.worker.autoscaling.enabled }}
   replicas: {{ .Values.worker.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "plugin-worker.selectorLabels" (dict "context" . "name" .Values.worker.name) | nindent 6 }}


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Reporter

## Summary

Fixes a **Server-Side Apply field-ownership conflict on `.spec.replicas`** — the same class of bug as #1760 (plugin-br-pix-indirect-btg), found by a repo-wide sweep.

The **reporter** Deployment template(s) (`manager, worker`) rendered `spec.replicas` **unconditionally**, even with `autoscaling.enabled: true`. When the chart's HPA is active, `kube-controller-manager` owns `.spec.replicas` via the `scale` subresource, so under SSA (Rancher/Fleet, ArgoCD) Helm and the HPA contend for the field:

```
conflict with "kube-controller-manager" with subresource "scale" using apps/v1: .spec.replicas
```

## Fix

Wrap `replicas` in `{{- if not .Values.<component>.autoscaling.enabled }}` so it is omitted whenever that component's HPA owns it. Standard HPA-chart practice (Bitnami, kube-prometheus-stack).

## Testing

- [x] `helm template` verified: `autoscaling.enabled=true` → `spec.replicas` **absent**; `false` → declared `replicaCount`.

## Checklist

- [x] I have tested these changes locally.
- [x] This PR modifies **only one chart**.
- [x] I did **not** hand-edit `Chart.yaml` `version`, `CHANGELOG.md`, or the README version matrix (CI owns these; `fix` → patch bump).

## Additional Notes

Part of a coordinated sweep of the HPA/SSA `replicas` bug across charts. `lerian-common` `_deployment.tpl` does not emit `replicas`, so lib-based charts are unaffected.
