### PR TITLE
fix(charts): restore the streaming-hub release section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,14 @@ For implementation and configuration details, see the [README](https://charts.le
 | :---: | :---: | :---: |
 | `1.2.0-beta.1` | `1.0.0-beta.109` | `1.0.0-beta.109` |
 -----------------
+
+### Streaming Hub
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/streaming-hub).
+
+#### Application Version Mapping
+
+| Chart Version | App Version |
+| :---: | :---: |
+| `1.0.0-beta.4` | 1.0.0 |
+-----------------


### PR DESCRIPTION
## What

Restores the `### Streaming Hub` section in this README, with its version-matrix table.

## Why it matters

**The streaming-hub release has been broken since 2026-07-08, and nobody knew** — no release of that chart was attempted in between, so the failure had no way to surface.

The release job runs `update-chart-version-readme-bin --chart <name> --version <v>` in semantic-release's `prepare` step. That script needs a `### <Chart>` section with a version-matrix table here, and exits 1 without one. That fails the whole job and leaves `Install oras`, `Tag chart as latest` and `Publish Release` **skipped** — nothing published, no git tag. Because semantic-release has already computed the next version by then, the log reads like a healthy release right up to the line where it dies.

Observed on run [30664072139](https://github.com/LerianStudio/helm/actions/runs/30664072139) (merge of #1769):

```
[semantic-release] [semantic-release-helm3] › ℹ  Updating Chart.yaml with version 1.0.0-beta.5.
[semantic-release] [@semantic-release/exec] › ℹ  Call script ./.github/scripts/update-chart-version-readme-bin --chart streaming-hub --version 1.0.0-beta.5
WARNING: Could not find section for chart 'streaming-hub'
ERROR: Could not find version matrix table in README.md
Error: Command failed with exit code 1
```

## How it went missing — worth a second look beyond this fix

The section was added in `1f6a3751` (#1571, 2026-06-24). **That commit is an ancestor of `develop`, and the section is not in `develop` today** — so it disappeared in a **merge**, not a revert. `git log -S "### Streaming Hub" -- README.md` shows only the addition and never a removal, which is exactly why nothing flagged it.

That failure mode is not specific to this chart: any of the 18 sections here can be dropped the same way, and the loss stays invisible until someone tries to release that chart. Worth considering a CI guard that asserts every `charts/*` directory has a matching README section — happy to open that separately if the team wants it.

## Verification

| Check | Result |
|---|---|
| The exact failing command | exits 0, finds the section at line 240 and the table at 246-249, rewrites the Chart Version cell |
| `notifications` | exits 0 |
| `br-sisbajud` | exits 0 |
| `go-boilerplate-ddd` | exits 0 |
| `lender` | exits 0 |

Adding a section regresses no other chart. The row carries `1.0.0-beta.4` — the currently published version — so the next release bumps from the real baseline rather than inventing one.

The `Could not find app.image.tag in values.yaml` warning is expected and non-fatal: this chart keys its image under `streamingHub.image.tag`. It was present in the original section too.

## Why this is time-sensitive

Context from outside this repo: `stg-mt/streaming-hub` in `lerian-internal-gitops` currently renders the **alpha** package cut from #1769, because `rolesAnywhere.enabled: true` there and no released chart carries that feature — the stable `1.0.0-beta.4` predates it (verified by `helm pull` + grep). `helm-alpha-cleanup` deletes alpha tags older than 3 days, so that build disappears around **2026-08-03 03:00 UTC**, after which `argocd-vault-plugin` cannot pull the chart and the whole `stg-mt` render fails — deploying nothing.

#1769 merged to unblock exactly this, and the release then died on the README. Merging here lets `1.0.0-beta.5` actually publish.

https://claude.ai/code/session_01AQHofhVKKGUbSo959SEn5r