### PR TITLE
fix(plugin-access-manager): guard replicas when autoscaling enabled

### DIFF
--- a/charts/plugin-access-manager/templates/auth-backend/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth-backend/deployment.yaml
@@ -8,7 +8,9 @@ spec:
   revisionHistoryLimit: {{ .Values.auth.backend.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.auth.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.auth.backend.autoscaling.enabled }}
   replicas: {{ .Values.auth.backend.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "plugin-auth-backend.selectorLabels" (dict "context" . "name" .Values.auth.backend.name) | nindent 6 }}

--- a/charts/plugin-access-manager/templates/auth/deployment.yaml
+++ b/charts/plugin-access-manager/templates/auth/deployment.yaml
@@ -8,7 +8,9 @@ spec:
   revisionHistoryLimit: {{ .Values.auth.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.auth.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.auth.autoscaling.enabled }}
   replicas: {{ .Values.auth.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "plugin-auth.selectorLabels" (dict "context" . "name" .Values.auth.name) | nindent 6 }}

--- a/charts/plugin-access-manager/templates/identity/deployment.yaml
+++ b/charts/plugin-access-manager/templates/identity/deployment.yaml
@@ -8,7 +8,9 @@ spec:
   revisionHistoryLimit: {{ .Values.identity.revisionHistoryLimit | default 10 }}
   strategy:
     {{- toYaml .Values.identity.deploymentStrategy | nindent 4 }}
+  {{- if not .Values.identity.autoscaling.enabled }}
   replicas: {{ .Values.identity.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "plugin-identity.selectorLabels" (dict "context" . "name" .Values.identity.name) | nindent 6 }}


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [x] Plugin Access Manager

## Summary

Fixes a **Server-Side Apply field-ownership conflict on `.spec.replicas`** — the same class of bug as #1760 (plugin-br-pix-indirect-btg), found by a repo-wide sweep.

The **plugin-access-manager** Deployment template(s) (`auth, auth-backend, identity`) rendered `spec.replicas` **unconditionally**, even with `autoscaling.enabled: true`. When the chart's HPA is active, `kube-controller-manager` owns `.spec.replicas` via the `scale` subresource, so under SSA (Rancher/Fleet, ArgoCD) Helm and the HPA contend for the field:

```
conflict with "kube-controller-manager" with subresource "scale" using apps/v1: .spec.replicas
```

## Fix

Wrap `replicas` in `{{- if not .Values.<component>.autoscaling.enabled }}` so it is omitted whenever that component's HPA owns it. Standard HPA-chart practice (Bitnami, kube-prometheus-stack).

## Testing

- [x] `helm template` verified: `autoscaling.enabled=true` → `spec.replicas` **absent**; `false` → declared `replicaCount`.

## Checklist

- [x] I have tested these changes locally.
- [x] This PR modifies **only one chart**.
- [x] I did **not** hand-edit `Chart.yaml` `version`, `CHANGELOG.md`, or the README version matrix (CI owns these; `fix` → patch bump).

## Additional Notes

Part of a coordinated sweep of the HPA/SSA `replicas` bug across charts. `lerian-common` `_deployment.tpl` does not emit `replicas`, so lib-based charts are unaffected.
