### PR TITLE
fix(common): SD_ENABLED-alone contract + presence-based MT tuning / ingress className

### DIFF
--- a/charts/lerian-common/README.md
+++ b/charts/lerian-common/README.md
@@ -10,9 +10,12 @@ via `include` by the product charts that declare it as a dependency.
   `lerian-common.multiTenant.env` — env-wide constants come from `global.*`
   (set once per environment); the per-app enable knob stays in the component's
   `extraEnvVars`/`configmap`; a component value overrides the global default; and
-  each helper stays **inert until `global.*` is set** (backward-compatible);
-  `serviceDiscovery.env` additionally activates from a legacy `configmap.SD_ADDRESS`,
-  and a component `configmap.SD_*` value takes precedence over the `global.*` default.
+  each helper stays **inert until enabled** (backward-compatible); `serviceDiscovery.env`
+  activates on the app's `SD_ENABLED` knob (`.enabled`) and, when enabled, emits the full
+  SD_* contract with `SD_ADDRESS` defaulting to `localhost:8500`; `global.serviceDiscovery.
+  address` or a legacy `configmap.SD_ADDRESS` override that default, and a component
+  `configmap.SD_*` value takes precedence over the `global.*` default. A chart that renders
+  this helper must not also hand-set SD_* in `extraEnvVars` (that would duplicate keys).
   The external endpoint (`SD_EXTERNAL_ADDRESS`/`SD_EXTERNAL_PORT`) is derived from
   the Ingress host when present, **and** is preserved when supplied explicitly via
   legacy `configmap.SD_EXTERNAL_*` even with no Ingress (on-prem) — honoring the

--- a/charts/lerian-common/README.md
+++ b/charts/lerian-common/README.md
@@ -14,8 +14,10 @@ via `include` by the product charts that declare it as a dependency.
   activates on the app's `SD_ENABLED` knob (`.enabled`) and, when enabled, emits the full
   SD_* contract with `SD_ADDRESS` defaulting to `localhost:8500`; `global.serviceDiscovery.
   address` or a legacy `configmap.SD_ADDRESS` override that default, and a component
-  `configmap.SD_*` value takes precedence over the `global.*` default. A chart that renders
-  this helper must not also hand-set SD_* in `extraEnvVars` (that would duplicate keys).
+  `configmap.SD_*` value takes precedence over the `global.*` default. Ownership: the caller
+  supplies exactly one SD key — `SD_ENABLED` (via `extraEnvVars`/`configmap`) — and the helper
+  owns every derived `SD_*` sibling; keep those derived keys out of `extraEnvVars` (leaving one
+  there too would duplicate it).
   The external endpoint (`SD_EXTERNAL_ADDRESS`/`SD_EXTERNAL_PORT`) is derived from
   the Ingress host when present, **and** is preserved when supplied explicitly via
   legacy `configmap.SD_EXTERNAL_*` even with no Ingress (on-prem) — honoring the

--- a/charts/lerian-common/docs/UPGRADE-1.0.md
+++ b/charts/lerian-common/docs/UPGRADE-1.0.md
@@ -91,7 +91,7 @@ Product chart maintainers include this helper in their ConfigMap template:
 # templates/configmap.yaml
 data:
   # SD_ENABLED is the app's own knob — resolve it to a strict bool and pass it as `enabled`.
