### PR TITLE
docs(charts): add BR SFN section to the chart version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `1.0.0` | `1.0.0-beta.1` |
+| `1.0.0-beta.1` | `1.0.0-beta.1` |
 -----------------
 
 ### Lerian Common (Library)

--- a/README.md
+++ b/README.md
@@ -238,6 +238,17 @@ For implementation and configuration details, see the [README](https://charts.le
 | `1.1.0` | `1.0.0-beta.109` | `1.0.0-beta.109` |
 -----------------
 
+### BR SFN
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/br-sfn).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `1.0.0` | `1.0.0-beta.1` |
+-----------------
+
 ### Lerian Common (Library)
 
 Library chart consumed by other Lerian charts — renders nothing on its own.


### PR DESCRIPTION
Unblocks the br-sfn chart release.

The `Helm Release` run for #1775 ([run](https://github.com/LerianStudio/helm/actions/runs/30623746769)) failed in semantic-release `prepare`:

```
Command failed with exit code 1: ./.github/scripts/update-chart-version-readme-bin --chart br-sfn --version 1.0.0
WARNING: Could not find section for chart 'br-sfn'
```

`update-chart-version-readme-bin` updates an **existing** README section per chart — it never creates one — and #1775 didn't add it. This PR adds the `### BR SFN` section in the same shape as the neighbors (BR SISBAJUD et al.), with the app-version mapping pointing at the monorepo's per-component `svc/v1.0.0-beta.1` tags.

Note: `release.yml` has `paths-ignore: README.md`, so this PR itself won't trigger a release — the next qualifying push to `charts/br-sfn/**` (or a re-run) will pick the section up.