### PR TITLE
feat(charts): br-sfn multi-component chart — modular SFN rails (SPB, SPI, SILOC, SCR, desk, slc-edge, cockpit)

### DIFF
--- a/.github/configs/helm-render-values/br-sfn.yaml
+++ b/.github/configs/helm-render-values/br-sfn.yaml
@@ -1,0 +1,60 @@
+# CI render fixture: every component ON with minimal required values, so the
+# render gate exercises all templates. NOT a production example.
+spb:
+  enabled: true
+  configmap:
+    POSTGRES_HOST: spb-postgres
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: br_spb
+    POSTGRES_DB: br_bank_transfer_jota
+  secrets:
+    POSTGRES_PASSWORD: "ci-dummy"
+spi:
+  enabled: true
+  configmap:
+    POSTGRES_HOST: spi-postgres
+    POSTGRES_USER: brspi
+    POSTGRES_DB: brspi
+  secrets:
+    POSTGRES_PASSWORD: "ci-dummy"
+siloc:
+  enabled: true
+  configmap:
+    POSTGRES_HOST: siloc-postgres
+    POSTGRES_USER: br_siloc
+    POSTGRES_DB: br_siloc
+  secrets:
+    POSTGRES_PASSWORD: "ci-dummy"
+scr:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - host: scr.ci.local
+        paths:
+          - path: /
+            pathType: Prefix
+  autoscaling:
+    enabled: true
+  pdb:
+    enabled: true
+  configmap:
+    POSTGRES_HOST: scr-postgres
+    POSTGRES_USER: br_scr
+    POSTGRES_DB: br_scr
+  secrets:
+    POSTGRES_PASSWORD: "ci-dummy"
+desk:
+  enabled: true
+  configmap:
+    POSTGRES_HOST: desk-postgres
+    POSTGRES_USER: br_desk
+    POSTGRES_DB: br_desk
+  secrets:
+    POSTGRES_PASSWORD: "ci-dummy"
+slcEdge:
+  enabled: true
+  configmap:
+    SLC_CORE_URL: http://br-slc:4000
+cockpit:
+  enabled: true

--- a/charts/br-sfn/Chart.yaml
+++ b/charts/br-sfn/Chart.yaml
@@ -1,0 +1,45 @@
+apiVersion: v2
+name: br-sfn-helm
+description: A Helm chart for br-sfn — the Lerian Brazilian SFN rails monorepo
+  (SPB/STR, SPI/Pix, SILOC, SCR, desk, slc-edge, cockpit). Modular by design —
+  every component ships disabled; operators enable only the rails they run.
+
+type: application
+annotations:
+  lerian.studio/chart-type: multi-component
+
+home: https://github.com/LerianStudio/helm
+
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/br-sfn
+  - https://github.com/LerianStudio/br-sfn
+
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+
+version: 1.0.0-beta.1
+
+# NOTE: appVersion is the default image tag for every component and migration
+# Job. Components version independently in the monorepo (svc/vX.Y.Z tags), so
+# production values pin <component>.image.tag explicitly; appVersion is only
+# the tag of the release train the chart was cut against.
+appVersion: "1.0.0-beta.1"
+
+keywords:
+  - br-sfn
+  - spb
+  - str
+  - spi
+  - pix
+  - siloc
+  - scr
+  - bacen
+  - rsfn
+  - lerian
+
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+
+# No dependencies on purpose: Postgres, Valkey/Redis, RabbitMQ, RedPanda and
+# IBM MQ are EXTERNAL, pre-provisioned services on every target environment
+# (benedita tiers and BYOC alike). This chart ships application workloads only.

--- a/charts/br-sfn/README.md
+++ b/charts/br-sfn/README.md
@@ -1,0 +1,95 @@
+# br-sfn
+
+Helm chart for **br-sfn** — the Lerian Brazilian SFN rails monorepo: SPB/STR
+(TED), SPI (Pix — four runtime binaries), SILOC (card settlement), SCR (credit
+information), desk (cockpit operator-state + four-eyes), slc-edge (Cabine SLC
+authenticated passthrough) and the cockpit operations SPA.
+
+## Modularity contract
+
+**Every component ships `enabled: false`.** br-sfn is a monorepo of independent
+rails and no environment runs all of them — enable exactly what the deployment
+operates:
+
+```yaml
+spb:
+  enabled: true
+spi:
+  enabled: true
+cockpit:
+  enabled: true
+```
+
+A default render produces only the shared ServiceAccount.
+
+| Component | Values key | Image | Port | Migrations |
+|-----------|-----------|-------|------|------------|
+| SPB/STR rail | `spb` | `ghcr.io/lerianstudio/br-spb` | 3000 | baked (`/app/migrations`) |
+| SPI/Pix api | `spi.api` | `ghcr.io/lerianstudio/br-spi` | 9800 | family Job (dedicated image) |
+| SPI/Pix dict | `spi.dict` | `ghcr.io/lerianstudio/br-spi-dict` | 9801 | — |
+| SPI/Pix brcode | `spi.brcode` | `ghcr.io/lerianstudio/br-spi-brcode` | 9802 | — |
+| SPI/Pix core | `spi.core` | `ghcr.io/lerianstudio/br-spi-core` | 9803 | — |
+| SILOC rail | `siloc` | `ghcr.io/lerianstudio/br-siloc` | 9820 | dedicated (`br-siloc-migrations`) |
+| SCR rail | `scr` | `ghcr.io/lerianstudio/br-scr` | 3003 | baked (`/migrations`, table `schema_migrations_scr`) |
+| desk | `desk` | `ghcr.io/lerianstudio/br-desk` | 3002 | baked (`/migrations`) |
+| slc-edge | `slcEdge` | `ghcr.io/lerianstudio/br-slc-edge` | 3005 | none (stateless) |
+| cockpit SPA | `cockpit` | `ghcr.io/lerianstudio/br-sfn-cockpit` | 8080 | none (static bundle) |
+
+The four SPI components share `spi.configmap` / `spi.secrets` (merged under
+each component's own block; component keys win) because they ride one Postgres,
+one Redis and one RedPanda.
+
+## Migrations
+
+PreSync ArgoCD hook Jobs (`hook-weight: -1`), one per rail that owns a schema,
+in two flavors:
+
+- **baked** (spb, scr, desk): an initContainer copies the migrations tree out
+  of the app image; `migrate/migrate` applies it. Postgres passwords must be
+  URL-safe (no `@ : / ? # %`).
+- **dedicated** (spi, siloc): the rail's own migrator image runs with the
+  `POSTGRES_*` env contract. The SPI migrator owns module ordering
+  (global → events → spi → dict → brcode → core) and the per-module bookkeeping
+  tables its `/readyz` schema probes read — never replace it with a plain
+  golang-migrate run.
+
+Connection settings resolve from `<component>.migrations.postgres.*`, falling
+back to the component's `configmap` keys (`POSTGRES_HOST`, `POSTGRES_PORT`,
+`POSTGRES_USER`, `POSTGRES_DB`, `POSTGRES_SSLMODE`). Host, user and database
+are required — the render fails loud when missing.
+
+## Configuration model
+
+`<component>.configmap` and `<component>.secrets` are emitted **verbatim** into
+the component's ConfigMap/Secret (no fixed allowlist), so new env vars never
+need a chart change. On GitOps tiers the secrets map carries ArgoCD Vault
+Plugin `<path:...>` refs. `useExistingSecret: true` + `existingSecretName`
+switches the component to an operator-provided Secret.
+
+## Infra contract
+
+Postgres, Valkey/Redis, RabbitMQ, RedPanda and IBM MQ are **external**,
+pre-provisioned services — this chart ships no infra subcharts and no
+dependencies. RedPanda topics for spb/spi are an environment concern (the
+compose `redpanda-topics` one-shot is dev-only).
+
+## Cockpit caveat
+
+The SPA bakes `VITE_*` URLs at **image build time**. The published baseline
+image carries honest-degrade defaults; an environment that needs real URLs
+pins an environment-specific image build.
+
+## Chart Contract
+
+- Chart type: `multi-component`
+- Required secrets: None for default render (all components disabled). Per
+  enabled rail: `POSTGRES_PASSWORD` in `<component>.secrets` (or an
+  `existingSecretName` Secret) for spb/spi/siloc/scr/desk; slc-edge and
+  cockpit need none.
+- Dependency notes: no subcharts — Postgres/Valkey/RabbitMQ/RedPanda/IBM MQ
+  are external services by contract.
+- Production overrides: `<component>.enabled`, `<component>.image.tag`
+  (components version independently — `svc/vX.Y.Z` tags), `configmap`/`secrets`
+  maps per rail, `resources`, `ingress`; `useExistingSecret`/
+  `existingSecretName` for operator-owned credentials.
+- Source/license: https://github.com/LerianStudio/br-sfn (proprietary).

