### PR TITLE
fix(plugins): guard replicas when autoscaling enabled

### DIFF
--- a/charts/plugin-br-payments/templates/deployment.yaml
+++ b/charts/plugin-br-payments/templates/deployment.yaml
@@ -18,7 +18,9 @@ spec:
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if not .Values.app.autoscaling.enabled }}
   replicas: {{ .Values.app.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "plugin-br-payments.selectorLabels" (dict "context" .) | nindent 6 }}


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

_(chart `plugin-br-payments` — sem caixa específica no template; scope `plugins`)_

## Summary

Fixes a **Server-Side Apply field-ownership conflict on `.spec.replicas`** — the same class of bug as #1760 (plugin-br-pix-indirect-btg), found by a repo-wide sweep.

The **plugin-br-payments** Deployment template(s) (`app`) rendered `spec.replicas` **unconditionally**, even with `autoscaling.enabled: true`. When the chart's HPA is active, `kube-controller-manager` owns `.spec.replicas` via the `scale` subresource, so under SSA (Rancher/Fleet, ArgoCD) Helm and the HPA contend for the field:

```
conflict with "kube-controller-manager" with subresource "scale" using apps/v1: .spec.replicas
```

## Fix

Wrap `replicas` in `{{- if not .Values.<component>.autoscaling.enabled }}` so it is omitted whenever that component's HPA owns it. Standard HPA-chart practice (Bitnami, kube-prometheus-stack).

## Testing

- [x] `helm template` verified: `autoscaling.enabled=true` → `spec.replicas` **absent**; `false` → declared `replicaCount`.

## Checklist

- [x] I have tested these changes locally.
- [x] This PR modifies **only one chart**.
- [x] I did **not** hand-edit `Chart.yaml` `version`, `CHANGELOG.md`, or the README version matrix (CI owns these; `fix` → patch bump).

## Additional Notes

Part of a coordinated sweep of the HPA/SSA `replicas` bug across charts. `lerian-common` `_deployment.tpl` does not emit `replicas`, so lib-based charts are unaffected.
