### PR TITLE
fix(common): configmap passthrough in serviceDiscovery/streaming env helpers + streaming knobs

### DIFF
--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -31,6 +31,11 @@ Inputs (dict):
   namespace   (req)  resolved namespace string
   ingressHost (opt)  external host; when non-empty, emits SD_EXTERNAL_*
                      (omit for consumer-only / internal-only instances)
+  configmap   (opt)  the component's legacy `.configmap` map. When a key is
+                     present here, its flat `configmap.SD_*` value WINS over the
+                     global/derived value below (backward-compat for the flat
+                     configmap API). Defaults to an empty dict → every key falls
+                     through to the derived value (byte-identical to no-configmap).
 
 global.serviceDiscovery (all optional except address when enabled):
   address, tls, tlsSkipVerify, workload, preferView, internalScheme, externalPort
@@ -38,6 +43,10 @@ global.serviceDiscovery (all optional except address when enabled):
 */}}
 {{- define "lerian-common.serviceDiscovery.env" -}}
 {{- $sd := (.context.Values.global | default dict).serviceDiscovery | default dict -}}
+{{- /* Legacy flat configmap source: a present `configmap.SD_*` key WINS over the
+   global/derived value (mirrors multiTenant.env). Empty dict when omitted, so a
+   no-configmap caller renders byte-identical to before. */ -}}
+{{- $c := .configmap | default dict -}}
 {{- /*
   Derive ONLY when enabled AND global.serviceDiscovery.address is configured.
   This keeps adoption backward-compatible: a chart carrying this helper but
@@ -51,17 +60,17 @@ global.serviceDiscovery (all optional except address when enabled):
 {{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
    rendered by the component's own extraEnvVars passthrough. Emitting it again
    would produce a duplicate key. This helper only adds the derived siblings. */ -}}
-SD_ADDRESS: {{ $sd.address | quote }}
-SD_TLS: {{ $sd.tls | default false | quote }}
-SD_TLS_SKIP_VERIFY: {{ $sd.tlsSkipVerify | default false | quote }}
-SD_WORKLOAD: {{ $sd.workload | default "" | quote }}
-SD_PREFER_VIEW: {{ $sd.preferView | default "internal" | quote }}
-SD_INTERNAL_ADDRESS: {{ include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace) | quote }}
-SD_INTERNAL_PORT: {{ .port | quote }}
-SD_INTERNAL_SCHEME: {{ $sd.internalScheme | default "http" | quote }}
+SD_ADDRESS: {{ index $c "SD_ADDRESS" | default $sd.address | quote }}
+SD_TLS: {{ index $c "SD_TLS" | default ($sd.tls | default false) | quote }}
+SD_TLS_SKIP_VERIFY: {{ index $c "SD_TLS_SKIP_VERIFY" | default ($sd.tlsSkipVerify | default false) | quote }}
+SD_WORKLOAD: {{ index $c "SD_WORKLOAD" | default ($sd.workload | default "") | quote }}
+SD_PREFER_VIEW: {{ index $c "SD_PREFER_VIEW" | default ($sd.preferView | default "internal") | quote }}
+SD_INTERNAL_ADDRESS: {{ index $c "SD_INTERNAL_ADDRESS" | default (include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace)) | quote }}
+SD_INTERNAL_PORT: {{ index $c "SD_INTERNAL_PORT" | default .port | quote }}
+SD_INTERNAL_SCHEME: {{ index $c "SD_INTERNAL_SCHEME" | default ($sd.internalScheme | default "http") | quote }}
 {{- if .ingressHost }}
-SD_EXTERNAL_ADDRESS: {{ printf "https://%s" .ingressHost | quote }}
-SD_EXTERNAL_PORT: {{ $sd.externalPort | default 443 | quote }}
+SD_EXTERNAL_ADDRESS: {{ index $c "SD_EXTERNAL_ADDRESS" | default (printf "https://%s" .ingressHost) | quote }}
+SD_EXTERNAL_PORT: {{ index $c "SD_EXTERNAL_PORT" | default ($sd.externalPort | default 443) | quote }}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/lerian-common/templates/_streaming.tpl
+++ b/charts/lerian-common/templates/_streaming.tpl
@@ -31,23 +31,39 @@ Inputs (dict):
   enabled           (req)  bool — whether to emit the constants
   clientId          (opt)  STREAMING_CLIENT_ID — emitted only when provided
   cloudeventsSource (opt)  STREAMING_CLOUDEVENTS_SOURCE — emitted only when provided
+  configmap         (opt)  the component's legacy `.configmap` map. When a key is
+                           present here, its flat `configmap.STREAMING_*` value
+                           WINS over the global value below (backward-compat for
+                           the flat configmap API). Defaults to an empty dict → every
+                           key falls through to global/default (byte-identical to
+                           a no-configmap caller, aside from the new knobs below).
 
 global.streaming (all optional except brokers, which gates emission):
-  brokers, tlsEnabled, saslMechanism, saslUsername
+  brokers, tlsEnabled, saslMechanism, saslUsername, saslAllowPlaintext,
+  compression, requiredAcks, batchLingerMs, importantEmitTimeoutMs
 ==============================================================================
 */}}
 {{- define "lerian-common.streaming.env" -}}
 {{- $s := (.context.Values.global | default dict).streaming | default dict -}}