--- a/charts/br-sfn/templates/_helpers.tpl
+++ b/charts/br-sfn/templates/_helpers.tpl
@@ -218,10 +218,16 @@ spec:
       {{- include "br-sfn.componentSelectorLabels" $id | nindent 6 }}
   template:
     metadata:
-      {{- with .comp.podAnnotations }}
       annotations:
+        {{- with .comp.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        {{- if $configData }}
+        checksum/config: {{ $configData | sha256sum }}
+        {{- end }}
+        {{- if $secretData }}
+        checksum/secret: {{ $secretData | sha256sum }}
+        {{- end }}
       labels:
         {{- include "br-sfn.componentSelectorLabels" $id | nindent 8 }}
     spec:
@@ -240,14 +246,16 @@ spec:
           image: {{ include "br-sfn.componentImage" (dict "root" .root "comp" .comp) | quote }}
           imagePullPolicy: {{ .comp.image.pullPolicy | default "IfNotPresent" }}
           {{- if or $configData $hasSecret }}
+          # Secret LAST: envFrom resolves duplicate keys to the last source, so
+          # a key in both maps takes the credentialed value, never the ConfigMap.
           envFrom:
-            {{- if $hasSecret }}
-            - secretRef:
-                name: {{ include "br-sfn.componentSecretName" (dict "root" .root "name" .name "comp" .comp "sharedCfg" $sharedCfg) }}
-            {{- end }}
             {{- if $configData }}
             - configMapRef:
                 name: {{ $fullname }}
+            {{- end }}
+            {{- if $hasSecret }}
+            - secretRef:
+                name: {{ include "br-sfn.componentSecretName" (dict "root" .root "name" .name "comp" .comp "sharedCfg" $sharedCfg) }}
             {{- end }}
           {{- end }}
           {{- with .comp.extraEnvVars }}
@@ -477,8 +485,49 @@ Input dict: root, name (component), comp, shared, sharedCfg, flavor
 {{- end -}}
 {{- $pgSsl := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "sslMode" "cfg" $cfg "cfgKey" "POSTGRES_SSLMODE" "fallback" "disable") -}}
 {{- $pwSecret := ($mig.passwordSecret | default dict) -}}
-{{- $pwName := $pwSecret.name | default (include "br-sfn.componentSecretName" (dict "root" .root "name" (.secretComponent | default .name) "comp" .comp "sharedCfg" (.sharedCfg | default dict))) -}}
 {{- $pwKey := $pwSecret.key | default "POSTGRES_PASSWORD" -}}
+{{- $sharedCfgM := .sharedCfg | default dict -}}
+{{- $mergedSecrets := mergeOverwrite (deepCopy (.sharedSecrets | default dict)) (.comp.secrets | default dict) -}}
+{{- $pwName := "" -}}
+{{- $mintSecret := false -}}
+{{- if $pwSecret.name -}}
+{{- /* Operator-owned Secret: name + key are the operator's contract. */ -}}
+{{- $pwName = $pwSecret.name -}}
+{{- else if or .comp.useExistingSecret $sharedCfgM.useExistingSecret -}}
+{{- /* Existing-secret override: resolve the SAME name the component resolves
+       (component-level flag first, then the family-level one), so the Job and
+       the Deployment always read one Secret. */ -}}
+{{- $pwName = include "br-sfn.componentSecretName" (dict "root" .root "name" (.secretComponent | default .name) "comp" .comp "sharedCfg" $sharedCfgM) -}}
+{{- else -}}
+{{- /* Generated path: the component Secret is a MAIN-SYNC resource, so a
+       PreSync Job racing it would sit in CreateContainerConfigError. Mint a
+       dedicated PreSync hook Secret (weight -2, created before the Job at -1,
+       BeforeHookCreation only so it survives the whole PreSync phase) carrying
+       just the password. Fail loud when the key is missing — a Job pointing at
+       an absent key would otherwise hang until activeDeadlineSeconds. */ -}}
+{{- if not (hasKey $mergedSecrets $pwKey) -}}
+{{- fail (printf "br-sfn: %s migrations need %s in %s.secrets (or set %s.migrations.passwordSecret.name to an operator-provided Secret)" .name $pwKey .name .name) -}}
+{{- end -}}
+{{- $pwName = include "br-sfn.componentFullname" $id -}}
+{{- $mintSecret = true -}}
+{{- end -}}
+{{- if $mintSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $pwName }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" $id | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-2"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+type: Opaque
+stringData:
+  {{ $pwKey }}: {{ index $mergedSecrets $pwKey | quote }}
+---
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/br-sfn/templates/_helpers.tpl
+++ b/charts/br-sfn/templates/_helpers.tpl
@@ -1,0 +1,590 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "br-sfn.name" -}}
+{{- default "br-sfn" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars because some Kubernetes name fields are limited by the DNS spec.
+*/}}
+{{- define "br-sfn.fullname" -}}
+{{- default (include "br-sfn.name" .) .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "br-sfn.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Expand the namespace of the release. Overridable for multi-namespace layouts.
+*/}}
+{{- define "global.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Name of the service account to use (shared by every component).
+*/}}
+{{- define "br-sfn.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "br-sfn.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+componentFullname — <chart fullname>-<component>, e.g. br-sfn-spb.
+Input dict: root, name.
+*/}}
+{{- define "br-sfn.componentFullname" -}}
+{{- printf "%s-%s" (include "br-sfn.fullname" .root | trunc (int (sub 62 (len .name))) | trimSuffix "-") .name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Selector labels for one component (stable across image bumps).
+Input dict: root, name.
+*/}}
+{{- define "br-sfn.componentSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "br-sfn.componentFullname" . }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+{{- end }}
+
+{{/*
+Common labels for one component. Input dict: root, name.
+*/}}
+{{- define "br-sfn.componentLabels" -}}
+helm.sh/chart: {{ include "br-sfn.chart" .root }}
+{{ include "br-sfn.componentSelectorLabels" . }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+app.kubernetes.io/part-of: br-sfn
+app.kubernetes.io/component: {{ .name }}
+{{- end }}
+
+{{/*
+componentConfigData — the component's effective ConfigMap map: the optional
+`shared` map (spi-family) merged under the component's own configmap (component
+keys win). Input dict: comp, shared (optional). Emits YAML map or "".
+*/}}
+{{- define "br-sfn.componentConfigData" -}}
+{{- $shared := .shared | default dict -}}
+{{- $own := .comp.configmap | default dict -}}
+{{- $merged := mergeOverwrite (deepCopy $shared) $own -}}
+{{- if $merged -}}
+{{- toYaml $merged -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+componentSecretData — same merge for the Secret map. Input dict: comp, shared.
+*/}}
+{{- define "br-sfn.componentSecretData" -}}
+{{- $shared := .shared | default dict -}}
+{{- $own := .comp.secrets | default dict -}}
+{{- $merged := mergeOverwrite (deepCopy $shared) $own -}}
+{{- if $merged -}}
+{{- toYaml $merged -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+componentSecretName — the Secret the component's envFrom points at.
+Fails loud when useExistingSecret is set without a name (per-component flag
+first, then the spi-family shared flag). Input dict: root, name, comp,
+sharedCfg (optional map carrying useExistingSecret/existingSecretName).
+*/}}
+{{- define "br-sfn.componentSecretName" -}}
+{{- $shared := .sharedCfg | default dict -}}
+{{- if .comp.useExistingSecret -}}
+{{- required (printf "br-sfn: %s.existingSecretName must be set when %s.useExistingSecret is true" .name .name) .comp.existingSecretName -}}
+{{- else if $shared.useExistingSecret -}}
+{{- required "br-sfn: spi.existingSecretName must be set when spi.useExistingSecret is true" $shared.existingSecretName -}}
+{{- else -}}
+{{- include "br-sfn.componentFullname" (dict "root" .root "name" .name) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+componentConfigmap — ConfigMap for one component (only when it has data).
+Input dict: root, name, comp, shared (optional).
+*/}}
+{{- define "br-sfn.componentConfigmap" -}}
+{{- $data := include "br-sfn.componentConfigData" (dict "comp" .comp "shared" .shared) -}}
+{{- if $data }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-sfn.componentFullname" (dict "root" .root "name" .name) }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" (dict "root" .root "name" .name) | nindent 4 }}
+data:
+  {{- $data | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+componentSecrets — Secret for one component (only when it has data and the
+operator is not bringing their own). Input dict: root, name, comp, shared,
+sharedCfg.
+*/}}
+{{- define "br-sfn.componentSecrets" -}}
+{{- $sharedCfg := .sharedCfg | default dict -}}
+{{- if not (or .comp.useExistingSecret $sharedCfg.useExistingSecret) -}}
+{{- $data := include "br-sfn.componentSecretData" (dict "comp" .comp "shared" .shared) -}}
+{{- if $data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-sfn.componentFullname" (dict "root" .root "name" .name) }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" (dict "root" .root "name" .name) | nindent 4 }}
+type: Opaque
+stringData:
+  {{- $data | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+componentImage — "<repository>:<tag|appVersion>".
+Input dict: root, comp.
+*/}}
+{{- define "br-sfn.componentImage" -}}
+{{- printf "%s:%s" .comp.image.repository (.comp.image.tag | default .root.Chart.AppVersion) -}}
+{{- end }}
+
+{{/*
+componentPullSecrets — component override, else chart default, else global.
+Input dict: root, comp. Emits a YAML list or "".
+*/}}
+{{- define "br-sfn.componentPullSecrets" -}}
+{{- $secrets := .comp.imagePullSecrets | default (.root.Values.imagePullSecrets | default .root.Values.global.imagePullSecrets) -}}
+{{- if $secrets -}}
+{{- toYaml $secrets -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+componentDeployment — the generic Deployment for one HTTP component.
+Input dict:
+  root         — the chart root context
+  name         — component resource name segment ("spb", "spi-api", ...)
+  comp         — the component values block
+  shared       — optional shared configmap/secrets source (spi family)
+  sharedCfg    — optional shared useExistingSecret carrier (spi family)
+  defaultPort  — the container port matching the image's EXPOSE
+  livenessPath — default liveness path ("/health"; cockpit passes "/")
+  readyPath    — default readiness path ("/readyz"; cockpit passes "/")
+*/}}
+{{- define "br-sfn.componentDeployment" -}}
+{{- $id := dict "root" .root "name" .name -}}
+{{- $fullname := include "br-sfn.componentFullname" $id -}}
+{{- $configData := include "br-sfn.componentConfigData" (dict "comp" .comp "shared" .shared) -}}
+{{- $secretData := include "br-sfn.componentSecretData" (dict "comp" .comp "shared" .shared) -}}
+{{- $sharedCfg := .sharedCfg | default dict -}}
+{{- $hasSecret := or $secretData .comp.useExistingSecret $sharedCfg.useExistingSecret -}}
+{{- $secCtx := .comp.securityContext | default .root.Values.securityContext -}}
+{{- $liveness := .comp.livenessProbe | default dict -}}
+{{- $readiness := .comp.readinessProbe | default dict -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" $id | nindent 4 }}
+spec:
+  revisionHistoryLimit: {{ .comp.revisionHistoryLimit | default 10 }}
+  {{- if not .comp.autoscaling.enabled }}
+  replicas: {{ .comp.replicaCount | default 1 }}
+  {{- end }}
+  strategy:
+    type: {{ .comp.deploymentUpdate.type | default "RollingUpdate" }}
+    {{- if eq (.comp.deploymentUpdate.type | default "RollingUpdate") "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .comp.deploymentUpdate.maxSurge | default 1 }}
+      maxUnavailable: {{ .comp.deploymentUpdate.maxUnavailable | default 0 }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "br-sfn.componentSelectorLabels" $id | nindent 6 }}
+  template:
+    metadata:
+      {{- with .comp.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "br-sfn.componentSelectorLabels" $id | nindent 8 }}
+    spec:
+      {{- with (include "br-sfn.componentPullSecrets" (dict "root" .root "comp" .comp)) }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "br-sfn.serviceAccountName" .root }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .root.Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .name }}
+          securityContext:
+            {{- toYaml $secCtx | nindent 12 }}
+          image: {{ include "br-sfn.componentImage" (dict "root" .root "comp" .comp) | quote }}
+          imagePullPolicy: {{ .comp.image.pullPolicy | default "IfNotPresent" }}
+          {{- if or $configData $hasSecret }}
+          envFrom:
+            {{- if $hasSecret }}
+            - secretRef:
+                name: {{ include "br-sfn.componentSecretName" (dict "root" .root "name" .name "comp" .comp "sharedCfg" $sharedCfg) }}
+            {{- end }}
+            {{- if $configData }}
+            - configMapRef:
+                name: {{ $fullname }}
+            {{- end }}
+          {{- end }}
+          {{- with .comp.extraEnvVars }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .comp.service.port | default .defaultPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ $liveness.path | default .livenessPath }}
+              port: http
+            initialDelaySeconds: {{ $liveness.initialDelaySeconds | default 15 }}
+            periodSeconds: {{ $liveness.periodSeconds | default 20 }}
+            timeoutSeconds: {{ $liveness.timeoutSeconds | default 5 }}
+            successThreshold: {{ $liveness.successThreshold | default 1 }}
+            failureThreshold: {{ $liveness.failureThreshold | default 3 }}
+          readinessProbe:
+            httpGet:
+              path: {{ $readiness.path | default .readyPath }}
+              port: http
+            initialDelaySeconds: {{ $readiness.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ $readiness.periodSeconds | default 10 }}
+            timeoutSeconds: {{ $readiness.timeoutSeconds | default 5 }}
+            successThreshold: {{ $readiness.successThreshold | default 1 }}
+            failureThreshold: {{ $readiness.failureThreshold | default 3 }}
+          {{- with .comp.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .comp.resources | nindent 12 }}
+      {{- with .comp.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .comp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .comp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .comp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+
+{{/*
+componentService — ClusterIP Service. Input dict: root, name, comp, defaultPort.
+*/}}
+{{- define "br-sfn.componentService" -}}
+{{- $id := dict "root" .root "name" .name -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "br-sfn.componentFullname" $id }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" $id | nindent 4 }}
+spec:
+  type: {{ .comp.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ .comp.service.port | default .defaultPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "br-sfn.componentSelectorLabels" $id | nindent 4 }}
+{{- end }}
+
+{{/*
+componentIngress — optional Ingress. Input dict: root, name, comp, defaultPort.
+*/}}
+{{- define "br-sfn.componentIngress" -}}
+{{- if .comp.ingress.enabled -}}
+{{- $id := dict "root" .root "name" .name -}}
+{{- $fullname := include "br-sfn.componentFullname" $id -}}
+{{- $port := .comp.service.port | default .defaultPort -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" $id | nindent 4 }}
+  {{- with .comp.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .comp.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .comp.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .comp.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullname }}
+                port:
+                  number: {{ $port }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+componentHpa — optional HorizontalPodAutoscaler. Input dict: root, name, comp.
+*/}}
+{{- define "br-sfn.componentHpa" -}}
+{{- if .comp.autoscaling.enabled -}}
+{{- $id := dict "root" .root "name" .name -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "br-sfn.componentFullname" $id }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" $id | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "br-sfn.componentFullname" $id }}
+  minReplicas: {{ .comp.autoscaling.minReplicas }}
+  maxReplicas: {{ .comp.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .comp.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}
+
+{{/*
+componentPdb — optional PodDisruptionBudget. Input dict: root, name, comp.
+*/}}
+{{- define "br-sfn.componentPdb" -}}
+{{- if .comp.pdb.enabled -}}
+{{- $id := dict "root" .root "name" .name -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "br-sfn.componentFullname" $id }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" $id | nindent 4 }}
+spec:
+  minAvailable: {{ .comp.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "br-sfn.componentSelectorLabels" $id | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{/*
+migrationPgValue — resolve one migrations.postgres.* value with fallback to the
+component's effective configmap key. Input dict: mig (migrations block), key
+(postgres sub-key), cfg (merged configmap map), cfgKey (configmap key name),
+fallback (last-resort literal).
+*/}}
+{{- define "br-sfn.migrationPgValue" -}}
+{{- $fromMig := index (.mig.postgres | default dict) .key -}}
+{{- if $fromMig -}}
+{{- $fromMig -}}
+{{- else if hasKey .cfg .cfgKey -}}
+{{- index .cfg .cfgKey -}}
+{{- else -}}
+{{- .fallback -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+componentMigrationJob — PreSync migration Job, two flavors:
+
+  BAKED     (spb, scr, desk): the app image bakes its migrations tree; an
+            initContainer copies it into an emptyDir and the shared
+            migrate/migrate image applies it with an optional
+            x-migrations-table. Requires a URL-safe Postgres password.
+  DEDICATED (spi, siloc): the rail ships its own migrator image whose
+            entrypoint owns module ordering and bookkeeping tables; the Job
+            just runs it with the POSTGRES_* env contract.
+
+hook-weight -1 puts the Job after any PreSync Secret and before the main-sync
+Deployments, so no rail boots unmigrated.
+
+Input dict: root, name (component), comp, shared, sharedCfg, flavor
+("baked"|"dedicated").
+*/}}
+{{- define "br-sfn.componentMigrationJob" -}}
+{{- $mig := .comp.migrations | default dict -}}
+{{- if $mig.enabled -}}
+{{- $id := dict "root" .root "name" (printf "%s-migrations" .name) -}}
+{{- $compId := dict "root" .root "name" .name -}}
+{{- $fullname := include "br-sfn.componentFullname" $id -}}
+{{- $cfgStr := include "br-sfn.componentConfigData" (dict "comp" .comp "shared" .shared) -}}
+{{- $cfg := dict -}}
+{{- if $cfgStr }}{{ $cfg = fromYaml $cfgStr }}{{ end -}}
+{{- $pgHost := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "host" "cfg" $cfg "cfgKey" "POSTGRES_HOST" "fallback" "") -}}
+{{- if not $pgHost -}}
+{{- fail (printf "br-sfn: %s migrations need a Postgres host — set %s.migrations.postgres.host or %s.configmap.POSTGRES_HOST" .name .name .name) -}}
+{{- end -}}
+{{- $pgPort := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "port" "cfg" $cfg "cfgKey" "POSTGRES_PORT" "fallback" "5432") -}}
+{{- $pgUser := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "user" "cfg" $cfg "cfgKey" "POSTGRES_USER" "fallback" "") -}}
+{{- if not $pgUser -}}
+{{- fail (printf "br-sfn: %s migrations need a Postgres user — set %s.migrations.postgres.user or %s.configmap.POSTGRES_USER" .name .name .name) -}}
+{{- end -}}
+{{- $pgDb := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "database" "cfg" $cfg "cfgKey" "POSTGRES_DB" "fallback" "") -}}
+{{- if not $pgDb -}}
+{{- fail (printf "br-sfn: %s migrations need a Postgres database — set %s.migrations.postgres.database or %s.configmap.POSTGRES_DB" .name .name .name) -}}
+{{- end -}}
+{{- $pgSsl := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "sslMode" "cfg" $cfg "cfgKey" "POSTGRES_SSLMODE" "fallback" "disable") -}}
+{{- $pwSecret := ($mig.passwordSecret | default dict) -}}
+{{- $pwName := $pwSecret.name | default (include "br-sfn.componentSecretName" (dict "root" .root "name" (.secretComponent | default .name) "comp" .comp "sharedCfg" (.sharedCfg | default dict))) -}}
+{{- $pwKey := $pwSecret.key | default "POSTGRES_PASSWORD" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ include "global.namespace" .root }}
+  labels:
+    {{- include "br-sfn.componentLabels" $id | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: {{ $mig.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ $mig.activeDeadlineSeconds | default 600 }}
+  ttlSecondsAfterFinished: {{ $mig.ttlSecondsAfterFinished | default 600 }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-sfn.componentLabels" $id | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with (include "br-sfn.componentPullSecrets" (dict "root" .root "comp" (dict "imagePullSecrets" ($mig.imagePullSecrets | default .comp.imagePullSecrets)))) }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ .root.Values.waitImage | default "busybox:1.36" }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              echo "waiting for {{ $pgHost }}:{{ $pgPort }}...";
+              until nc -z {{ $pgHost }} {{ $pgPort }}; do
+                echo "{{ $pgHost }}:{{ $pgPort }} not ready, waiting..."; sleep 5;
+              done;
+              echo "{{ $pgHost }}:{{ $pgPort }} is ready"
+          securityContext:
+            {{- toYaml .root.Values.securityContext | nindent 12 }}
+        {{- if eq .flavor "baked" }}
+        # The app image is the single source of the migrations tree; copy it
+        # out so the migrate container never runs the service binary.
+        - name: extract-migrations
+          image: {{ include "br-sfn.componentImage" (dict "root" .root "comp" .comp) | quote }}
+          imagePullPolicy: {{ .comp.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /bin/sh
+            - -c
+            - cp -R {{ $mig.sourcePath | default "/migrations" }}/. /workdir/
+          securityContext:
+            {{- toYaml .root.Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: migrations
+              mountPath: /workdir
+        {{- end }}
+      containers:
+        {{- if eq .flavor "baked" }}
+        - name: migrations
+          image: {{ .root.Values.migrateImage | default "migrate/migrate:v4.18.1" }}
+          # URL assembled in-shell so the password rides a Secret env var, not
+          # the rendered manifest. Passwords must be URL-safe (no @ : / ? # %) —
+          # same constraint the compose migrators document.
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              migrate -path /migrations
+              -database "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=${POSTGRES_SSLMODE}{{ with $mig.table }}&x-migrations-table={{ . }}{{ end }}"
+              up
+          volumeMounts:
+            - name: migrations
+              mountPath: /migrations
+              readOnly: true
+        {{- else }}
+        - name: migrations
+          image: "{{ $mig.image.repository }}:{{ $mig.image.tag | default .root.Chart.AppVersion }}"
+          imagePullPolicy: {{ $mig.image.pullPolicy | default "IfNotPresent" }}
+        {{- end }}
+          env:
+            - name: POSTGRES_HOST
+              value: {{ $pgHost | quote }}
+            - name: POSTGRES_PORT
+              value: {{ $pgPort | quote }}
+            - name: POSTGRES_USER
+              value: {{ $pgUser | quote }}
+            - name: POSTGRES_DB
+              value: {{ $pgDb | quote }}
+            - name: POSTGRES_SSLMODE
+              value: {{ $pgSsl | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $pwName }}
+                  key: {{ $pwKey }}
+          securityContext:
+            {{- toYaml .root.Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml ($mig.resources | default dict) | nindent 12 }}
+      {{- if eq .flavor "baked" }}
+      volumes:
+        - name: migrations
+          emptyDir: {}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/br-sfn/templates/cockpit/configmap.yaml
+++ b/charts/br-sfn/templates/cockpit/configmap.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.cockpit.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "cockpit" "comp" $.Values.cockpit) }}
+{{- end -}}

--- a/charts/br-sfn/templates/cockpit/deployment.yaml
+++ b/charts/br-sfn/templates/cockpit/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.cockpit.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "cockpit" "comp" $.Values.cockpit "defaultPort" 8080 "livenessPath" "/" "readyPath" "/") }}
+{{- end -}}

--- a/charts/br-sfn/templates/cockpit/hpa.yaml
+++ b/charts/br-sfn/templates/cockpit/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.cockpit.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "cockpit" "comp" $.Values.cockpit) }}
+{{- end -}}

--- a/charts/br-sfn/templates/cockpit/ingress.yaml
+++ b/charts/br-sfn/templates/cockpit/ingress.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.cockpit.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "cockpit" "comp" $.Values.cockpit "defaultPort" 8080) }}
+{{- end -}}

