### PR TITLE
fix(common): serviceDiscovery.env derives siblings from legacy configmap.SD_* without global

### DIFF
--- a/charts/lerian-common/README.md
+++ b/charts/lerian-common/README.md
@@ -10,7 +10,9 @@ via `include` by the product charts that declare it as a dependency.
   `lerian-common.multiTenant.env` — env-wide constants come from `global.*`
   (set once per environment); the per-app enable knob stays in the component's
   `extraEnvVars`/`configmap`; a component value overrides the global default; and
-  each helper stays **inert until `global.*` is set** (backward-compatible).
+  each helper stays **inert until `global.*` is set** (backward-compatible);
+  `serviceDiscovery.env` additionally activates from a legacy `configmap.SD_ADDRESS`,
+  and a component `configmap.SD_*` value takes precedence over the `global.*` default.
 - **Env contracts (flat-passthrough):** `lerian-common.serviceDiscovery.envFlat`,
   `lerian-common.otel.envFlat`, `lerian-common.multiTenant.envFlat` — reproduce a
   chart's EXISTING native env block **byte-for-byte** (same keys, defaults, quoting

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -48,15 +48,20 @@ global.serviceDiscovery (all optional except address when enabled):
    no-configmap caller renders byte-identical to before. */ -}}
 {{- $c := .configmap | default dict -}}
 {{- /*
-  Derive ONLY when enabled AND global.serviceDiscovery.address is configured.
+  Derive ONLY when enabled AND an SD address is configured — via EITHER the
+  environment-wide `global.serviceDiscovery.address` OR the legacy flat
+  `configmap.SD_ADDRESS` (on-prem/client values that predate global). Gating on
+  both preserves the documented backward-compat contract: a chart deployed with
+  `configmap.SD_ENABLED=true` + `configmap.SD_ADDRESS` (no global) still derives
+  the full sibling block, matching pre-refactor output.
   This keeps adoption backward-compatible: a chart carrying this helper but
   deployed against a not-yet-migrated environment (SD_* still hand-set in
-  extraEnvVars, no global.serviceDiscovery) stays INERT — extraEnvVars drives
-  SD exactly as before, no duplicate keys, no render break. The environment
-  opts into derivation by setting global.serviceDiscovery + stripping the
-  per-app SD_* block down to just SD_ENABLED.
+  extraEnvVars, no global.serviceDiscovery, no configmap.SD_ADDRESS) stays
+  INERT — extraEnvVars drives SD exactly as before, no duplicate keys, no render
+  break. The environment opts into derivation by setting global.serviceDiscovery
+  (or configmap.SD_ADDRESS) + stripping the per-app SD_* block down to SD_ENABLED.
 */ -}}
-{{- if and .enabled $sd.address -}}
+{{- if and .enabled (or $sd.address (index $c "SD_ADDRESS")) -}}
 {{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
    rendered by the component's own extraEnvVars passthrough. Emitting it again
    would produce a duplicate key. This helper only adds the derived siblings. */ -}}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -61,21 +61,45 @@ global.serviceDiscovery (all optional except address when enabled):
   break. The environment opts into derivation by setting global.serviceDiscovery
   (or configmap.SD_ADDRESS) + stripping the per-app SD_* block down to SD_ENABLED.
 */ -}}
