### PR TITLE
feat(charts): add br-consignado gateway with operator console

### DIFF
--- a/.github/configs/helm-render-values/br-consignado-gw-helm.yaml
+++ b/.github/configs/helm-render-values/br-consignado-gw-helm.yaml
@@ -1,0 +1,35 @@
+# CI render fixture — dummy values only, NOT a production example.
+api:
+  enabled: true
+  image:
+    tag: "1.3.0-beta.33"
+  configmap:
+    ENV_NAME: "development"
+    POSTGRES_HOST: "postgres.example.internal"
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: "br_consignado_gw"
+    POSTGRES_NAME: "br_consignado_gw"
+    POSTGRES_SSLMODE: "disable"
+  secrets:
+    POSTGRES_PASSWORD: "fixture-url-safe-password"
+
+ui:
+  enabled: true
+  image:
+    tag: "1.3.0-beta.33"
+  configmap:
+    API_BASE_URL: ""
+    CASDOOR_CSP_ORIGIN: "https://casdoor.example.internal"
+    CASDOOR_ENDPOINT: "https://casdoor.example.internal"
+    CASDOOR_CLIENT_ID: "fixture-client"
+    CASDOOR_ORG_NAME: "lerian"
+    CASDOOR_APP_NAME: "br-consignado-gw"
+    AUTH_DISABLED: "false"
+
+ingress:
+  enabled: true
+  hosts:
+    - host: "consignado.example.internal"
+
+migrations:
+  enabled: true

--- a/README.md
+++ b/README.md
@@ -249,6 +249,19 @@ For implementation and configuration details, see the [README](https://charts.le
 | `1.0.0` | `1.0.0-beta.1` |
 -----------------
 
+### BR Consignado GW
+
+API gateway and same-origin operator console for the Dataprev consignado rail.
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/br-consignado-gw).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `1.0.0` | `1.3.0-beta.33` |
+-----------------
+
 ### Lerian Common (Library)
 
 Library chart consumed by other Lerian charts — renders nothing on its own.

--- a/charts/br-consignado-gw-helm/Chart.yaml
+++ b/charts/br-consignado-gw-helm/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: br-consignado-gw-helm
+description: Helm chart for br-consignado-gw and its same-origin operator console
+
+type: application
+annotations:
+  lerian.studio/chart-type: multi-component
+
+home: https://github.com/LerianStudio/helm
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/br-consignado-gw-helm
+  - https://github.com/LerianStudio/br-consignado-gw
+maintainers:
+  - name: Lerian Studio
+    email: support@lerian.studio
+
+# Semantic-release owns the OCI package version. This source version documents
+# the initial chart line only; consumers must pin the version actually published.
+version: 1.0.0-beta.1
+appVersion: "1.3.0-beta.33"
+keywords:
+  - consignado
+  - br-consignado-gw
+  - dataprev
+  - credit
+  - lerian