--- a/charts/br-sfn/templates/cockpit/pdb.yaml
+++ b/charts/br-sfn/templates/cockpit/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.cockpit.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "cockpit" "comp" $.Values.cockpit) }}
+{{- end -}}

--- a/charts/br-sfn/templates/cockpit/secrets.yaml
+++ b/charts/br-sfn/templates/cockpit/secrets.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.cockpit.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "cockpit" "comp" $.Values.cockpit) }}
+{{- end -}}

--- a/charts/br-sfn/templates/cockpit/service.yaml
+++ b/charts/br-sfn/templates/cockpit/service.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.cockpit.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "cockpit" "comp" $.Values.cockpit "defaultPort" 8080) }}
+{{- end -}}

--- a/charts/br-sfn/templates/common/NOTES.txt
+++ b/charts/br-sfn/templates/common/NOTES.txt
@@ -1,0 +1,31 @@
+br-sfn — Brazilian SFN rails ({{ .Chart.Version }})
+
+Enabled components:
+{{- $any := false }}
+{{- if .Values.spb.enabled }}{{ $any = true }}
+  - spb (SPB/STR)          → svc {{ include "br-sfn.componentFullname" (dict "root" . "name" "spb") }}:{{ .Values.spb.service.port }}
+{{- end }}
+{{- if .Values.spi.enabled }}{{ $any = true }}
+  - spi (Pix: api/dict/brcode/core) → svc {{ include "br-sfn.componentFullname" (dict "root" . "name" "spi-api") }}:{{ .Values.spi.api.service.port }} (+dict/brcode/core)
+{{- end }}
+{{- if .Values.siloc.enabled }}{{ $any = true }}
+  - siloc                  → svc {{ include "br-sfn.componentFullname" (dict "root" . "name" "siloc") }}:{{ .Values.siloc.service.port }}
+{{- end }}
+{{- if .Values.scr.enabled }}{{ $any = true }}
+  - scr                    → svc {{ include "br-sfn.componentFullname" (dict "root" . "name" "scr") }}:{{ .Values.scr.service.port }}
+{{- end }}
+{{- if .Values.desk.enabled }}{{ $any = true }}
+  - desk                   → svc {{ include "br-sfn.componentFullname" (dict "root" . "name" "desk") }}:{{ .Values.desk.service.port }}
+{{- end }}
+{{- if .Values.slcEdge.enabled }}{{ $any = true }}
+  - slc-edge               → svc {{ include "br-sfn.componentFullname" (dict "root" . "name" "slc-edge") }}:{{ .Values.slcEdge.service.port }}
+{{- end }}
+{{- if .Values.cockpit.enabled }}{{ $any = true }}
+  - cockpit (SPA)          → svc {{ include "br-sfn.componentFullname" (dict "root" . "name" "cockpit") }}:{{ .Values.cockpit.service.port }}
+{{- end }}
+{{- if not $any }}
+  (none — this chart is modular; enable rails via <component>.enabled=true)
+{{- end }}
+
+Infra (Postgres/Valkey/RabbitMQ/RedPanda/IBM MQ) is external by contract.
+RedPanda topics for spb/spi are an environment concern (not created here).