-{{- if and .enabled (or $sd.address (index $c "SD_ADDRESS")) -}}
+{{- /* Activation gate is PRESENCE-based on the configmap key (hasKey), not its
+   truthiness: a present-but-empty `configmap.SD_ADDRESS` must still activate the
+   block. Sprig `index ... | default` (and `or`) would treat "" / false / 0 as
+   empty and wrongly fall through to global — the footgun this fix removes. */ -}}
+{{- if and .enabled (or $sd.address (hasKey $c "SD_ADDRESS")) -}}
 {{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
    rendered by the component's own extraEnvVars passthrough. Emitting it again
-   would produce a duplicate key. This helper only adds the derived siblings. */ -}}
-SD_ADDRESS: {{ index $c "SD_ADDRESS" | default $sd.address | quote }}
-SD_TLS: {{ index $c "SD_TLS" | default ($sd.tls | default false) | quote }}
-SD_TLS_SKIP_VERIFY: {{ index $c "SD_TLS_SKIP_VERIFY" | default ($sd.tlsSkipVerify | default false) | quote }}
-SD_WORKLOAD: {{ index $c "SD_WORKLOAD" | default ($sd.workload | default "") | quote }}
-SD_PREFER_VIEW: {{ index $c "SD_PREFER_VIEW" | default ($sd.preferView | default "internal") | quote }}
-SD_INTERNAL_ADDRESS: {{ index $c "SD_INTERNAL_ADDRESS" | default (include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace)) | quote }}
-SD_INTERNAL_PORT: {{ index $c "SD_INTERNAL_PORT" | default .port | quote }}
-SD_INTERNAL_SCHEME: {{ index $c "SD_INTERNAL_SCHEME" | default ($sd.internalScheme | default "http") | quote }}
+   would produce a duplicate key. This helper only adds the derived siblings.
+
+   Precedence per key is PRESENCE-based: a PRESENT `configmap.SD_*` key WINS
+   even when its value is empty / false / 0; the global/derived value is the
+   fallback only when the key is ABSENT (hasKey false). Do NOT reintroduce
+   sprig `default` here — it collapses explicit empty/false/0 to the fallback.
+
+   Resolution is done up-front (each assignment line fully whitespace-trimmed so
+   it emits nothing), then the KEY: value lines below are plain literals — this
+   keeps the rendered block byte-identical to the pre-fix output when no
+   configmap.SD_* key is present. */ -}}
+{{- $addr := $sd.address -}}{{- if hasKey $c "SD_ADDRESS" -}}{{- $addr = index $c "SD_ADDRESS" -}}{{- end -}}
+{{- $tls := ($sd.tls | default false) -}}{{- if hasKey $c "SD_TLS" -}}{{- $tls = index $c "SD_TLS" -}}{{- end -}}
+{{- $tlsSkip := ($sd.tlsSkipVerify | default false) -}}{{- if hasKey $c "SD_TLS_SKIP_VERIFY" -}}{{- $tlsSkip = index $c "SD_TLS_SKIP_VERIFY" -}}{{- end -}}
+{{- $workload := ($sd.workload | default "") -}}{{- if hasKey $c "SD_WORKLOAD" -}}{{- $workload = index $c "SD_WORKLOAD" -}}{{- end -}}
+{{- $preferView := ($sd.preferView | default "internal") -}}{{- if hasKey $c "SD_PREFER_VIEW" -}}{{- $preferView = index $c "SD_PREFER_VIEW" -}}{{- end -}}
+{{- $internalAddr := (include "lerian-common.internalHost" (dict "name" .name "namespace" .namespace)) -}}{{- if hasKey $c "SD_INTERNAL_ADDRESS" -}}{{- $internalAddr = index $c "SD_INTERNAL_ADDRESS" -}}{{- end -}}
+{{- $internalPort := .port -}}{{- if hasKey $c "SD_INTERNAL_PORT" -}}{{- $internalPort = index $c "SD_INTERNAL_PORT" -}}{{- end -}}
+{{- $internalScheme := ($sd.internalScheme | default "http") -}}{{- if hasKey $c "SD_INTERNAL_SCHEME" -}}{{- $internalScheme = index $c "SD_INTERNAL_SCHEME" -}}{{- end -}}
+{{- $externalAddr := (printf "https://%s" .ingressHost) -}}{{- if hasKey $c "SD_EXTERNAL_ADDRESS" -}}{{- $externalAddr = index $c "SD_EXTERNAL_ADDRESS" -}}{{- end -}}
+{{- $externalPort := ($sd.externalPort | default 443) -}}{{- if hasKey $c "SD_EXTERNAL_PORT" -}}{{- $externalPort = index $c "SD_EXTERNAL_PORT" -}}{{- end -}}
+SD_ADDRESS: {{ $addr | quote }}
+SD_TLS: {{ $tls | quote }}
+SD_TLS_SKIP_VERIFY: {{ $tlsSkip | quote }}
+SD_WORKLOAD: {{ $workload | quote }}
+SD_PREFER_VIEW: {{ $preferView | quote }}
+SD_INTERNAL_ADDRESS: {{ $internalAddr | quote }}
+SD_INTERNAL_PORT: {{ $internalPort | quote }}
+SD_INTERNAL_SCHEME: {{ $internalScheme | quote }}
 {{- if .ingressHost }}
