### PR TITLE
fix(lender): default consignado dark so eight deployments stop depending on one line

### DIFF
--- a/charts/lender/values.yaml
+++ b/charts/lender/values.yaml
@@ -313,6 +313,15 @@ lender:
     STREAMING_CLOSE_TIMEOUT_S: "30"
     STREAMING_TLS_ENABLED: "false"
 
+    # Consignado contratação master switch. Dark by default: the contratação path
+    # wires an in-memory fake CCB signer, and the app's boot guard refuses to
+    # start any hardened deployment that would wire it — and DEPLOYMENT_MODE
+    # above makes every deployment hardened. CCB issuance and signing moved to
+    # the client (D-CCB-CLIENT, 2026-07-28), so the route stays dark until the
+    # emission path is deleted. Enabling this on a hardened deployment is a boot
+    # refusal, not a degradation.
+    CONSIGNADO_ENABLED: "false"
+
     # Inbound consignado consumer opt-in flags (all dark by default)
     CONSUMER_CONSIGNADO_AVERBACAO_CONFIRMED_ENABLED: "false"
     CONSUMER_CONSIGNADO_AVERBACAO_REJECTED_ENABLED: "false"


### PR DESCRIPTION
## What this closes

The chart defaults `DEPLOYMENT_MODE: "production"` and **no GitOps values file in either cluster overrides it** — so the lender's hardened money-path floor is armed in all eight deployments, including the ones whose `ENV_NAME` reads `development`.

That makes the app's consignado boot guard live everywhere. It refuses to start any deployment that would wire the in-memory **fake CCB signer**, which is correct: a fake-signed CCB can drive a real, irreversible averbação. CCB issuance and signing moved to the client (decision D-CCB-CLIENT, 2026-07-28), so no real signer will ever exist in the lender; the route stays dark until the emission path is deleted.

Until now the chart did not set `CONSIGNADO_ENABLED` at all. The only thing preventing a boot refusal across those eight environments was a per-environment configmap line added by hand today. An app-side config-loader fix (`LerianStudio/lender#103`) makes that line load for the first time — so **flipping or deleting it now takes the environment down**, where previously it was silently ignored.

Defaulting it dark here turns each environment's line into redundancy instead of the sole obstacle, and makes enabling consignado an explicit request rather than an omission.

## Verification

1. **Rendered delta is one key.** `helm template` before/after: `> CONSIGNADO_ENABLED: "false"` and nothing else moved.
2. **Override precedence proven, which mattered more than the edit.** All eight environments already set this key explicitly; a chart default that shadowed them would be worse than no default. Rendering with an environment override of `"true"` yields `"true"`; rendering without one yields the chart default `"false"`.
3. **Schema-legal.** `helm lint` passes on this chart version — worth checking, since a sibling change in this fleet hit root `additionalProperties: false` on the same version.

No chart version bump: this repo versions through semantic-release from conventional commits, not by hand.

## Related, and worth a separate decision

While verifying, I inventoried every env var this chart defaults that governs hardened posture or a security guarantee **and that no environment overrides**. There are **21**. Two stand out:

- **`ALLOW_RUNTIME_RATELIMIT_DISABLE: "true"`** — permits HTTP rate limiting to be switched off at runtime from the config plane, and the app's production forcing only fixes the boot-time value. A permissive bypass, on by default, in all eight deployments, from a chart default nobody reads.
- **`STREAMING_TLS_ENABLED: "false"`** and **`OUTBOX_ALLOW_EMPTY_TENANT: "true"`** — the second is not a bypass despite the name; it is what lets the outbox write in single-tenant mode, which matters more once the outbox becomes mandatory.

Not touched here. A chart default nobody reads governing money-path posture is the pattern behind the incident that started this work, and the full list belongs in front of a human before anything changes.

https://claude.ai/code/session_016tGF4nEC1QgZuYs479gnBk