--- a/charts/br-sfn/templates/common/serviceaccount.yaml
+++ b/charts/br-sfn/templates/common/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "br-sfn.serviceAccountName" . }}
+  namespace: {{ include "global.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "br-sfn.chart" . }}
+    app.kubernetes.io/name: {{ include "br-sfn.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: br-sfn
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/br-sfn/templates/desk/configmap.yaml
+++ b/charts/br-sfn/templates/desk/configmap.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "desk" "comp" $.Values.desk) }}
+{{- end -}}

--- a/charts/br-sfn/templates/desk/deployment.yaml
+++ b/charts/br-sfn/templates/desk/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "desk" "comp" $.Values.desk "defaultPort" 3002 "livenessPath" "/health" "readyPath" "/readyz") }}
+{{- end -}}

--- a/charts/br-sfn/templates/desk/hpa.yaml
+++ b/charts/br-sfn/templates/desk/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "desk" "comp" $.Values.desk) }}
+{{- end -}}

--- a/charts/br-sfn/templates/desk/ingress.yaml
+++ b/charts/br-sfn/templates/desk/ingress.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "desk" "comp" $.Values.desk "defaultPort" 3002) }}
+{{- end -}}

--- a/charts/br-sfn/templates/desk/migrations-job.yaml
+++ b/charts/br-sfn/templates/desk/migrations-job.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "desk" "comp" $.Values.desk "flavor" "baked") }}
+{{- end -}}

