### PR TITLE
fix(charts): pin consignado defaults to beta.36

### DIFF
--- a/.github/configs/helm-render-values/br-consignado-gw-helm.yaml
+++ b/.github/configs/helm-render-values/br-consignado-gw-helm.yaml
@@ -2,7 +2,7 @@
 api:
   enabled: true
   image:
-    tag: "1.3.0-beta.33"
+    tag: "1.3.0-beta.36"
   configmap:
     ENV_NAME: "development"
     POSTGRES_HOST: "postgres.example.internal"
@@ -16,7 +16,7 @@ api:
 ui:
   enabled: true
   image:
-    tag: "1.3.0-beta.33"
+    tag: "1.3.0-beta.36"
   configmap:
     API_BASE_URL: ""
     CASDOOR_CSP_ORIGIN: "https://casdoor.example.internal"

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ For implementation and configuration details, see the [README](https://charts.le
 
 | Chart Version | App Version |
 | :---: | :---: |
-| `1.0.0` | `1.3.0-beta.33` |
+| `1.0.0` | `1.3.0-beta.36` |
 -----------------
 
 ### Lerian Common (Library)

--- a/charts/br-consignado-gw-helm/Chart.yaml
+++ b/charts/br-consignado-gw-helm/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # Semantic-release owns the OCI package version. This source version documents
 # the initial chart line only; consumers must pin the version actually published.
 version: 1.0.0
-appVersion: "1.3.0-beta.33"
+appVersion: "1.3.0-beta.36"
 keywords:
   - consignado
   - br-consignado-gw


### PR DESCRIPTION
The API, UI, and migration OCI artifacts were verified at `1.3.0-beta.36` after `br-consignado-gw` #68 merged.

This follow-up corrects the initial chart default/fixture/docs mapping before GitOps consumes the chart.

Validation:
- `helm lint charts/br-consignado-gw-helm`
- `helm template` with the full render fixture