--- a/charts/br-consignado-gw-helm/README.md
+++ b/charts/br-consignado-gw-helm/README.md
@@ -1,0 +1,48 @@
+# br-consignado-gw Helm Chart
+
+Deploys the **br-consignado-gw** Dataprev consignado gateway together with its
+operator console. The console is a separate nginx SPA Deployment, but it shares
+one ingress host with the API: `/` serves the UI and `/v1` routes to the API.
+That topology is intentional — the console refuses cross-origin API URLs so its
+Bearer token cannot be sent to an arbitrary origin.
+
+## Chart Contract
+
+- Chart type: `multi-component` (`api`, `ui`, `migrations`). Components default to `enabled: false`; enable only the surface you intend to operate.
+- Required secrets: when `migrations.enabled=true`, a Postgres password is required through `migrations.postgres.password`, `api.secrets.POSTGRES_PASSWORD`, or an operator-owned `migrations.postgres.passwordSecret.name`. In GitOps, use AVP/Vault placeholders — never store credentials in values. `api.useExistingSecret` / `api.existingSecretName` replace the chart-managed API Secret.
+- Dependency notes: Postgres, Valkey/Redis, RabbitMQ/Redpanda, Casdoor, and image credentials are external platform services. The chart deliberately has no infra subcharts. The dedicated migrations image contains the SQL tree because the API image is distroless.
+- Production overrides: set API and UI image tags; Postgres host/user/database/password and explicit TLS mode; app integration keys under `api.configmap` / `api.secrets`; the one ingress host; and UI Casdoor runtime configuration. Keep `ui.configmap.API_BASE_URL` empty unless it is a same-origin path prefix — the chart routes `/v1` on that host to the API. UI nginx is read-only and mounts `/tmp`; its image pins one worker to prevent high-core nodes from creating a worker-per-core OOM.
+- Source/license: chart source is `github.com/LerianStudio/helm` (Apache-2.0); service and UI source is `github.com/LerianStudio/br-consignado-gw`.
+
+## Components
+
+### API
+
+`api.configmap` and `api.secrets` are verbatim maps, not allowlists. This keeps
+the chart compatible as the gateway gains rail, outbox, tenant, and observability
+settings. Put only non-secret settings in `api.configmap`; secret fields belong
+in `api.secrets` or an existing Secret.
+
+### Operator console
+
+The console gets public runtime values from `ui.configmap`, rendered into
+`/config.js` at container start. `CASDOOR_CLIENT_ID` is a PKCE public identifier,
+not a secret. The API and UI must use the same browser origin; `ingress.apiPaths`
+keeps `/v1`, health, readiness, version, and metrics routed to the API while the
+UI owns `/`.
+
+### Migrations
+
+`migrations.enabled` creates an ArgoCD PreSync Secret (weight `-2`) and Job
+(weight `-1`). This sequencing is necessary on a first install: the Job cannot
+read the main-sync API Secret. The Job invokes `migrate` from
+`br-consignado-gw-migrations` and uses the migration image's `/migrations` tree.
+Passwords must be URL-safe for the PostgreSQL migration DSN.
+
+## Validation
+
+```sh
+helm lint charts/br-consignado-gw-helm
+helm template br-consignado-gw charts/br-consignado-gw-helm \
+  -f .github/configs/helm-render-values/br-consignado-gw.yaml
+```

--- a/charts/br-consignado-gw-helm/templates/_helpers.tpl
+++ b/charts/br-consignado-gw-helm/templates/_helpers.tpl
@@ -4,7 +4,16 @@
 {{- end -}}
 
 {{- define "br-consignado-gw.fullname" -}}
