### PR TITLE
ci(pipe): migrate workflow jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/helm-chart-standard.yml
+++ b/.github/workflows/helm-chart-standard.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   validate:
     name: Validate Helm chart standard
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/pr-sizing.yml
+++ b/.github/workflows/pr-sizing.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
       statuses: write
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   notify:
     name: Send Slack Notification
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   get-changed-paths:
     if: github.actor != 'lerian-studio-midaz-push-bot[bot]'
     name: Get Changed Paths
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
@@ -43,7 +43,7 @@ jobs:
     needs: get-changed-paths
     name: Release Helm Chart
     if: needs.get-changed-paths.outputs.matrix != '[]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       max-parallel: 1
       fail-fast: false
@@ -237,7 +237,7 @@ jobs:
       - release-helm-chart
     name: 🔀 Back Merge to Develop
     if: needs.get-changed-paths.outputs.matrix != '[]' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
Standardizes this repo's CI on Blacksmith runners as part of the org-wide migration. Blacksmith is a drop-in replacement for GitHub-hosted runners, roughly 2x faster at about half the per-minute price, and uses the same `blacksmith-4vcpu-ubuntu-2404` label as the rest of the org.

```yaml
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
```

Only `runs-on:` labels changed; workflow logic is untouched.