--- a/charts/br-sfn/templates/desk/pdb.yaml
+++ b/charts/br-sfn/templates/desk/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "desk" "comp" $.Values.desk) }}
+{{- end -}}

--- a/charts/br-sfn/templates/desk/secrets.yaml
+++ b/charts/br-sfn/templates/desk/secrets.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "desk" "comp" $.Values.desk) }}
+{{- end -}}

--- a/charts/br-sfn/templates/desk/service.yaml
+++ b/charts/br-sfn/templates/desk/service.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.desk.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "desk" "comp" $.Values.desk "defaultPort" 3002) }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/configmap.yaml
+++ b/charts/br-sfn/templates/scr/configmap.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "scr" "comp" $.Values.scr) }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/deployment.yaml
+++ b/charts/br-sfn/templates/scr/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "scr" "comp" $.Values.scr "defaultPort" 3003 "livenessPath" "/health" "readyPath" "/readyz") }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/hpa.yaml
+++ b/charts/br-sfn/templates/scr/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "scr" "comp" $.Values.scr) }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/ingress.yaml
+++ b/charts/br-sfn/templates/scr/ingress.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "scr" "comp" $.Values.scr "defaultPort" 3003) }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/migrations-job.yaml
+++ b/charts/br-sfn/templates/scr/migrations-job.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "scr" "comp" $.Values.scr "flavor" "baked") }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/pdb.yaml
+++ b/charts/br-sfn/templates/scr/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "scr" "comp" $.Values.scr) }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/secrets.yaml
+++ b/charts/br-sfn/templates/scr/secrets.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "scr" "comp" $.Values.scr) }}
+{{- end -}}

--- a/charts/br-sfn/templates/scr/service.yaml
+++ b/charts/br-sfn/templates/scr/service.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.scr.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "scr" "comp" $.Values.scr "defaultPort" 3003) }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/configmap.yaml
+++ b/charts/br-sfn/templates/siloc/configmap.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "siloc" "comp" $.Values.siloc) }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/deployment.yaml
+++ b/charts/br-sfn/templates/siloc/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "siloc" "comp" $.Values.siloc "defaultPort" 9820 "livenessPath" "/health" "readyPath" "/readyz") }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/hpa.yaml
+++ b/charts/br-sfn/templates/siloc/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "siloc" "comp" $.Values.siloc) }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/ingress.yaml
+++ b/charts/br-sfn/templates/siloc/ingress.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "siloc" "comp" $.Values.siloc "defaultPort" 9820) }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/migrations-job.yaml
+++ b/charts/br-sfn/templates/siloc/migrations-job.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "siloc" "comp" $.Values.siloc "flavor" "dedicated") }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/pdb.yaml
+++ b/charts/br-sfn/templates/siloc/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "siloc" "comp" $.Values.siloc) }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/secrets.yaml
+++ b/charts/br-sfn/templates/siloc/secrets.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "siloc" "comp" $.Values.siloc) }}
+{{- end -}}

--- a/charts/br-sfn/templates/siloc/service.yaml
+++ b/charts/br-sfn/templates/siloc/service.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.siloc.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "siloc" "comp" $.Values.siloc "defaultPort" 9820) }}
+{{- end -}}

--- a/charts/br-sfn/templates/slc-edge/configmap.yaml
+++ b/charts/br-sfn/templates/slc-edge/configmap.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.slcEdge.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "slc-edge" "comp" $.Values.slcEdge) }}
+{{- end -}}

--- a/charts/br-sfn/templates/slc-edge/deployment.yaml
+++ b/charts/br-sfn/templates/slc-edge/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.slcEdge.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "slc-edge" "comp" $.Values.slcEdge "defaultPort" 3005 "livenessPath" "/health" "readyPath" "/readyz") }}
+{{- end -}}

--- a/charts/br-sfn/templates/slc-edge/hpa.yaml
+++ b/charts/br-sfn/templates/slc-edge/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.slcEdge.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "slc-edge" "comp" $.Values.slcEdge) }}
+{{- end -}}

--- a/charts/br-sfn/templates/slc-edge/ingress.yaml
+++ b/charts/br-sfn/templates/slc-edge/ingress.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.slcEdge.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "slc-edge" "comp" $.Values.slcEdge "defaultPort" 3005) }}
+{{- end -}}

--- a/charts/br-sfn/templates/slc-edge/pdb.yaml
+++ b/charts/br-sfn/templates/slc-edge/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.slcEdge.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "slc-edge" "comp" $.Values.slcEdge) }}
+{{- end -}}

--- a/charts/br-sfn/templates/slc-edge/secrets.yaml
+++ b/charts/br-sfn/templates/slc-edge/secrets.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.slcEdge.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "slc-edge" "comp" $.Values.slcEdge) }}
+{{- end -}}