-  {{- $sdEnabled := eq (index .Values.myapp.configmap "SD_ENABLED" | default "false" | toString) "true" }}
+  {{- $sdEnabled := eq (index (.Values.myapp.configmap | default dict) "SD_ENABLED" | default "false" | toString) "true" }}
   SD_ENABLED: {{ $sdEnabled | quote }}
   {{- include "lerian-common.serviceDiscovery.env" (dict
         "context" $ "enabled" $sdEnabled "configmap" .Values.myapp.configmap

--- a/charts/lerian-common/docs/UPGRADE-1.0.md
+++ b/charts/lerian-common/docs/UPGRADE-1.0.md
@@ -90,7 +90,12 @@ Product chart maintainers include this helper in their ConfigMap template:
 ```yaml
 # templates/configmap.yaml
 data:
-  {{- include "lerian-common.serviceDiscovery.env" (dict "context" $ "configmap" .Values.myapp.configmap) | nindent 2 }}
+  # SD_ENABLED is the app's own knob — resolve it to a strict bool and pass it as `enabled`.
+  {{- $sdEnabled := eq (index .Values.myapp.configmap "SD_ENABLED" | default "false" | toString) "true" }}
+  SD_ENABLED: {{ $sdEnabled | quote }}
+  {{- include "lerian-common.serviceDiscovery.env" (dict
+        "context" $ "enabled" $sdEnabled "configmap" .Values.myapp.configmap
+        "name" (include "myapp.fullname" .) "port" 8080 "namespace" .Release.Namespace) | nindent 2 }}
 ```
 
 ### 2. Streaming Environment Variables

--- a/charts/lerian-common/docs/UPGRADE-1.0.md
+++ b/charts/lerian-common/docs/UPGRADE-1.0.md
@@ -57,7 +57,7 @@ The `lerian-common.serviceDiscovery.env` helper emits environment variables for 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SD_ENABLED` | `false` | Enable service discovery for this component |
-| `SD_ADDRESS` | `""` | Service discovery server address (e.g. `consul.prod:443`) |
+| `SD_ADDRESS` | `localhost:8500` | Service discovery server address (e.g. `consul.prod:443`); defaults to `localhost:8500` when neither `global.serviceDiscovery.address` nor legacy `configmap.SD_ADDRESS` is set |
 | `SD_TLS` | `false` | Enable TLS for service discovery connection |
 | `SD_TLS_SKIP_VERIFY` | `false` | Skip TLS certificate verification |
 | `SD_WORKLOAD` | `""` | Workload isolation key (provider and consumer must match) |

--- a/charts/lerian-common/templates/_ingress.tpl
+++ b/charts/lerian-common/templates/_ingress.tpl
@@ -52,7 +52,9 @@ Inputs (dict):
 {{- $g := .global | default dict -}}
 {{- $name := .name -}}
 {{- $svcPort := .svcPort -}}
-{{- $className := $ing.className | default $g.className -}}
+{{- /* Presence-based (hasKey) so an explicit component className "" (deliberately no
+   class) is honored instead of falling back to the global class. */ -}}
+{{- $className := $g.className -}}{{- if hasKey $ing "className" -}}{{- $className = index $ing "className" -}}{{- end -}}
 {{- /* mergeOverwrite (not merge): per-ingress annotations must win over same-key global. */ -}}
 {{- $annotations := mergeOverwrite (deepCopy ($g.annotations | default dict)) ($ing.annotations | default dict) -}}
 {{- $tls := $g.tls -}}

--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -69,8 +69,10 @@ MULTI_TENANT_URL: {{ $url | quote }}
 MULTI_TENANT_SERVICE_NAME: {{ $svcName | quote }}
 {{- end }}
 {{- if not (and (hasKey . "circuitBreaker") (eq .circuitBreaker false)) }}
-MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" | default "5" | quote }}
-MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ index $c "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC" | default "30" | quote }}
+{{- $cbThreshold := "5" -}}{{- if hasKey $c "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" -}}{{- $cbThreshold = index $c "MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD" -}}{{- end }}
+MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD: {{ $cbThreshold | quote }}
+{{- $cbTimeout := "30" -}}{{- if hasKey $c "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC" -}}{{- $cbTimeout = index $c "MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC" -}}{{- end }}
+MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC: {{ $cbTimeout | quote }}
 {{- end }}
 {{- if .emitRedis }}
 {{- $redisHost := ($g.redisHost | default "") -}}{{- if hasKey $c "MULTI_TENANT_REDIS_HOST" -}}{{- $redisHost = index $c "MULTI_TENANT_REDIS_HOST" -}}{{- end -}}
@@ -85,13 +87,18 @@ MULTI_TENANT_REDIS_PORT: {{ $redisPort | quote }}
 MULTI_TENANT_REDIS_TLS: {{ $redisTls | quote }}
 {{- end }}
 {{- if .emitPool }}
-MULTI_TENANT_MAX_TENANT_POOLS: {{ index $c "MULTI_TENANT_MAX_TENANT_POOLS" | default "100" | quote }}
-MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ index $c "MULTI_TENANT_IDLE_TIMEOUT_SEC" | default "300" | quote }}
+{{- $maxPools := "100" -}}{{- if hasKey $c "MULTI_TENANT_MAX_TENANT_POOLS" -}}{{- $maxPools = index $c "MULTI_TENANT_MAX_TENANT_POOLS" -}}{{- end }}
+MULTI_TENANT_MAX_TENANT_POOLS: {{ $maxPools | quote }}
+{{- $idleTimeout := "300" -}}{{- if hasKey $c "MULTI_TENANT_IDLE_TIMEOUT_SEC" -}}{{- $idleTimeout = index $c "MULTI_TENANT_IDLE_TIMEOUT_SEC" -}}{{- end }}
+MULTI_TENANT_IDLE_TIMEOUT_SEC: {{ $idleTimeout | quote }}
 {{- end }}
 {{- if .emitCache }}
-MULTI_TENANT_TIMEOUT: {{ index $c "MULTI_TENANT_TIMEOUT" | default "30" | quote }}
-MULTI_TENANT_CACHE_TTL_SEC: {{ index $c "MULTI_TENANT_CACHE_TTL_SEC" | default "120" | quote }}
-MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ index $c "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" | default "30" | quote }}
+{{- $mtTimeout := "30" -}}{{- if hasKey $c "MULTI_TENANT_TIMEOUT" -}}{{- $mtTimeout = index $c "MULTI_TENANT_TIMEOUT" -}}{{- end }}
+MULTI_TENANT_TIMEOUT: {{ $mtTimeout | quote }}
+{{- $cacheTtl := "120" -}}{{- if hasKey $c "MULTI_TENANT_CACHE_TTL_SEC" -}}{{- $cacheTtl = index $c "MULTI_TENANT_CACHE_TTL_SEC" -}}{{- end }}
+MULTI_TENANT_CACHE_TTL_SEC: {{ $cacheTtl | quote }}
+{{- $connCheck := "30" -}}{{- if hasKey $c "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" -}}{{- $connCheck = index $c "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" -}}{{- end }}
+MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC: {{ $connCheck | quote }}
 {{- end }}
 {{- if .emitEnvironment }}
 MULTI_TENANT_ENVIRONMENT: {{ index $c "MULTI_TENANT_ENVIRONMENT" | default "" | quote }}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -53,24 +53,20 @@ global.serviceDiscovery (all optional except address when enabled):
    no-configmap caller renders byte-identical to before. */ -}}
 {{- $c := .configmap | default dict -}}
 {{- /*
-  Derive ONLY when enabled AND an SD address is configured — via EITHER the
-  environment-wide `global.serviceDiscovery.address` OR the legacy flat
-  `configmap.SD_ADDRESS` (on-prem/client values that predate global). Gating on
-  both preserves the documented backward-compat contract: a chart deployed with
-  `configmap.SD_ENABLED=true` + `configmap.SD_ADDRESS` (no global) still derives
-  the full sibling block, matching pre-refactor output.
-  This keeps adoption backward-compatible: a chart carrying this helper but
-  deployed against a not-yet-migrated environment (SD_* still hand-set in
-  extraEnvVars, no global.serviceDiscovery, no configmap.SD_ADDRESS) stays
-  INERT — extraEnvVars drives SD exactly as before, no duplicate keys, no render
-  break. The environment opts into derivation by setting global.serviceDiscovery
-  (or configmap.SD_ADDRESS) + stripping the per-app SD_* block down to SD_ENABLED.
+  Activation is the app's own SD_ENABLED knob, passed in as `.enabled` (the consumer
+  resolves it, typically from `configmap.SD_ENABLED` / a grouped `serviceDiscovery.
+  enabled` param). When SD is ENABLED the full derived sibling block is emitted with
+  sensible defaults — `SD_ADDRESS` falls back to `localhost:8500`, matching the pre-
+  productization chart where enabling SD alone (no global.serviceDiscovery, no
+  configmap.SD_ADDRESS) still rendered the whole SD_* contract. `global.service
+  Discovery.address` or a legacy flat `configmap.SD_ADDRESS` override that default
+  (configmap wins). When SD is DISABLED the block stays inert (no derived keys).
+
+  Adoption note: a chart that renders this helper MUST drive SD through it, not also
+  hand-set SD_* in extraEnvVars — enabling both would duplicate keys. The migration is
+  to strip the per-app flat SD_* block down to SD_ENABLED and let the helper derive
+  the rest (from global.serviceDiscovery, legacy configmap.SD_*, or the defaults).
 */ -}}
-{{- /* Activation is the app's own SD_ENABLED knob (.enabled). When SD is enabled the
-   full derived block is emitted with sensible defaults (SD_ADDRESS falls back to
-   localhost:8500), matching the pre-productization chart where enabling SD alone —
-   with no global.serviceDiscovery and no configmap.SD_ADDRESS — still rendered the
-   whole SD_* contract. When SD is disabled the block stays inert (no keys). */ -}}
 {{- if .enabled -}}
 {{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
    rendered by the component's own extraEnvVars passthrough. Emitting it again

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -66,11 +66,12 @@ global.serviceDiscovery (all optional except address when enabled):
   break. The environment opts into derivation by setting global.serviceDiscovery
   (or configmap.SD_ADDRESS) + stripping the per-app SD_* block down to SD_ENABLED.
 */ -}}
-{{- /* Activation gate is PRESENCE-based on the configmap key (hasKey), not its
-   truthiness: a present-but-empty `configmap.SD_ADDRESS` must still activate the
-   block. Sprig `index ... | default` (and `or`) would treat "" / false / 0 as
-   empty and wrongly fall through to global — the footgun this fix removes. */ -}}
-{{- if and .enabled (or $sd.address (hasKey $c "SD_ADDRESS")) -}}
+{{- /* Activation is the app's own SD_ENABLED knob (.enabled). When SD is enabled the
+   full derived block is emitted with sensible defaults (SD_ADDRESS falls back to
+   localhost:8500), matching the pre-productization chart where enabling SD alone —
+   with no global.serviceDiscovery and no configmap.SD_ADDRESS — still rendered the
+   whole SD_* contract. When SD is disabled the block stays inert (no keys). */ -}}
+{{- if .enabled -}}
 {{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
    rendered by the component's own extraEnvVars passthrough. Emitting it again
    would produce a duplicate key. This helper only adds the derived siblings.
@@ -84,7 +85,7 @@ global.serviceDiscovery (all optional except address when enabled):
    it emits nothing), then the KEY: value lines below are plain literals — this
    keeps the rendered block byte-identical to the pre-fix output when no
    configmap.SD_* key is present. */ -}}
-{{- $addr := $sd.address -}}{{- if hasKey $c "SD_ADDRESS" -}}{{- $addr = index $c "SD_ADDRESS" -}}{{- end -}}
+{{- $addr := ($sd.address | default "localhost:8500") -}}{{- if hasKey $c "SD_ADDRESS" -}}{{- $addr = index $c "SD_ADDRESS" -}}{{- end -}}
 {{- $tls := ($sd.tls | default false) -}}{{- if hasKey $c "SD_TLS" -}}{{- $tls = index $c "SD_TLS" -}}{{- end -}}
 {{- $tlsSkip := ($sd.tlsSkipVerify | default false) -}}{{- if hasKey $c "SD_TLS_SKIP_VERIFY" -}}{{- $tlsSkip = index $c "SD_TLS_SKIP_VERIFY" -}}{{- end -}}
 {{- $workload := ($sd.workload | default "") -}}{{- if hasKey $c "SD_WORKLOAD" -}}{{- $workload = index $c "SD_WORKLOAD" -}}{{- end -}}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -70,7 +70,10 @@ global.serviceDiscovery (all optional except address when enabled):
   keeping a derived key in extraEnvVars too would duplicate it. SD_ENABLED stays with
   the caller and is never emitted here.
 */ -}}
-{{- if .enabled -}}
+{{- /* Normalize .enabled to a strict bool: a raw string "false" (e.g. passed straight
+   from a configmap value) would otherwise be truthy under `if`. */ -}}
+{{- $enabled := eq (toString (.enabled | default false)) "true" -}}
+{{- if $enabled -}}
 {{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is
    rendered by the component's own extraEnvVars passthrough. Emitting it again
    would produce a duplicate key. This helper only adds the derived siblings.

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -62,10 +62,13 @@ global.serviceDiscovery (all optional except address when enabled):
   Discovery.address` or a legacy flat `configmap.SD_ADDRESS` override that default
   (configmap wins). When SD is DISABLED the block stays inert (no derived keys).
 
-  Adoption note: a chart that renders this helper MUST drive SD through it, not also
-  hand-set SD_* in extraEnvVars — enabling both would duplicate keys. The migration is
-  to strip the per-app flat SD_* block down to SD_ENABLED and let the helper derive
-  the rest (from global.serviceDiscovery, legacy configmap.SD_*, or the defaults).
+  Ownership: the caller supplies exactly ONE SD key — `SD_ENABLED` (the app's knob,
+  via the component's extraEnvVars/configmap) — and this helper owns every DERIVED
+  SD_* sibling (SD_ADDRESS, SD_TLS, SD_INTERNAL_*, SD_EXTERNAL_*, tuning). Adoption
+  means stripping those derived SD_* keys out of extraEnvVars and letting the helper
+  render them (from global.serviceDiscovery, legacy configmap.SD_*, or the defaults);
+  keeping a derived key in extraEnvVars too would duplicate it. SD_ENABLED stays with
+  the caller and is never emitted here.
 */ -}}
 {{- if .enabled -}}
 {{- /* SD_ENABLED is NOT emitted here: it is the app's single knob and is

--- a/charts/lerian-common/values.yaml
+++ b/charts/lerian-common/values.yaml
@@ -8,15 +8,17 @@
 # `global.*`, the per-app enable knob stays in the component `extraEnvVars`
 # (`SD_ENABLED` / `STREAMING_ENABLED`) or `configmap` (`MULTI_TENANT_ENABLED`),
 # and a component's own value overrides the global default. Every helper is
-# backward-compatible: with the `global.*` block absent it stays inert and the
-# component's existing values drive the output unchanged. Exception:
-# `serviceDiscovery.env` also activates from a legacy `configmap.SD_ADDRESS`
-# (a component `configmap.SD_*` value takes precedence over the `global.*` default).
+# backward-compatible: while disabled the helper stays inert and the component's
+# existing values drive the output unchanged. `serviceDiscovery.env` activates on the
+# app's `SD_ENABLED` knob and, when enabled, emits the full SD_* contract with
+# `SD_ADDRESS` defaulting to `localhost:8500`; `global.serviceDiscovery.address` or a
+# legacy `configmap.SD_ADDRESS` override it (a component `configmap.SD_*` value takes
+# precedence over the `global.*` default). Do not also hand-set SD_* in extraEnvVars.
 
 global: {}
   # -- Service Discovery (lib-service-discovery). Set once per environment.
   # serviceDiscovery:
-  #   address: ""            # SD_ADDRESS when SD_ENABLED=true (e.g. consul.<env>:443), unless supplied via legacy configmap.SD_ADDRESS (which wins). No default.
+  #   address: ""            # SD_ADDRESS when SD_ENABLED=true (e.g. consul.<env>:443); legacy configmap.SD_ADDRESS wins. Defaults to localhost:8500 when neither is set.
   #   tls: false             # SD_TLS
   #   tlsSkipVerify: false   # SD_TLS_SKIP_VERIFY
   #   workload: ""           # SD_WORKLOAD — per-env isolation key (provider+consumer must match)

--- a/charts/lerian-common/values.yaml
+++ b/charts/lerian-common/values.yaml
@@ -13,7 +13,8 @@
 # app's `SD_ENABLED` knob and, when enabled, emits the full SD_* contract with
 # `SD_ADDRESS` defaulting to `localhost:8500`; `global.serviceDiscovery.address` or a
 # legacy `configmap.SD_ADDRESS` override it (a component `configmap.SD_*` value takes
-# precedence over the `global.*` default). Do not also hand-set SD_* in extraEnvVars.
+# precedence over the `global.*` default). The caller supplies only `SD_ENABLED`; the
+# helper owns the derived SD_* siblings — keep those out of extraEnvVars.
 
 global: {}
   # -- Service Discovery (lib-service-discovery). Set once per environment.


### PR DESCRIPTION
Addresses a backward-compat regression raised on midaz #1741 (Gandalf 4th review).

## Problem
With only the legacy enable flag — `configmap.SD_ENABLED=true`, no `SD_ADDRESS`, no `global.serviceDiscovery` — the activation gate (`and .enabled (or $sd.address (hasKey $c "SD_ADDRESS"))`) did not fire, so the helper emitted only `SD_ENABLED` and dropped the ~16 derived siblings. The pre-productization chart rendered all 17 `SD_*` keys (including `SD_ADDRESS=localhost:8500`) on the enable flag alone. Reproduced in Ledger and CRM.

## Fix
- Gate on `.enabled` alone — enabling SD emits the full derived block.
- `SD_ADDRESS` falls back to `localhost:8500` (the pre-productization default) when neither `global.serviceDiscovery.address` nor `configmap.SD_ADDRESS` is set.

## Validation
| Scenario | Result |
|---|---|
| `SD_ENABLED=true` alone | full block, `SD_ADDRESS: "localhost:8500"` |
| SD disabled | inert (no derived keys) |
| `global.serviceDiscovery.address` set | uses it (no default) |
| legacy `configmap.SD_*` (on-prem, external, tuning) | unchanged — still preserved |

`helm lint` passes. A render assertion for this minimal case lands with the midaz re-pin in #1741.