### PR TITLE
fix(common): streaming.secret requires SASL username with the mechanism

### DIFF
--- a/charts/lerian-common/templates/_streaming.tpl
+++ b/charts/lerian-common/templates/_streaming.tpl
@@ -110,14 +110,16 @@ matching `data:`/`stringData:` key:
         "secretName" (include "midaz.ledger.fullname" .)
         "valuesPrefix" "ledger.secrets." "mode" "data"
         "enabled" true "useExistingSecret" .Values.ledger.useExistingSecret
-        "saslMechanism" (dig "streaming" "saslMechanism" "" (.Values.global | default dict)))) }}
+        "saslMechanism" (dig "streaming" "saslMechanism" "" (.Values.global | default dict))
+        "saslUsername" (dig "streaming" "saslUsername" "" (.Values.global | default dict)))) }}
   {{- . | nindent 2 }}
   {{- end }}
 
 Inputs: context, secrets, secretName, valuesPrefix, mode,
         enabled (bool — STREAMING_ENABLED),
         useExistingSecret (bool — skip entirely when true),
-        saslMechanism (string — when non-empty, SASL_PASSWORD becomes required).
+        saslMechanism (string — when non-empty, both SASL_USERNAME and SASL_PASSWORD become required),
+        saslUsername (string — the resolved STREAMING_SASL_USERNAME; required when saslMechanism is set).
 ------------------------------------------------------------------------------
 */}}
 {{- define "lerian-common.streaming.secret" -}}
@@ -126,6 +128,14 @@ Inputs: context, secrets, secretName, valuesPrefix, mode,
 {{- $b64 := eq (.mode | default "stringData") "data" -}}
 {{- $ns := .context.Release.Namespace -}}
 {{- $lines := list -}}
+{{- /* STREAMING_SASL_USERNAME — required (with the password) whenever a SASL mechanism
+   is set; lib-streaming rejects a mechanism without BOTH credentials. The username is a
+   ConfigMap value (not a secret), resolved by the caller with the same precedence
+   (configmap.STREAMING_SASL_USERNAME -> global.streaming.saslUsername) and passed here so
+   the render fails fast instead of shipping a boot-crashing config. */ -}}
+{{- if and .saslMechanism (not .saslUsername) -}}
+{{- fail (printf "\n[lerian-common] Value required but empty: STREAMING_SASL_USERNAME\n  a SASL mechanism (%s) is set, which requires both a username and a password.\n  set:     configmap.STREAMING_SASL_USERNAME (or global.streaming.saslUsername)\n" .saslMechanism) -}}
+{{- end -}}
 {{- /* STREAMING_SASL_PASSWORD — required only when a SASL mechanism is set */ -}}
 {{- $sasl := index $s "STREAMING_SASL_PASSWORD" -}}
 {{- if and .saslMechanism (not $sasl) -}}

--- a/charts/lerian-common/templates/_streaming.tpl
+++ b/charts/lerian-common/templates/_streaming.tpl
@@ -105,13 +105,20 @@ on install AND upgrade (these values are operator/Vault-provided, never generate
 matching `data:`/`stringData:` key:
 
   # STREAMING SECRETS
+  # Resolve mechanism + username with the SAME configmap-over-global precedence the
+  # ConfigMap uses (streaming.env), so a ConfigMap-only mechanism is still validated and
+  # a ConfigMap-only username does not cause a false failure. An explicit empty ConfigMap
+  # value is preserved (hasKey) so validation still fails when it should.
+  {{- $saslMech := (((.Values.global | default dict).streaming | default dict).saslMechanism | default "") }}
+  {{- if hasKey .Values.ledger.configmap "STREAMING_SASL_MECHANISM" }}{{- $saslMech = index .Values.ledger.configmap "STREAMING_SASL_MECHANISM" }}{{- end }}
+  {{- $saslUser := (((.Values.global | default dict).streaming | default dict).saslUsername | default "") }}
+  {{- if hasKey .Values.ledger.configmap "STREAMING_SASL_USERNAME" }}{{- $saslUser = index .Values.ledger.configmap "STREAMING_SASL_USERNAME" }}{{- end }}
   {{- with (include "lerian-common.streaming.secret" (dict
         "context" . "secrets" .Values.ledger.secrets
         "secretName" (include "midaz.ledger.fullname" .)
         "valuesPrefix" "ledger.secrets." "mode" "data"
         "enabled" true "useExistingSecret" .Values.ledger.useExistingSecret
-        "saslMechanism" (dig "streaming" "saslMechanism" "" (.Values.global | default dict))
-        "saslUsername" (dig "streaming" "saslUsername" "" (.Values.global | default dict)))) }}
+        "saslMechanism" $saslMech "saslUsername" $saslUser)) }}
   {{- . | nindent 2 }}
   {{- end }}
 


### PR DESCRIPTION
Addresses a fail-fast gap raised on midaz #1741 (Gandalf 5th review).

## Problem
The SASL fail-fast (added earlier) only required `STREAMING_SASL_PASSWORD`. With a mechanism (e.g. `SCRAM-SHA-512`) and a password but **no username**, the render passed (Ledger and CRM), the ConfigMap emitted `STREAMING_SASL_USERNAME: ""`, and the workload crashed at bootstrap — lib-streaming rejects a SASL mechanism without **both** credentials.

## Fix
`lerian-common.streaming.secret` now accepts the resolved `saslUsername` (a ConfigMap value, resolved by the caller with `configmap.STREAMING_SASL_USERNAME → global.streaming.saslUsername`) and fails the render when a mechanism is set without it — same shape as the existing password check.

## Validation
| Scenario | Result |
|---|---|
| mechanism + password, no username | ❌ render fails (STREAMING_SASL_USERNAME) |
| mechanism + username, no password | ❌ render fails (STREAMING_SASL_PASSWORD) |
| mechanism + both | ✅ renders |
| no mechanism | ✅ passes |

`helm lint` passes. The midaz call sites pass `saslUsername` and negative assertions (username missing, Ledger + CRM) land with the re-pin in #1741.