--- a/charts/br-sfn/templates/slc-edge/service.yaml
+++ b/charts/br-sfn/templates/slc-edge/service.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.slcEdge.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "slc-edge" "comp" $.Values.slcEdge "defaultPort" 3005) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/configmap.yaml
+++ b/charts/br-sfn/templates/spb/configmap.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "spb" "comp" $.Values.spb) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/deployment.yaml
+++ b/charts/br-sfn/templates/spb/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "spb" "comp" $.Values.spb "defaultPort" 3000 "livenessPath" "/health" "readyPath" "/readyz") }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/hpa.yaml
+++ b/charts/br-sfn/templates/spb/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "spb" "comp" $.Values.spb) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/ingress.yaml
+++ b/charts/br-sfn/templates/spb/ingress.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "spb" "comp" $.Values.spb "defaultPort" 3000) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/migrations-job.yaml
+++ b/charts/br-sfn/templates/spb/migrations-job.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "spb" "comp" $.Values.spb "flavor" "baked") }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/pdb.yaml
+++ b/charts/br-sfn/templates/spb/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "spb" "comp" $.Values.spb) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/secrets.yaml
+++ b/charts/br-sfn/templates/spb/secrets.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "spb" "comp" $.Values.spb) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spb/service.yaml
+++ b/charts/br-sfn/templates/spb/service.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.spb.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "spb" "comp" $.Values.spb "defaultPort" 3000) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/configmap.yaml
+++ b/charts/br-sfn/templates/spi/configmap.yaml
@@ -1,0 +1,9 @@
+{{- if $.Values.spi.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "spi-api" "comp" $.Values.spi.api "shared" $.Values.spi.configmap) }}
+---
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "spi-dict" "comp" $.Values.spi.dict "shared" $.Values.spi.configmap) }}
+---
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "spi-brcode" "comp" $.Values.spi.brcode "shared" $.Values.spi.configmap) }}
+---
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "spi-core" "comp" $.Values.spi.core "shared" $.Values.spi.configmap) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/deployment.yaml
+++ b/charts/br-sfn/templates/spi/deployment.yaml
@@ -1,0 +1,9 @@
+{{- if $.Values.spi.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "spi-api" "comp" $.Values.spi.api "shared" $.Values.spi.configmap "sharedCfg" $.Values.spi "defaultPort" 9800 "livenessPath" "/health" "readyPath" "/readyz") }}
+---
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "spi-dict" "comp" $.Values.spi.dict "shared" $.Values.spi.configmap "sharedCfg" $.Values.spi "defaultPort" 9801 "livenessPath" "/health" "readyPath" "/readyz") }}
+---
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "spi-brcode" "comp" $.Values.spi.brcode "shared" $.Values.spi.configmap "sharedCfg" $.Values.spi "defaultPort" 9802 "livenessPath" "/health" "readyPath" "/readyz") }}
+---
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "spi-core" "comp" $.Values.spi.core "shared" $.Values.spi.configmap "sharedCfg" $.Values.spi "defaultPort" 9803 "livenessPath" "/health" "readyPath" "/readyz") }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/hpa.yaml
+++ b/charts/br-sfn/templates/spi/hpa.yaml
@@ -1,0 +1,9 @@
+{{- if $.Values.spi.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "spi-api" "comp" $.Values.spi.api) }}
+---
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "spi-dict" "comp" $.Values.spi.dict) }}
+---
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "spi-brcode" "comp" $.Values.spi.brcode) }}
+---
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "spi-core" "comp" $.Values.spi.core) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/ingress.yaml
+++ b/charts/br-sfn/templates/spi/ingress.yaml
@@ -1,0 +1,9 @@
+{{- if $.Values.spi.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "spi-api" "comp" $.Values.spi.api "defaultPort" 9800) }}
+---
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "spi-dict" "comp" $.Values.spi.dict "defaultPort" 9801) }}
+---
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "spi-brcode" "comp" $.Values.spi.brcode "defaultPort" 9802) }}
+---
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "spi-core" "comp" $.Values.spi.core "defaultPort" 9803) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/migrations-job.yaml
+++ b/charts/br-sfn/templates/spi/migrations-job.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.spi.enabled -}}
+{{- /* One PreSync Job for the whole Pix family: the dedicated br-spi-migrations
+image owns module ordering (global → events → spi → dict → brcode → core) and
+the per-module bookkeeping tables every /readyz schema probe reads. The comp
+dict is assembled so Postgres fallbacks read the api component's effective
+configmap and the password defaults to the spi-api Secret (the shared
+spi.secrets map renders into each component Secret, api included). */ -}}
+{{- $comp := dict
+      "migrations" .Values.spi.migrations
+      "configmap" .Values.spi.api.configmap
+      "secrets" .Values.spi.api.secrets
+      "image" .Values.spi.api.image
+      "imagePullSecrets" .Values.spi.api.imagePullSecrets
+      "useExistingSecret" .Values.spi.useExistingSecret
+      "existingSecretName" .Values.spi.existingSecretName
+-}}
+{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "spi" "secretComponent" "spi-api" "comp" $comp "shared" .Values.spi.configmap "sharedCfg" .Values.spi "flavor" "dedicated") }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/migrations-job.yaml
+++ b/charts/br-sfn/templates/spi/migrations-job.yaml
@@ -3,16 +3,18 @@
 image owns module ordering (global → events → spi → dict → brcode → core) and
 the per-module bookkeeping tables every /readyz schema probe reads. The comp
 dict is assembled so Postgres fallbacks read the api component's effective
-configmap and the password defaults to the spi-api Secret (the shared
-spi.secrets map renders into each component Secret, api included). */ -}}
+configmap and the password resolves EXACTLY like spi-api's own Secret does:
+api-level useExistingSecret/existingSecretName first, then the family-level
+spi.* flags (sharedCfg), then the generated path — which mints a dedicated
+PreSync Secret from the merged spi.secrets + spi.api.secrets maps. */ -}}
 {{- $comp := dict
       "migrations" .Values.spi.migrations
       "configmap" .Values.spi.api.configmap
       "secrets" .Values.spi.api.secrets
       "image" .Values.spi.api.image
       "imagePullSecrets" .Values.spi.api.imagePullSecrets
-      "useExistingSecret" .Values.spi.useExistingSecret
-      "existingSecretName" .Values.spi.existingSecretName
+      "useExistingSecret" .Values.spi.api.useExistingSecret
+      "existingSecretName" .Values.spi.api.existingSecretName
 -}}
-{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "spi" "secretComponent" "spi-api" "comp" $comp "shared" .Values.spi.configmap "sharedCfg" .Values.spi "flavor" "dedicated") }}
+{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "spi" "secretComponent" "spi-api" "comp" $comp "shared" .Values.spi.configmap "sharedSecrets" .Values.spi.secrets "sharedCfg" .Values.spi "flavor" "dedicated") }}
 {{- end -}}

--- a/charts/br-sfn/templates/spi/pdb.yaml
+++ b/charts/br-sfn/templates/spi/pdb.yaml
@@ -1,0 +1,9 @@
+{{- if $.Values.spi.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "spi-api" "comp" $.Values.spi.api) }}
+---
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "spi-dict" "comp" $.Values.spi.dict) }}
+---
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "spi-brcode" "comp" $.Values.spi.brcode) }}
+---
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "spi-core" "comp" $.Values.spi.core) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/secrets.yaml
+++ b/charts/br-sfn/templates/spi/secrets.yaml
@@ -1,0 +1,9 @@
+{{- if $.Values.spi.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "spi-api" "comp" $.Values.spi.api "shared" $.Values.spi.secrets "sharedCfg" $.Values.spi) }}
+---
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "spi-dict" "comp" $.Values.spi.dict "shared" $.Values.spi.secrets "sharedCfg" $.Values.spi) }}
+---
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "spi-brcode" "comp" $.Values.spi.brcode "shared" $.Values.spi.secrets "sharedCfg" $.Values.spi) }}
+---
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "spi-core" "comp" $.Values.spi.core "shared" $.Values.spi.secrets "sharedCfg" $.Values.spi) }}
+{{- end -}}

--- a/charts/br-sfn/templates/spi/service.yaml
+++ b/charts/br-sfn/templates/spi/service.yaml
@@ -1,0 +1,9 @@
+{{- if $.Values.spi.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "spi-api" "comp" $.Values.spi.api "defaultPort" 9800) }}
+---
+{{ include "br-sfn.componentService" (dict "root" $ "name" "spi-dict" "comp" $.Values.spi.dict "defaultPort" 9801) }}
+---
+{{ include "br-sfn.componentService" (dict "root" $ "name" "spi-brcode" "comp" $.Values.spi.brcode "defaultPort" 9802) }}
+---
+{{ include "br-sfn.componentService" (dict "root" $ "name" "spi-core" "comp" $.Values.spi.core "defaultPort" 9803) }}
+{{- end -}}