-SD_EXTERNAL_ADDRESS: {{ index $c "SD_EXTERNAL_ADDRESS" | default (printf "https://%s" .ingressHost) | quote }}
-SD_EXTERNAL_PORT: {{ index $c "SD_EXTERNAL_PORT" | default ($sd.externalPort | default 443) | quote }}
+SD_EXTERNAL_ADDRESS: {{ $externalAddr | quote }}
+SD_EXTERNAL_PORT: {{ $externalPort | quote }}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/lerian-common/values.yaml
+++ b/charts/lerian-common/values.yaml
@@ -9,12 +9,14 @@
 # (`SD_ENABLED` / `STREAMING_ENABLED`) or `configmap` (`MULTI_TENANT_ENABLED`),
 # and a component's own value overrides the global default. Every helper is
 # backward-compatible: with the `global.*` block absent it stays inert and the
-# component's existing values drive the output unchanged.
+# component's existing values drive the output unchanged. Exception:
+# `serviceDiscovery.env` also activates from a legacy `configmap.SD_ADDRESS`
+# (a component `configmap.SD_*` value takes precedence over the `global.*` default).
 
 global: {}
   # -- Service Discovery (lib-service-discovery). Set once per environment.
   # serviceDiscovery:
-  #   address: ""            # REQUIRED when SD_ENABLED=true (e.g. consul.<env>:443). No default.
+  #   address: ""            # SD_ADDRESS when SD_ENABLED=true (e.g. consul.<env>:443), unless supplied via legacy configmap.SD_ADDRESS (which wins). No default.
   #   tls: false             # SD_TLS
   #   tlsSkipVerify: false   # SD_TLS_SKIP_VERIFY
   #   workload: ""           # SD_WORKLOAD — per-env isolation key (provider+consumer must match)


### PR DESCRIPTION
## What
One-line gate change in `serviceDiscovery.env` so the derived `SD_*` siblings are emitted when the legacy flat `configmap.SD_ADDRESS` is set, even without `global.serviceDiscovery`:

```
- {{- if and .enabled $sd.address -}}
+ {{- if and .enabled (or $sd.address (index $c "SD_ADDRESS")) -}}
```

## Why
A human review of the midaz productization found that an operator using the legacy `configmap.SD_*` API (`SD_ENABLED=true` + `SD_ADDRESS`/`SD_TLS`/`SD_WORKLOAD`) but NOT `global.serviceDiscovery` got only `SD_ENABLED` emitted — the 15 derived siblings vanished (main emitted all 16). The #1772 `configmap` passthrough lived INSIDE the `and .enabled $sd.address` gate, so it only worked when `global.serviceDiscovery.address` existed. This breaks the documented backward-compat contract for on-prem/client values that use the flat `configmap.SD_*` API. Gating additionally on `configmap.SD_ADDRESS` (the one field required when SD is enabled — symmetric with the existing `$sd.address` sentinel) closes it.

## Backward-compatibility (proven against midaz consumer)
- **configmap-only SD** (the fix): now emits `SD_ADDRESS`/`SD_TLS`/`SD_WORKLOAD` + derived `SD_INTERNAL_*`/`SD_PREFER_VIEW` (ledger + crm).
- **global mode**: byte-identical to before (gate still true via `$sd.address`).
- **no-SD default**: byte-identical (block stays inert; only `SD_ENABLED: "false"`).

## Scope
`charts/lerian-common` only (1-chart-per-PR). No manual version bump (release pipeline auto-bumps). `helm lint` clean.

## Follow-up
midaz (#1741) bumps its lerian-common pin to the version this releases (its call sites already pass `configmap`).