-{{- default (include "br-consignado-gw.name" .) .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "br-consignado-gw.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "br-consignado-gw.namespace" -}}

--- a/charts/br-consignado-gw-helm/templates/_helpers.tpl
+++ b/charts/br-consignado-gw-helm/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/* Chart and naming helpers. */}}
+{{- define "br-consignado-gw.name" -}}
+{{- default "br-consignado-gw" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.fullname" -}}
+{{- default (include "br-consignado-gw.name" .) .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Component helpers take dict {root: $, name: "api"|"ui"|"migrations"}. */}}
+{{- define "br-consignado-gw.componentFullname" -}}
+{{- printf "%s-%s" (include "br-consignado-gw.fullname" .root) .name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.componentSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "br-consignado-gw.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .name }}
+{{- end -}}
+
+{{- define "br-consignado-gw.componentLabels" -}}
+helm.sh/chart: {{ include "br-consignado-gw.chart" .root }}
+{{ include "br-consignado-gw.componentSelectorLabels" . }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+app.kubernetes.io/part-of: br-consignado-gw
+{{- end -}}
+
+{{- define "br-consignado-gw.componentImage" -}}
+{{- printf "%s:%s" .comp.image.repository (default .root.Chart.AppVersion .comp.image.tag) -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.componentPullSecrets" -}}
+{{- $pullSecrets := .comp.imagePullSecrets | default .root.Values.imagePullSecrets -}}
+{{- with $pullSecrets }}{{ toYaml . }}{{ end -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "br-consignado-gw.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.apiFullname" -}}
+{{- include "br-consignado-gw.componentFullname" (dict "root" . "name" "api") -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.uiFullname" -}}
+{{- include "br-consignado-gw.componentFullname" (dict "root" . "name" "ui") -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.migrationsFullname" -}}
+{{- include "br-consignado-gw.componentFullname" (dict "root" . "name" "migrations") -}}
+{{- end -}}
+
+{{- define "br-consignado-gw.apiSecretName" -}}
+{{- if .Values.api.useExistingSecret -}}
+{{- required "api.existingSecretName is required when api.useExistingSecret=true" .Values.api.existingSecretName -}}
+{{- else -}}
+{{- include "br-consignado-gw.apiFullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/br-consignado-gw-helm/templates/api-configmap.yaml
+++ b/charts/br-consignado-gw-helm/templates/api-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.api.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-consignado-gw.apiFullname" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "api") | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.api.configmap }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}
+  VERSION: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/api-deployment.yaml
+++ b/charts/br-consignado-gw-helm/templates/api-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.api.enabled }}
 {{- $fullname := include "br-consignado-gw.apiFullname" . }}
-{{- $pullSecrets := .Values.api.imagePullSecrets | default .Values.imagePullSecrets }}
+{{- $pullSecrets := include "br-consignado-gw.componentPullSecrets" (dict "root" . "comp" .Values.api) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: {{ include "br-consignado-gw.serviceAccountName" . }}
       {{- with $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: api

--- a/charts/br-consignado-gw-helm/templates/api-deployment.yaml
+++ b/charts/br-consignado-gw-helm/templates/api-deployment.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.api.enabled }}
+{{- $fullname := include "br-consignado-gw.apiFullname" . }}
+{{- $pullSecrets := .Values.api.imagePullSecrets | default .Values.imagePullSecrets }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "api") | nindent 4 }}
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  revisionHistoryLimit: {{ .Values.api.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "br-consignado-gw.componentSelectorLabels" (dict "root" . "name" "api") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/api-configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.api.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "br-consignado-gw.componentSelectorLabels" (dict "root" . "name" "api") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      serviceAccountName: {{ include "br-consignado-gw.serviceAccountName" . }}
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api
+          image: {{ include "br-consignado-gw.componentImage" (dict "root" . "comp" .Values.api) | quote }}
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.apiSecurityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ $fullname }}
+            - secretRef:
+                name: {{ include "br-consignado-gw.apiSecretName" . }}
+          {{- with .Values.api.extraEnvVars }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.api.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.api.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.api.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.readinessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/api-service.yaml
+++ b/charts/br-consignado-gw-helm/templates/api-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "br-consignado-gw.apiFullname" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "api") | nindent 4 }}
+  {{- with .Values.api.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.api.service.type }}
+  selector:
+    {{- include "br-consignado-gw.componentSelectorLabels" (dict "root" . "name" "api") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/ingress.yaml
+++ b/charts/br-consignado-gw-helm/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled }}
+{{- if not (or .Values.api.enabled .Values.ui.enabled) }}
+{{- fail "ingress.enabled requires api.enabled and/or ui.enabled" }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "br-consignado-gw.fullname" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "br-consignado-gw.chart" . }}
+    app.kubernetes.io/name: {{ include "br-consignado-gw.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    {{- if not .host }}{{ fail "ingress.hosts[].host is required when ingress.enabled=true" }}{{ end }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- if $.Values.api.enabled }}
+          {{- range $.Values.ingress.apiPaths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "br-consignado-gw.apiFullname" $ }}
+                port:
+                  number: {{ $.Values.api.service.port }}
+          {{- end }}
+          {{- end }}
+          {{- if $.Values.ui.enabled }}
+          - path: {{ $.Values.ingress.uiPath.path }}
+            pathType: {{ $.Values.ingress.uiPath.pathType }}
+            backend:
+              service:
+                name: {{ include "br-consignado-gw.uiFullname" $ }}
+                port:
+                  number: {{ $.Values.ui.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/migrations-job.yaml
+++ b/charts/br-consignado-gw-helm/templates/migrations-job.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.migrations.enabled }}
+{{- if not .Values.api.enabled }}{{ fail "migrations.enabled requires api.enabled" }}{{ end }}
+{{- $pg := .Values.migrations.postgres }}
+{{- $host := $pg.host | default .Values.api.configmap.POSTGRES_HOST }}
+{{- $port := $pg.port | default .Values.api.configmap.POSTGRES_PORT | default "5432" }}
+{{- $user := $pg.user | default .Values.api.configmap.POSTGRES_USER }}
+{{- $database := $pg.database | default .Values.api.configmap.POSTGRES_NAME }}
+{{- $sslMode := $pg.sslMode | default .Values.api.configmap.POSTGRES_SSLMODE | default "disable" }}
+{{- if not $host }}{{ fail "migrations need a Postgres host: set migrations.postgres.host or api.configmap.POSTGRES_HOST" }}{{ end }}
+{{- if not $user }}{{ fail "migrations need a Postgres user: set migrations.postgres.user or api.configmap.POSTGRES_USER" }}{{ end }}
+{{- if not $database }}{{ fail "migrations need a Postgres database: set migrations.postgres.database or api.configmap.POSTGRES_NAME" }}{{ end }}
+{{- $secretName := $pg.passwordSecret.name | default (include "br-consignado-gw.migrationsFullname" .) }}
+{{- $secretKey := $pg.passwordSecret.key | default "POSTGRES_PASSWORD" }}
+{{- $pullSecrets := .Values.migrations.imagePullSecrets | default .Values.imagePullSecrets }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "br-consignado-gw.migrationsFullname" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "migrations") | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "br-consignado-gw.componentSelectorLabels" (dict "root" . "name" "migrations") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -ec
+            - >-
+              until nc -z {{ $host }} {{ $port }}; do
+                echo "waiting for postgres {{ $host }}:{{ $port }}"; sleep 5;
+              done
+          securityContext:
+            {{- toYaml .Values.apiSecurityContext | nindent 12 }}
+      containers:
+        - name: migrations
+          image: {{ include "br-consignado-gw.componentImage" (dict "root" . "comp" .Values.migrations) | quote }}
+          imagePullPolicy: {{ .Values.migrations.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - >-
+              migrate -path /migrations
+              -database "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}?sslmode=${POSTGRES_SSLMODE}"
+              up
+          env:
+            - name: POSTGRES_HOST
+              value: {{ $host | quote }}
+            - name: POSTGRES_PORT
+              value: {{ $port | quote }}
+            - name: POSTGRES_USER
+              value: {{ $user | quote }}
+            - name: POSTGRES_NAME
+              value: {{ $database | quote }}
+            - name: POSTGRES_SSLMODE
+              value: {{ $sslMode | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $secretKey }}
+          securityContext:
+            {{- toYaml .Values.apiSecurityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/migrations-job.yaml
+++ b/charts/br-consignado-gw-helm/templates/migrations-job.yaml
@@ -58,22 +58,28 @@ spec:
             - /bin/sh
             - -ec
           args:
-            # Percent-encode the password byte-by-byte before building the DSN:
-            # reserved URL characters in the raw Secret value would otherwise
-            # break golang-migrate's URL parsing.
+            # Percent-encode user, password, and database byte-by-byte before
+            # building the DSN: reserved URL characters in the raw values would
+            # otherwise break golang-migrate's URL parsing.
             - |
-              encoded=""
-              rest="${POSTGRES_PASSWORD}"
-              while [ -n "${rest}" ]; do
-                char="${rest%"${rest#?}"}"
-                rest="${rest#?}"
-                case "${char}" in
-                  [A-Za-z0-9.~_-]) encoded="${encoded}${char}" ;;
-                  *) encoded="${encoded}$(printf '%%%02X' "'${char}")" ;;
-                esac
-              done
+              urlenc() {
+                encoded=""
+                rest="$1"
+                while [ -n "${rest}" ]; do
+                  char="${rest%"${rest#?}"}"
+                  rest="${rest#?}"
+                  case "${char}" in
+                    [A-Za-z0-9.~_-]) encoded="${encoded}${char}" ;;
+                    *) encoded="${encoded}$(printf '%%%02X' "'${char}")" ;;
+                  esac
+                done
+                printf '%s' "${encoded}"
+              }
+              user="$(urlenc "${POSTGRES_USER}")"
+              password="$(urlenc "${POSTGRES_PASSWORD}")"
+              database="$(urlenc "${POSTGRES_NAME}")"
               migrate -path /migrations \
-                -database "postgres://${POSTGRES_USER}:${encoded}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}?sslmode=${POSTGRES_SSLMODE}" \
+                -database "postgres://${user}:${password}@${POSTGRES_HOST}:${POSTGRES_PORT}/${database}?sslmode=${POSTGRES_SSLMODE}" \
                 up
           env:
             - name: POSTGRES_HOST

--- a/charts/br-consignado-gw-helm/templates/migrations-job.yaml
+++ b/charts/br-consignado-gw-helm/templates/migrations-job.yaml
@@ -11,7 +11,7 @@
 {{- if not $database }}{{ fail "migrations need a Postgres database: set migrations.postgres.database or api.configmap.POSTGRES_NAME" }}{{ end }}
 {{- $secretName := $pg.passwordSecret.name | default (include "br-consignado-gw.migrationsFullname" .) }}
 {{- $secretKey := $pg.passwordSecret.key | default "POSTGRES_PASSWORD" }}
-{{- $pullSecrets := .Values.migrations.imagePullSecrets | default .Values.imagePullSecrets }}
+{{- $pullSecrets := include "br-consignado-gw.componentPullSecrets" (dict "root" . "comp" .Values.migrations) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -36,7 +36,7 @@ spec:
       automountServiceAccountToken: false
       {{- with $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       initContainers:
         - name: wait-for-postgres
@@ -58,10 +58,23 @@ spec:
             - /bin/sh
             - -ec
           args:
-            - >-
-              migrate -path /migrations
-              -database "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}?sslmode=${POSTGRES_SSLMODE}"
-              up
+            # Percent-encode the password byte-by-byte before building the DSN:
+            # reserved URL characters in the raw Secret value would otherwise
+            # break golang-migrate's URL parsing.
+            - |
+              encoded=""
+              rest="${POSTGRES_PASSWORD}"
+              while [ -n "${rest}" ]; do
+                char="${rest%"${rest#?}"}"
+                rest="${rest#?}"
+                case "${char}" in
+                  [A-Za-z0-9.~_-]) encoded="${encoded}${char}" ;;
+                  *) encoded="${encoded}$(printf '%%%02X' "'${char}")" ;;
+                esac
+              done
+              migrate -path /migrations \
+                -database "postgres://${POSTGRES_USER}:${encoded}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}?sslmode=${POSTGRES_SSLMODE}" \
+                up
           env:
             - name: POSTGRES_HOST
               value: {{ $host | quote }}

--- a/charts/br-consignado-gw-helm/templates/secrets.yaml
+++ b/charts/br-consignado-gw-helm/templates/secrets.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.api.enabled }}
+{{- if not .Values.api.useExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "br-consignado-gw.apiFullname" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "api") | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.api.secrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.migrations.enabled }}
+{{- if not .Values.api.enabled }}{{ fail "migrations.enabled requires api.enabled" }}{{ end }}
+{{- $pg := .Values.migrations.postgres }}
+{{- $secretName := $pg.passwordSecret.name }}
+{{- if not $secretName }}
+{{- $password := $pg.password | default .Values.api.secrets.POSTGRES_PASSWORD }}
+{{- if not $password }}{{ fail "migrations need POSTGRES_PASSWORD: set migrations.postgres.password or api.secrets.POSTGRES_PASSWORD" }}{{ end }}
+{{- $secretName = include "br-consignado-gw.migrationsFullname" . }}
+---
+# PreSync Secret must be distinct from the API Secret: ArgoCD runs this Job
+# before main-sync resources are created on a first install.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "migrations") | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-weight: "-2"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+type: Opaque
+stringData:
+  {{ $pg.passwordSecret.key | default "POSTGRES_PASSWORD" }}: {{ $password | quote }}
+{{- end }}
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/serviceaccount.yaml
+++ b/charts/br-consignado-gw-helm/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,3 +14,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: false
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/serviceaccount.yaml
+++ b/charts/br-consignado-gw-helm/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "br-consignado-gw.serviceAccountName" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "br-consignado-gw.chart" . }}
+    app.kubernetes.io/name: {{ include "br-consignado-gw.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false

--- a/charts/br-consignado-gw-helm/templates/ui-configmap.yaml
+++ b/charts/br-consignado-gw-helm/templates/ui-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "br-consignado-gw.uiFullname" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "ui") | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.ui.configmap }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}
+  VERSION: {{ .Values.ui.image.tag | default .Chart.AppVersion | quote }}
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/ui-deployment.yaml
+++ b/charts/br-consignado-gw-helm/templates/ui-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ui.enabled }}
 {{- $fullname := include "br-consignado-gw.uiFullname" . }}
-{{- $pullSecrets := .Values.ui.imagePullSecrets | default .Values.imagePullSecrets }}
+{{- $pullSecrets := include "br-consignado-gw.componentPullSecrets" (dict "root" . "comp" .Values.ui) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: {{ include "br-consignado-gw.serviceAccountName" . }}
       {{- with $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: ui

--- a/charts/br-consignado-gw-helm/templates/ui-deployment.yaml
+++ b/charts/br-consignado-gw-helm/templates/ui-deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.ui.enabled }}
+{{- $fullname := include "br-consignado-gw.uiFullname" . }}
+{{- $pullSecrets := .Values.ui.imagePullSecrets | default .Values.imagePullSecrets }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "ui") | nindent 4 }}
+spec:
+  replicas: {{ .Values.ui.replicaCount }}
+  revisionHistoryLimit: {{ .Values.ui.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "br-consignado-gw.componentSelectorLabels" (dict "root" . "name" "ui") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ui-configmap.yaml") . | sha256sum }}
+        {{- with .Values.ui.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "br-consignado-gw.componentSelectorLabels" (dict "root" . "name" "ui") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      serviceAccountName: {{ include "br-consignado-gw.serviceAccountName" . }}
+      {{- with $pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ui
+          image: {{ include "br-consignado-gw.componentImage" (dict "root" . "comp" .Values.ui) | quote }}
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.uiSecurityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ $fullname }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ui.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.ui.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.ui.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.ui.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.ui.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.ui.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.ui.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.ui.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.ui.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.ui.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.ui.readinessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.ui.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/br-consignado-gw-helm/templates/ui-service.yaml
+++ b/charts/br-consignado-gw-helm/templates/ui-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "br-consignado-gw.uiFullname" . }}
+  namespace: {{ include "br-consignado-gw.namespace" . }}
+  labels:
+    {{- include "br-consignado-gw.componentLabels" (dict "root" . "name" "ui") | nindent 4 }}
+  {{- with .Values.ui.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  selector:
+    {{- include "br-consignado-gw.componentSelectorLabels" (dict "root" . "name" "ui") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.ui.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/br-consignado-gw-helm/values-template.yaml
+++ b/charts/br-consignado-gw-helm/values-template.yaml
@@ -1,0 +1,44 @@
+# Copy this values skeleton for a real environment. This chart does not deploy
+# Postgres, Valkey, RabbitMQ, or Casdoor — target tiers provide those services.
+imagePullSecrets:
+  - name: ghcr-credential
+
+api:
+  enabled: true
+  image:
+    tag: "" # defaults to Chart.appVersion
+  configmap:
+    ENV_NAME: "development"
+    POSTGRES_HOST: ""        # REQUIRED for migrations and app boot
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: "br_consignado_gw"
+    POSTGRES_NAME: "br_consignado_gw"
+    POSTGRES_SSLMODE: "require"
+    REDIS_HOST: ""
+  secrets:
+    POSTGRES_PASSWORD: ""    # REQUIRED; use an AVP Vault placeholder in GitOps
+
+ui:
+  enabled: true
+  image:
+    tag: "" # normally follows the same release as the API
+  configmap:
+    API_BASE_URL: ""         # MUST stay same-origin; ingress routes /v1 to API
+    CASDOOR_CSP_ORIGIN: ""
+    CASDOOR_ENDPOINT: ""
+    CASDOOR_CLIENT_ID: ""
+    CASDOOR_ORG_NAME: ""
+    CASDOOR_APP_NAME: ""
+    AUTH_DISABLED: "false"
+
+ingress:
+  enabled: true
+  hosts:
+    - host: "consignado.example.com"
+
+migrations:
+  enabled: true
+  postgres:
+    # Fields fall back to api.configmap / api.secrets. Fill only to override.
+    host: ""
+    password: ""

--- a/charts/br-consignado-gw-helm/values.schema.json
+++ b/charts/br-consignado-gw-helm/values.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "api": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "ui": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "migrations": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "apiSecurityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "uiSecurityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/charts/br-consignado-gw-helm/values.yaml
+++ b/charts/br-consignado-gw-helm/values.yaml
@@ -1,0 +1,195 @@
+# br-consignado-gw is a multi-component release: an API, same-origin operator
+# console, and a detached PreSync migrations Job. Every component is OFF by
+# default so operators explicitly choose what to install.
+nameOverride: "br-consignado-gw"
+fullnameOverride: ""
+namespaceOverride: ""
+
+imagePullSecrets:
+  - name: ghcr-credential
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+api:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-consignado-gw
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  livenessProbe:
+    path: /health
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    path: /readyz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # ConfigMap values are emitted verbatim. Add new non-secret API settings here
+  # without changing the chart; sensitive values belong in api.secrets.
+  configmap:
+    ENV_NAME: "development"
+    SERVER_ADDRESS: "0.0.0.0:8080"
+    POSTGRES_HOST: ""
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: ""
+    POSTGRES_NAME: ""
+    POSTGRES_SSLMODE: ""
+    REDIS_HOST: ""
+    LOG_LEVEL: "info"
+  secrets:
+    POSTGRES_PASSWORD: ""
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+
+# The Vite SPA is intentionally separate from the API but shares its ingress
+# host. Runtime API_BASE_URL must remain empty (same origin): the console
+# rejects a cross-origin API URL to avoid leaking its bearer token.
+ui:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/br-consignado-gw-ui
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  livenessProbe:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    path: /healthz
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # All keys are public browser runtime configuration and rendered at pod boot.
+  # CASDOOR_CSP_ORIGIN must be the issuer origin only, never a path.
+  configmap:
+    API_BASE_URL: ""
+    CASDOOR_CSP_ORIGIN: ""
+    CASDOOR_ENDPOINT: ""
+    CASDOOR_CLIENT_ID: ""
+    CASDOOR_ORG_NAME: ""
+    CASDOOR_APP_NAME: ""
+    AUTH_DISABLED: "false"
+
+# One host serves the SPA at / and proxies the API's public routes on the same
+# origin. `/v1` is the product API; platform health/version routes remain
+# explicit for external operational checks.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: ""
+  apiPaths:
+    - path: /v1
+      pathType: Prefix
+    - path: /health
+      pathType: Exact
+    - path: /readyz
+      pathType: Exact
+    - path: /version
+      pathType: Exact
+    - path: /metrics
+      pathType: Exact
+  uiPath:
+    path: /
+    pathType: Prefix
+  tls: []
+
+# The API image carries SQL under /migrations, but is distroless. A dedicated
+# migrator image is built from migrations/Dockerfile and executes it as an
+# ArgoCD PreSync Job. It defaults off with the API, avoiding a no-op install.
+migrations:
+  enabled: false
+  image:
+    repository: ghcr.io/lerianstudio/br-consignado-gw-migrations
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  postgres:
+    host: ""
+    port: ""
+    user: ""
+    database: ""
+    sslMode: ""
+    password: ""
+    passwordSecret:
+      name: ""
+      key: POSTGRES_PASSWORD
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 600
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+# Distroless API + nginx-unprivileged UI settings. The UI mounts /tmp as an
+# emptyDir because nginx needs temporary paths while the root filesystem stays
+# read-only. The UI image pins worker_processes=1 for high-core cluster nodes.
+apiSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ALL]
+  seccompProfile:
+    type: RuntimeDefault
+uiSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ALL]
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
## What changes
- Adds `br-consignado-gw-helm`, a modular chart with explicit API, UI, and PreSync migrations components.
- Adds a same-origin ingress: UI is `/`; `/v1` and operational routes stay on the API service. This is required by the console runtime, which rejects cross-origin API targets to protect bearer tokens.
- Adds a dedicated PreSync password Secret (weight -2) + migrations Job (weight -1), avoiding the first-install race against the main API Secret.
- Adds nginx-unprivileged hardening in the UI Deployment: uid 101, read-only rootfs, writable `/tmp` emptyDir.
- Registers the root README section required for the Helm release workflow.

## Validation
- `helm lint charts/br-consignado-gw-helm` — passed.
- Empty render produces only the ServiceAccount.
- Full fixture renders API + UI Deployments, 2 Services, 2 ConfigMaps, 2 Secrets, a PreSync Job, and the same-origin Ingress.
- Strict chart validator: 0 violations.
- Render gate: passed for the entire repository; the new chart uses its full fixture.
- Manual fixture assertion: zero dangling `secretKeyRef`s; API ingress paths precede UI `/`; UI mounts `/tmp`.
- Fail-loud tests: migrations without a Postgres host and `api.useExistingSecret=true` without a name both fail at render time.

## Release dependency
`br-consignado-gw#68` publishes the matching UI and migrations images. This chart consumes `ghcr.io/lerianstudio/br-consignado-gw{,-ui,-migrations}` at the same release tag.