+{{- /* Legacy flat configmap source: a present `configmap.STREAMING_*` key WINS
+   over the global value (mirrors multiTenant.env / serviceDiscovery.env). Empty
+   dict when omitted. */ -}}
+{{- $c := .configmap | default dict -}}
 {{- if and .enabled $s.brokers -}}
-STREAMING_BROKERS: {{ $s.brokers | quote }}
-STREAMING_TLS_ENABLED: {{ $s.tlsEnabled | default false | quote }}
-STREAMING_SASL_MECHANISM: {{ $s.saslMechanism | default "" | quote }}
-STREAMING_SASL_USERNAME: {{ $s.saslUsername | default "" | quote }}
+STREAMING_BROKERS: {{ index $c "STREAMING_BROKERS" | default $s.brokers | quote }}
+STREAMING_TLS_ENABLED: {{ index $c "STREAMING_TLS_ENABLED" | default ($s.tlsEnabled | default false) | quote }}
+STREAMING_SASL_MECHANISM: {{ index $c "STREAMING_SASL_MECHANISM" | default ($s.saslMechanism | default "") | quote }}
+STREAMING_SASL_USERNAME: {{ index $c "STREAMING_SASL_USERNAME" | default ($s.saslUsername | default "") | quote }}
+STREAMING_SASL_ALLOW_PLAINTEXT: {{ index $c "STREAMING_SASL_ALLOW_PLAINTEXT" | default ($s.saslAllowPlaintext | default "false") | quote }}
+STREAMING_COMPRESSION: {{ index $c "STREAMING_COMPRESSION" | default ($s.compression | default "lz4") | quote }}
+STREAMING_REQUIRED_ACKS: {{ index $c "STREAMING_REQUIRED_ACKS" | default ($s.requiredAcks | default "all") | quote }}
+STREAMING_BATCH_LINGER_MS: {{ index $c "STREAMING_BATCH_LINGER_MS" | default ($s.batchLingerMs | default "5") | quote }}
+STREAMING_IMPORTANT_EMIT_TIMEOUT_MS: {{ index $c "STREAMING_IMPORTANT_EMIT_TIMEOUT_MS" | default ($s.importantEmitTimeoutMs | default "5000") | quote }}
 {{- if hasKey . "clientId" }}
-STREAMING_CLIENT_ID: {{ .clientId | quote }}
+STREAMING_CLIENT_ID: {{ index $c "STREAMING_CLIENT_ID" | default .clientId | quote }}
 {{- end }}
 {{- if hasKey . "cloudeventsSource" }}
-STREAMING_CLOUDEVENTS_SOURCE: {{ .cloudeventsSource | quote }}
+STREAMING_CLOUDEVENTS_SOURCE: {{ index $c "STREAMING_CLOUDEVENTS_SOURCE" | default .cloudeventsSource | quote }}
 {{- end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What
Adds an optional `configmap` param to `lerian-common.serviceDiscovery.env` and `lerian-common.streaming.env` so consumers can honor legacy flat `configmap.SD_*` / `configmap.STREAMING_*` **server** keys (each resolves `configmap.<KEY>` → `global.streaming/serviceDiscovery.<field>` → default), mirroring what `multiTenant.env` already does. Also adds the streaming knobs the apps read: `STREAMING_COMPRESSION` (`lz4`), `STREAMING_REQUIRED_ACKS` (`all`), `STREAMING_BATCH_LINGER_MS` (`5`), `STREAMING_IMPORTANT_EMIT_TIMEOUT_MS` (`5000`), `STREAMING_SASL_ALLOW_PLAINTEXT` (`false`).

## Why
A human review of the midaz productization (#1741) found these two helpers read **only** `global.*` and drop the component's legacy `configmap.*` server config — breaking the documented backward-compat contract for on-prem/client values that use the `configmap` block (`multiTenant.env` already handles it). This restores parity and lets midaz + reporter drop their inline streaming-knob duplicates in follow-up PRs.

## Backward-compatibility (critical)
The `configmap` param is **optional** (defaults to empty dict). Current callers that don't pass it render **byte-identical** — the ONLY new output for a no-configmap caller is the 5 streaming knobs at their defaults (the intended parity gap-closer). Proven by rendering midaz with the updated lib: SD block unchanged, streaming block gains only the 5 defaulted knobs; and passing `configmap.SD_ADDRESS`/`STREAMING_COMPRESSION` correctly wins over global.

## Scope
`charts/lerian-common` only (1-chart-per-PR). No manual version bump (release pipeline auto-bumps). SD timeout/tuning keys (`SD_ALLOW_STALE` etc.) are emitted by the separate `serviceDiscovery.envFlat` helper, not this derivation helper, so they are intentionally not added here (the reviewer confirmed their absence is behavior-neutral: empty → unset → same default).

## Follow-ups (separate PRs)
midaz (#1741) and reporter pass `configmap` to their SD/streaming calls + bump the lerian-common pin, and drop their inline streaming-knob emissions.