--- a/charts/br-sfn/values-template.yaml
+++ b/charts/br-sfn/values-template.yaml
@@ -1,0 +1,66 @@
+# values-template.yaml — operator skeleton for the br-sfn chart.
+# Modular contract: every component defaults OFF. Enable only what you run,
+# then fill the required secrets for each enabled rail.
+
+# spb:
+#   enabled: true
+#   image:
+#     tag: ""            # pin the spb release (svc-scoped tags: spb/vX.Y.Z → X.Y.Z)
+#   configmap:
+#     POSTGRES_HOST: ""
+#     POSTGRES_PORT: "5432"
+#     POSTGRES_USER: ""
+#     POSTGRES_DB: ""
+#   secrets:
+#     POSTGRES_PASSWORD: ""   # required when spb.enabled (URL-safe)
+
+# spi:
+#   enabled: true
+#   configmap: {}            # shared by api/dict/brcode/core (component maps win)
+#   secrets:
+#     POSTGRES_PASSWORD: ""  # required when spi.enabled (URL-safe)
+#   api:
+#     image:
+#       tag: ""
+#   dict: {}
+#   brcode: {}
+#   core: {}
+#   migrations:
+#     image:
+#       tag: ""              # br-spi-migrations release
+
+# siloc:
+#   enabled: true
+#   secrets:
+#     POSTGRES_PASSWORD: ""
+#   migrations:
+#     image:
+#       tag: ""              # br-siloc-migrations release
+
+# scr:
+#   enabled: true
+#   configmap:
+#     POSTGRES_HOST: ""
+#     POSTGRES_USER: ""
+#     POSTGRES_DB: ""
+#   secrets:
+#     POSTGRES_PASSWORD: ""
+
+# desk:
+#   enabled: true
+#   configmap:
+#     POSTGRES_HOST: ""
+#     POSTGRES_USER: ""
+#     POSTGRES_DB: ""
+#   secrets:
+#     POSTGRES_PASSWORD: ""
+
+# slcEdge:
+#   enabled: true
+#   configmap:
+#     SLC_CORE_URL: ""       # br-slc core base URL
+
+# cockpit:
+#   enabled: true
+#   image:
+#     tag: ""                # VITE_* URLs are baked at image build time

--- a/charts/br-sfn/values-template.yaml
+++ b/charts/br-sfn/values-template.yaml
@@ -16,7 +16,11 @@
 
 # spi:
 #   enabled: true
-#   configmap: {}            # shared by api/dict/brcode/core (component maps win)
+#   configmap:               # shared by api/dict/brcode/core (component maps win)
+#     POSTGRES_HOST: ""
+#     POSTGRES_PORT: "5432"
+#     POSTGRES_USER: ""
+#     POSTGRES_DB: ""
 #   secrets:
 #     POSTGRES_PASSWORD: ""  # required when spi.enabled (URL-safe)
 #   api:
@@ -31,6 +35,11 @@
 
 # siloc:
 #   enabled: true
+#   configmap:
+#     POSTGRES_HOST: ""
+#     POSTGRES_PORT: "5432"
+#     POSTGRES_USER: ""
+#     POSTGRES_DB: ""
 #   secrets:
 #     POSTGRES_PASSWORD: ""
 #   migrations:

--- a/charts/br-sfn/values.schema.json
+++ b/charts/br-sfn/values.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "waitImage": {
+      "type": "string"
+    },
+    "migrateImage": {
+      "type": "string"
+    },
+    "spb": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "spi": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "siloc": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "scr": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "desk": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "slcEdge": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "cockpit": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/charts/br-sfn/values.yaml
+++ b/charts/br-sfn/values.yaml
@@ -1,0 +1,720 @@
+# Default values for the br-sfn (Brazilian SFN rails) chart.
+#
+# MODULARITY CONTRACT: every component defaults to enabled: false. This is a
+# monorepo of independent rails — SPB (STR/TED), SPI (Pix, 4 runtime binaries),
+# SILOC, SCR, desk (cockpit operator-state), slc-edge (Cabine SLC passthrough)
+# and the cockpit SPA — and no deployment runs all of them. Enable exactly the
+# rails the environment operates.
+#
+# INFRA CONTRACT: Postgres / Valkey(Redis) / RabbitMQ / RedPanda / IBM MQ are
+# EXTERNAL pre-provisioned services. This chart ships no infra subcharts; every
+# connection string arrives via each component's configmap/secrets maps, which
+# are emitted VERBATIM (no fixed allowlist) so new env vars never need a chart
+# change.
+#
+# RedPanda topics: spb and spi expect their topics to exist (the compose
+# redpanda-topics one-shot is a dev-only convenience). Topic provisioning is an
+# environment concern, not this chart's.
+nameOverride: "br-sfn"
+fullnameOverride: ""
+namespaceOverride: ""
+
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
+# -- Default pull secret for every component and migration Job (single GHCR
+# credential). Override per component via <component>.imagePullSecrets.
+imagePullSecrets:
+  - name: ghcr-credential
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# -- Pod-level security context (all components)
+podSecurityContext: {}
+
+# -- Container security context (alpine/debian nonroot images — UID/GID 65532;
+# the cockpit overrides runAsUser/runAsGroup via cockpit.securityContext because
+# nginx-unprivileged runs as uid 101).
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Image used by wait-for-dependency initContainers.
+waitImage: busybox:1.36
+
+# -- golang-migrate image for components whose migrations run from their baked
+# /migrations tree (spb, scr, desk). spi and siloc ship dedicated migrator
+# images instead (see their migrations blocks).
+migrateImage: migrate/migrate:v4.18.1
+
+# =============================================================================
+# spb — SPB/STR rail (TED). CGO + IBM MQ runtime (debian-based image).
+# =============================================================================
+spb:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-spb
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+  service:
+    type: ClusterIP
+    # Matches the Dockerfile EXPOSE 3000.
+    port: 3000
+  # -- Emitted verbatim into the component ConfigMap.
+  configmap: {}
+  # -- Emitted verbatim into the component Secret (AVP <path:...> refs on
+  # gitops tiers). Use useExistingSecret/existingSecretName to bring your own.
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  livenessProbe: {}
+  readinessProbe: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  # PreSync migration Job — golang-migrate over the migrations tree baked into
+  # the app image at /app/migrations (default schema_migrations table).
+  migrations:
+    enabled: true
+    # Baked flavor: copies the tree out of the app image and runs migrateImage.
+    sourcePath: /app/migrations
+    # x-migrations-table; empty = golang-migrate default (schema_migrations).
+    table: ""
+    postgres:
+      host: ""
+      port: ""
+      user: ""
+      database: ""
+      sslMode: ""
+    # Defaults to this component's Secret and POSTGRES_PASSWORD key.
+    passwordSecret:
+      name: ""
+      key: POSTGRES_PASSWORD
+    imagePullSecrets: []
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    ttlSecondsAfterFinished: 600
+    resources: {}
+
+# =============================================================================
+# spi — SPI/Pix rail: FOUR runtime binaries (spi, dict, brcode, core) sharing
+# one image family, one Postgres, one Redis and RedPanda, plus a dedicated
+# migrator image (br-spi-migrations) that owns the module-ordered schema.
+# =============================================================================
+spi:
+  enabled: false
+  # Shared blocks for all four components; each component block below can
+  # override any of them.
+  configmap: {}
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  api:
+    replicaCount: 1
+    revisionHistoryLimit: 10
+    image:
+      repository: ghcr.io/lerianstudio/br-spi
+      tag: ""
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    deploymentUpdate:
+      type: RollingUpdate
+      maxSurge: 1
+      maxUnavailable: 0
+    service:
+      type: ClusterIP
+      port: 9800
+    configmap: {}
+    secrets: {}
+    extraEnvVars: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    livenessProbe: {}
+    readinessProbe: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+    pdb:
+      enabled: false
+      minAvailable: 1
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  dict:
+    replicaCount: 1
+    revisionHistoryLimit: 10
+    image:
+      repository: ghcr.io/lerianstudio/br-spi-dict
+      tag: ""
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    deploymentUpdate:
+      type: RollingUpdate
+      maxSurge: 1
+      maxUnavailable: 0
+    service:
+      type: ClusterIP
+      port: 9801
+    configmap: {}
+    secrets: {}
+    extraEnvVars: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    livenessProbe: {}
+    readinessProbe: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+    pdb:
+      enabled: false
+      minAvailable: 1
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  brcode:
+    replicaCount: 1
+    revisionHistoryLimit: 10
+    image:
+      repository: ghcr.io/lerianstudio/br-spi-brcode
+      tag: ""
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    deploymentUpdate:
+      type: RollingUpdate
+      maxSurge: 1
+      maxUnavailable: 0
+    service:
+      type: ClusterIP
+      port: 9802
+    configmap: {}
+    secrets: {}
+    extraEnvVars: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    livenessProbe: {}
+    readinessProbe: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+    pdb:
+      enabled: false
+      minAvailable: 1
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  core:
+    replicaCount: 1
+    revisionHistoryLimit: 10
+    image:
+      repository: ghcr.io/lerianstudio/br-spi-core
+      tag: ""
+      pullPolicy: IfNotPresent
+    imagePullSecrets: []
+    podAnnotations: {}
+    deploymentUpdate:
+      type: RollingUpdate
+      maxSurge: 1
+      maxUnavailable: 0
+    service:
+      type: ClusterIP
+      port: 9803
+    configmap: {}
+    secrets: {}
+    extraEnvVars: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    livenessProbe: {}
+    readinessProbe: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+    pdb:
+      enabled: false
+      minAvailable: 1
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  # PreSync migration Job — the DEDICATED br-spi-migrations image. Its
+  # entrypoint applies the module-ordered tree (global → events → spi → dict →
+  # brcode → core) with per-module bookkeeping tables the /readyz schema probe
+  # reads; never swap it for a plain golang-migrate run.
+  migrations:
+    enabled: true
+    image:
+      repository: ghcr.io/lerianstudio/br-spi-migrations
+      tag: ""
+      pullPolicy: IfNotPresent
+    postgres:
+      host: ""
+      port: ""
+      user: ""
+      database: ""
+      sslMode: ""
+    passwordSecret:
+      name: ""
+      key: POSTGRES_PASSWORD
+    imagePullSecrets: []
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    ttlSecondsAfterFinished: 600
+    resources: {}
+
+# =============================================================================
+# siloc — SILOC rail (card settlement files). CGO + IBM MQ runtime, with a
+# dedicated migrator image (br-siloc-migrations).
+# =============================================================================
+siloc:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-siloc
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+  service:
+    type: ClusterIP
+    # Matches the Dockerfile EXPOSE 9820.
+    port: 9820
+  configmap: {}
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  livenessProbe: {}
+  readinessProbe: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  # PreSync migration Job — dedicated br-siloc-migrations image (module-ordered
+  # entrypoint, same shape as spi's).
+  migrations:
+    enabled: true
+    image:
+      repository: ghcr.io/lerianstudio/br-siloc-migrations
+      tag: ""
+      pullPolicy: IfNotPresent
+    postgres:
+      host: ""
+      port: ""
+      user: ""
+      database: ""
+      sslMode: ""
+    passwordSecret:
+      name: ""
+      key: POSTGRES_PASSWORD
+    imagePullSecrets: []
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    ttlSecondsAfterFinished: 600
+    resources: {}
+
+# =============================================================================
+# scr — SCR rail (credit information / wsscr2n). CGO-free alpine runtime;
+# migrations baked at /migrations with the schema_migrations_scr table.
+# =============================================================================
+scr:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-scr
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+  service:
+    type: ClusterIP
+    # Matches the Dockerfile EXPOSE 3003 (config defaultServerPort).
+    port: 3003
+  configmap: {}
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  livenessProbe: {}
+  readinessProbe: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  migrations:
+    enabled: true
+    sourcePath: /migrations
+    # The SCR /readyz schema probe reads exactly this bookkeeping table.
+    table: schema_migrations_scr
+    postgres:
+      host: ""
+      port: ""
+      user: ""
+      database: ""
+      sslMode: ""
+    passwordSecret:
+      name: ""
+      key: POSTGRES_PASSWORD
+    imagePullSecrets: []
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    ttlSecondsAfterFinished: 600
+    resources: {}
+
+# =============================================================================
+# desk — cockpit operator-state + four-eyes service. CGO-free alpine runtime;
+# migrations baked at /migrations (default schema_migrations table — the desk
+# schema-readiness probe reads that exact name).
+# =============================================================================
+desk:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-desk
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+  service:
+    type: ClusterIP
+    # Matches the Dockerfile EXPOSE 3002 (config defaultServerPort).
+    port: 3002
+  configmap: {}
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  livenessProbe: {}
+  readinessProbe: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  migrations:
+    enabled: true
+    sourcePath: /migrations
+    table: ""
+    postgres:
+      host: ""
+      port: ""
+      user: ""
+      database: ""
+      sslMode: ""
+    passwordSecret:
+      name: ""
+      key: POSTGRES_PASSWORD
+    imagePullSecrets: []
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    ttlSecondsAfterFinished: 600
+    resources: {}
+
+# =============================================================================
+# slcEdge — Cabine SLC authenticated passthrough edge (br-slc-edge). Stateless:
+# no datastore, no migrations. Renders as "slc-edge" resources.
+# =============================================================================
+slcEdge:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-slc-edge
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+  service:
+    type: ClusterIP
+    # Matches the Dockerfile EXPOSE 3005 (config defaultServerPort).
+    port: 3005
+  configmap: {}
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  livenessProbe: {}
+  readinessProbe: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+# =============================================================================
+# cockpit — the br-sfn operations SPA (nginx-unprivileged serving the Vite
+# bundle). VITE_* URLs are BAKED at image build time; the published baseline
+# image carries honest-degrade defaults, so environments that need real URLs
+# build/pin an environment-specific image. No configmap/secrets by default.
+# =============================================================================
+cockpit:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-sfn-cockpit
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+  service:
+    type: ClusterIP
+    # Matches nginx-unprivileged EXPOSE 8080.
+    port: 8080
+  configmap: {}
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+  # nginx-unprivileged needs a writable /tmp (pid file + proxy/cache dirs)
+  # under readOnlyRootFilesystem.
+  extraVolumes:
+    - name: tmp
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: tmp
+      mountPath: /tmp
+  # The SPA has no /health endpoints; nginx serves / for both probes.
+  livenessProbe:
+    path: /
+  readinessProbe:
+    path: /
+  # nginx-unprivileged runs as uid 101.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []


