### PR TITLE
feat(br-slc): let the mock's scenario posture be pinned from values

### DIFF
--- a/charts/br-slc/README.md
+++ b/charts/br-slc/README.md
@@ -150,6 +150,10 @@ When `mockNuclea.enabled=true`:
 - `mockNuclea.license.enabled: false` leaves the fixture unlicensed and calling
   no license gateway. Flip it on to have the mock validate the **release's own**
   Lerian license at boot — see "Licensing the fixture" below.
+- `mockNuclea.scenarios.defaultScenario` / `.scenarioSeed` are empty by default
+  (today's behavior: the mock boots on its compiled-in `happy` scenario). Set
+  them to pin a posture declaratively so it survives a pod restart — see
+  "Scenario seeding" below.
 
 ### Provisioning the SPB key set (signed round-trip runbook)
 
@@ -266,6 +270,40 @@ mockNuclea:
   enabled: true
   license:
     enabled: true        # reuses the app Secret's LICENSE_KEY; ORGANIZATION_IDS=global
+```
+
+### Scenario seeding (`mockNuclea.scenarios.*`)
+
+The mock's scenario store (which posture — `happy`, `spb_envelope`,
+`reject_eslc`, ..., closed set in `mock/scenarios.go`) is **in-memory** and,
+absent these envs, only writable at runtime via `PUT /admin/scenarios/{ispb}` —
+so every pod restart silently reverted every participant back to `happy`, and
+correlation then broke with **no signal at all** (the operation just sat in
+`SENT` with `lastError` null). These two envs let a gitops overlay pin the
+posture declaratively so it survives a restart.
+
+| Value | Default | Purpose |
+|---|---|---|
+| `mockNuclea.scenarios.defaultScenario` | `""` | `MOCK_NUCLEA_DEFAULT_SCENARIO` — the scenario applied to any ISPB with **no** explicit `scenarioSeed` entry. Empty keeps today's behavior (`happy`). An unrecognized name **fails the boot**, listing the closed scenario set. |
+| `mockNuclea.scenarios.scenarioSeed` | `""` | `MOCK_NUCLEA_SCENARIO_SEED` — OPTIONAL per-ISPB pin, `"<ispb>=<scenario>[,<ispb>=<scenario>]"`, e.g. `"29011780=spb_envelope_forward_confirm"`. Whitespace around entries/`=` is tolerated; empty entries are skipped. A malformed entry (missing `=`, non-8-digit ISPB, unrecognized scenario, duplicate ISPB) **fails the boot**. |
+
+> ⚠️ **Coupled with `mockNuclea.spbKeysSecret` above.** Seeding any SPB-family
+> scenario (`spb_envelope`, `spb_envelope_forward_confirm`,
+> `debit_spb_envelope`, `anticipation_spb_envelope`, ...) — via either value —
+> **without** `mockNuclea.spbKeysSecret.enabled: true` fails the boot closed
+> with `SPB scenario seeded without SPB key material`: the mock refuses to
+> seed a posture it cannot execute (it would otherwise answer 200 on the
+> plain-content path with nothing decrypted/verified — a green e2e for the
+> wrong reason). Enable `spbKeysSecret` first.
+
+```yaml
+mockNuclea:
+  enabled: true
+  spbKeysSecret:
+    enabled: true
+    secretName: br-slc-mock-spb-keys
+  scenarios:
+    scenarioSeed: "29011780=spb_envelope_forward_confirm"
 ```
 
 ## Install

--- a/charts/br-slc/templates/mock-nuclea/deployment.yaml
+++ b/charts/br-slc/templates/mock-nuclea/deployment.yaml
@@ -107,6 +107,22 @@ spec:
                   key: IS_DEVELOPMENT
                   optional: true
             {{- end }}
+            {{- if .Values.mockNuclea.scenarios.defaultScenario }}
+            {{- /* Boot-time scenario seeding (issue #211, F-3, mock/scenarios.go). Pins
+            the fallback scenario for any ISPB with no explicit scenarioSeed entry, so a
+            pod restart no longer silently reverts every participant to happy. An
+            unrecognized name FAILS THE BOOT (closed set) — see mockNuclea.scenarios in
+            values.yaml for the full rationale and the spbKeysSecret coupling. */}}
+            - name: MOCK_NUCLEA_DEFAULT_SCENARIO
+              value: {{ .Values.mockNuclea.scenarios.defaultScenario | quote }}
+            {{- end }}
+            {{- if .Values.mockNuclea.scenarios.scenarioSeed }}
+            {{- /* OPTIONAL per-ISPB scenario pin, "<ispb>=<scenario>[,...]" — e.g. pinning
+            Núclea's own 29011780 without changing the default for everyone else. A
+            malformed entry FAILS THE BOOT. */}}
+            - name: MOCK_NUCLEA_SCENARIO_SEED
+              value: {{ .Values.mockNuclea.scenarios.scenarioSeed | quote }}
+            {{- end }}
             {{- /* GOMAXPROCS from the container CFS cpu limit — see br-slc.gomaxprocsEnv (Gate 8 FIX 7). */}}
             {{- include "br-slc.gomaxprocsEnv" .Values.mockNuclea.resources | nindent 12 }}
           livenessProbe:

--- a/charts/br-slc/values.schema.json
+++ b/charts/br-slc/values.schema.json
@@ -512,6 +512,16 @@
             "organizationIDs": { "type": "string", "minLength": 1 }
           }
         },
+        "scenarios": {
+          "type": "object",
+          "properties": {
+            "defaultScenario": { "type": "string" },
+            "scenarioSeed": {
+              "type": "string",
+              "pattern": "^\\s*(\\d{8}\\s*=\\s*[A-Za-z0-9_]+\\s*)?(,\\s*(\\d{8}\\s*=\\s*[A-Za-z0-9_]+\\s*)?)*$"
+            }
+          }
+        },
         "resources": {
           "type": "object",
           "properties": {

--- a/charts/br-slc/values.yaml
+++ b/charts/br-slc/values.yaml
@@ -973,6 +973,41 @@ mockNuclea:
     # Deployment reads it from the app's ConfigMap with optional: true, so the
     # fixture never disagrees with the app about the gateway, and environments
     # that don't declare it (only dev-st does) still render.
+  # Boot-time scenario seeding (br-slc mock/scenarios.go, issue #211 / F-3). The
+  # scenario store is IN-MEMORY and, absent these envs, is only writable at
+  # runtime via `PUT /admin/scenarios/{ispb}` — so every pod restart silently
+  # reverted every participant back to `happy`, and correlation then broke with
+  # NO signal at all (the operation just sat in SENT with lastError null). These
+  # two envs let a gitops overlay pin the posture DECLARATIVELY so it survives a
+  # restart; an unrecognized scenario name in EITHER one FAILS THE BOOT (closed
+  # set) instead of degrading to a wrong-but-quiet default. Empty defaults for
+  # both ⇒ zero change from today's behavior (mock boots on the compiled-in
+  # `happy` default, exactly as before this chart exposed the knobs).
+  #
+  # ⚠️ COUPLING WITH spbKeysSecret ABOVE: seeding any SPB-family scenario (e.g.
+  # `spb_envelope`, `spb_envelope_forward_confirm`, `debit_spb_envelope`,
+  # `anticipation_spb_envelope`, ...) — via EITHER defaultScenario or
+  # scenarioSeed — WITHOUT `mockNuclea.spbKeysSecret.enabled: true` fails the
+  # boot closed with "SPB scenario seeded without SPB key material"
+  # (validateSPBSeeding in mock/main.go): the mock refuses to seed a posture it
+  # cannot actually execute (it would otherwise 200 on the plain-content path
+  # with nothing decrypted/verified — a green e2e for the wrong reason). Enable
+  # spbKeysSecret first when seeding an SPB-family scenario.
+  scenarios:
+    # MOCK_NUCLEA_DEFAULT_SCENARIO — applied to any ISPB with NO explicit entry
+    # in scenarioSeed below. Empty/unset keeps today's behavior (`happy`, the
+    # mock's compiled default). An unrecognized name FAILS THE BOOT, listing the
+    # closed set of valid scenario names.
+    defaultScenario: ""
+    # MOCK_NUCLEA_SCENARIO_SEED — OPTIONAL per-ISPB pin, format
+    # "<ispb>=<scenario>[,<ispb>=<scenario>]", e.g.
+    # "29011780=spb_envelope_forward_confirm" to pin Núclea's own ISPB (the one
+    # this incident needed) without changing the default for every other
+    # participant. Whitespace around entries and around each side of "=" is
+    # tolerated; a trailing comma (empty entry) is ignored. Empty/unset seeds
+    # nothing. A malformed entry — missing "=", a non-8-digit ISPB, an
+    # unrecognized scenario name, or a repeated ISPB — FAILS THE BOOT.
+    scenarioSeed: ""
   # Distroless static nonroot binary (USER 65532) that writes nothing to disk,
   # so readOnlyRootFilesystem is safe with no /tmp emptyDir needed (unlike the
   # app/signer/validator containers above).


### PR DESCRIPTION
## Description

The `mock-nuclea` container renders `MOCK_NUCLEA_ADDR`, the SPB key paths, the license trio and `GOMAXPROCS` — but **neither of the two envs the mock binary reads to seed its scenario store**. The posture can therefore only be set at runtime with `PUT /admin/scenarios/{ispb}`, and that store is in-memory: **every pod restart silently reverts every participant to `happy`.**

br-slc added those envs for exactly this reason (issue #211, F-3 — `mock/scenarios.go:336-350`):

> the scenario store is in-memory and was ONLY writable through `PUT /admin/scenarios/{ispb}`, so every pod restart silently reverted the participant to happy: correlation then broke with no signal at all (the operation just sat in SENT with lastError null). **These two envs let a gitops overlay pin the posture declaratively**, and any typo FAILS THE BOOT instead of degrading to a wrong-but-quiet default.

The chart never wired them.

### Measured on dev-st today

The scenario store read back `{}`, and no operation could get past `FORWARDED`. After a runtime `PUT` arming `spb_envelope_forward_confirm`, the same journey closed in **33 seconds** with the full seven-edge chain:

```
nil          -> CREATED       [API_SUBMISSION]
CREATED      -> QUEUED        [WINDOW_ASSIGNED]
QUEUED       -> SENT          [TRANSPORT_SENT]
SENT         -> ACKNOWLEDGED  [NUCLEA_ACK]
ACKNOWLEDGED -> ACCEPTED      [RET_ACCEPTED]
ACCEPTED     -> FORWARDED     [FORWARD_SENT]
FORWARDED    -> CONFIRMED     [IF_CONFIRMED]
```

That arming dies with the pod. Pinning it from values is what makes the environment reproducible instead of hand-armed — which matters because this tier is about to be handed to a client for IF Domicílio / IF Liquidante testing.

## Compatibility — purely additive

Both values default to empty, which reproduces today's render **byte-for-byte**. Verified by diffing the full default `helm template` output before and after the change:

```
$ diff full-default-before.yaml full-default-after.yaml && echo "NO DIFF"
NO DIFF (full chart, default values)
```

No change for dev-st, stg-st, sandbox or prd-st until an operator opts in.

## Schema pattern on `scenarioSeed`

`scenarioSeed` carries a pattern so the two commonest typos — a forgotten `=` and a wrong-length ISPB — fail at `helm template` time rather than at pod boot.

The pattern deliberately mirrors the **parser's real tolerance**, not the format's prose. An earlier, stricter draft rejected `"29011780=happy,,12345678=happy"` — which `parseScenarioSeed` actually **accepts**, since it trims and skips *any* empty entry, not only a trailing one. That was caught by testing the regex against the parser's behaviour before settling on it.

Left to the app's boot-time fail-closed check by design:

- **scenario-name validity** — enumerating ~20 names in the schema would drift against `mock/scenarios.go` on every addition;
- **duplicate ISPBs** — not expressible in a single-string regex without backreferences, which RE2 (used by both Go's `regexp` and the schema validator) does not support.

## The coupling worth reading

The values comment records the trap: seeding **any** SPB-family scenario without `mockNuclea.spbKeysSecret.enabled: true` fails the boot closed with `SPB scenario seeded without SPB key material`. The mock refuses to seed a posture it cannot execute — otherwise it would 200 on the plain-content path with nothing decrypted or verified, i.e. a green e2e for the wrong reason.

## Deliberately out of scope

`MOCK_NUCLEA_LOG_LEVEL` is **not** exposed. It is a diagnostic knob unrelated to this incident (which was "scenario reverts on restart", not "cannot see debug logs"), and its default is safe. Bundling it would widen a surgical change into a second concern. One-line follow-up if operators later want it.

`Chart.yaml` `version:` and `CHANGELOG.md` are untouched — `b66f8e03` established that the release pipeline owns both on merge to main.

## Validation

```
$ helm lint charts/br-slc
==> Linting charts/br-slc
1 chart(s) linted, 0 chart(s) failed
```

Rendered with the new values set (alongside `spbKeysSecret.enabled: true`):

```yaml
env:
  - name: MOCK_NUCLEA_ADDR
    value: ":9190"
  - name: SPB_RECIPIENT_KEY_PATH
    value: "/spb-keys/recipient.key"
  - name: SPB_EMITTER_CERT_PATH
    value: "/spb-keys/emitter.crt"
  - name: MOCK_NUCLEA_DEFAULT_SCENARIO
    value: "happy"
  - name: MOCK_NUCLEA_SCENARIO_SEED
    value: "29011780=spb_envelope_forward_confirm, 12345678 = reject_eslc"
  - name: GOMAXPROCS
    ...
```

Schema rejects malformed seeds before anything reaches the cluster:

```
$ helm template test charts/br-slc -f malformed-missing-equals.yaml
Error: values don't meet the specifications of the schema(s)
- mockNuclea.scenarios.scenarioSeed: Does not match pattern...

$ helm template test charts/br-slc -f malformed-7-digit-ispb.yaml
Error: values don't meet the specifications of the schema(s)
- mockNuclea.scenarios.scenarioSeed: Does not match pattern...
```

## Base branch

Targets `feat/br-slc`, where the chart lives — it has not merged to `main` yet. Note that a PR into a feature branch may not trigger the full chart CI; the validation above was run locally against `helm` v3.16.4.

## Follow-up, not in this PR

Once this lands and an alpha is cut, the dev-st gitops overlay should set:

```yaml
mockNuclea:
  scenarios:
    scenarioSeed: "29011780=spb_envelope_forward_confirm"
```

so the posture survives a pod restart instead of depending on someone remembering the `PUT`.
