### PR TITLE
fix(charts): streaming-hub values header still claimed fsGroup replaces the pod security context

### DIFF
--- a/charts/streaming-hub/values.yaml
+++ b/charts/streaming-hub/values.yaml
@@ -445,8 +445,10 @@ streamingHub:
 # kubernetes.io/tls (keys tls.crt / tls.key) named by certificateSecretName —
 # in the Lerian environments a cert-manager Certificate in the deploying overlay
 # creates it. fsGroup 65532 is applied to the pod so the sidecar's non-root user
-# can read the 0440 projection; that REPLACES streamingHub.podSecurityContext
-# while rolesAnywhere is enabled.
+# can read the 0440 projection; it is MERGED into streamingHub.podSecurityContext
+# while rolesAnywhere is enabled — fsGroup wins, and every other pod-level setting
+# you configured (runAsNonRoot, seccompProfile, supplementalGroups, ...) survives.
+# It used to replace the block wholesale, silently dropping all of them.
 #
 # trustAnchorArn / profileArn / roleArn are `required` when enabled — the chart
 # fails to render rather than starting a sidecar that cannot authenticate.


### PR DESCRIPTION
## What

The `aws.rolesAnywhere` header in `values.yaml` still says `fsGroup` **REPLACES** `streamingHub.podSecurityContext`. #1769 changed that to a merge and updated the comment inside `_deployment.tpl`, but not this one — and `values.yaml` is the file operators read *before* turning the feature on, so the stale half is the one that misleads.

Now it describes what the template does: `fsGroup` is merged in and wins, every other pod-level setting survives, and the old replace behaviour is named as past so anyone who remembers it knows it changed.

## Verification

Render, not reading — with `rolesAnywhere` on and a custom `podSecurityContext`:

```yaml
securityContext:
  fsGroup: 65532
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
  supplementalGroups:
  - 4242
```

`helm lint` clean.

## It also unblocks the release, and that is deliberate

Stating it plainly rather than letting it look incidental.

#1799 restored this chart's README section, which is what makes the release script succeed — without it, `update-chart-version-readme-bin` exits 1 and the whole release job dies after semantic-release has already computed the version. But **the Helm Release workflow has `README.md` in `paths-ignore`**, so #1799 could not trigger a release itself. There is no `workflow_dispatch` on that workflow, and re-running the original failed run would check out the tree that lacks the section.

A change inside `charts/streaming-hub/` is the only trigger available. Rather than an empty commit, this is the one real inconsistency still left in the chart — created by #1769 and missed by me when I fixed its sibling.

Merging this should publish `1.0.0-beta.5` on the normal OCI path, which `stg-mt/streaming-hub` in `lerian-internal-gitops` needs before its alpha package is deleted by `helm-alpha-cleanup` around **2026-08-03 03:00 UTC** — after which that environment's render fails and nothing deploys there.

https://claude.ai/code/session_01AQHofhVKKGUbSo959SEn5r