### PR DESCRIPTION
## What

Umbrella chart for the **br-sfn** monorepo with one component block per rail — and the modularity contract front and center: **everything ships `enabled: false`**. Not every deployment runs every rail; operators enable exactly what they operate. A default render produces only the shared ServiceAccount.

| Component | Values key | Image (ghcr) | Port | Migrations |
|-----------|-----------|--------------|------|------------|
| SPB/STR | `spb` | `br-spb` | 3000 | baked (`/app/migrations`) |
| SPI/Pix | `spi.{api,dict,brcode,core}` | `br-spi{,-dict,-brcode,-core}` | 9800–9803 | family Job (`br-spi-migrations`) |
| SILOC | `siloc` | `br-siloc` | 9820 | dedicated (`br-siloc-migrations`) |
| SCR | `scr` | `br-scr` | 3003 | baked (table `schema_migrations_scr`) |
| desk | `desk` | `br-desk` | 3002 | baked |
| slc-edge | `slcEdge` | `br-slc-edge` | 3005 | none (stateless) |
| cockpit | `cockpit` | `br-sfn-cockpit` | 8080 | none (SPA) |

## Design notes

- **multi-component standard shape**: generic component library in `_helpers.tpl`, thin per-component template dirs, `values-template.yaml`, generated `values.schema.json`, Chart Contract in the README.
- **SPI family**: four binaries, one Postgres/Redis/RedPanda — `spi.configmap`/`spi.secrets` merge under each component block (component wins). One PreSync migration Job for the family: the dedicated migrator owns module ordering (global→events→spi→dict→brcode→core) and the per-module bookkeeping tables the `/readyz` schema probes read.
- **Migration flavors**: baked (initContainer copies the tree out of the app image → `migrate/migrate`) vs dedicated (rail's own migrator image). Connection values resolve `migrations.postgres.*` → component `configmap` fallback; **fail-loud** when host/user/db are missing.
- **No dependencies**: Postgres/Valkey/RabbitMQ/RedPanda/IBM MQ are external pre-provisioned services on every target (benedita tiers and BYOC). RedPanda topic provisioning is an environment concern.
- **cockpit caveat** (documented): VITE_* URLs bake at image build time; baseline image = honest-degrade defaults; env-specific URLs need an env-specific image build. nginx-unprivileged uid 101 securityContext override + writable /tmp.
- Images published by the br-sfn release pipeline (LerianStudio/br-sfn#87) under svc-scoped tags — components version independently, so production values pin `<component>.image.tag`.

## Verification

- `helm lint` clean; **strict validator: 0 violations**; schema generated by `generate-values-schemas`.
- Full-render CI fixture (`.github/configs/helm-render-values/br-sfn.yaml`) exercises all 10 Deployments + 5 migration Jobs; **zero dangling secret refs** (checked doc-by-doc).
- Empty render = ServiceAccount only (modularity proof).
- Fail-loud gates tested: `useExistingSecret` without name, migrations without Postgres host.
- No Bitnami deps → no release-name-collapse surface.

## Sequencing

First consumer is gitops dev-st (single-tenant lane) once br-sfn#87 merges and the first `svc/v1.0.0-beta.1` tags publish images. Alpha channel (`helm-alpha.yml`) can exercise the chart before this merges.