### PR TITLE
chore(common): migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/helm-chart-standard.yml
+++ b/.github/workflows/helm-chart-standard.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   validate:
     name: Validate Helm chart standard
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/pr-sizing.yml
+++ b/.github/workflows/pr-sizing.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
       statuses: write
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   notify:
     name: Send Slack Notification
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   get-changed-paths:
     if: github.actor != 'lerian-studio-midaz-push-bot[bot]'
     name: Get Changed Paths
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
@@ -43,7 +43,7 @@ jobs:
     needs: get-changed-paths
     name: Release Helm Chart
     if: needs.get-changed-paths.outputs.matrix != '[]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       max-parallel: 1
       fail-fast: false
@@ -252,7 +252,7 @@ jobs:
       - release-helm-chart
     name: 🔀 Back Merge to Develop
     if: needs.get-changed-paths.outputs.matrix != '[]' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
Migrates this repository's GitHub Actions jobs from GitHub-hosted runners to Blacksmith runners, as part of the org-wide migration. Every hardcoded `ubuntu-*` label (both `runs-on:` and `runner_type:` inputs passed to shared workflows) now points to Blacksmith:

```yaml
runs-on: blacksmith-4vcpu-ubuntu-2404
```

Jobs pinned to `ubuntu-22.04` map to `blacksmith-4vcpu-ubuntu-2204` to keep the same OS version. Self-hosted labels (`eveo-*`, `self-hosted`) are untouched, and no other workflow logic changed.
