### PR TITLE
fix(pipe): drop chart :latest tagging and main->develop back-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,27 +180,6 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
 
 
-      - name: Install oras
-        if: steps.semantic_changelog.outputs.new_release_published == 'true' && github.ref == 'refs/heads/main'
-        uses: oras-project/setup-oras@v1.2.4
-
-      - name: Tag chart as latest
-        if: steps.semantic_changelog.outputs.new_release_published == 'true' && github.ref == 'refs/heads/main'
-        run: |
-          CHART="${{ matrix.chart.name }}"
-          VERSION="${{ steps.semantic_changelog.outputs.new_release_version }}"
-
-          if [ "$CHART" == "plugin-access-manager" ] || [ "$CHART" == "otel-collector-lerian" ]; then
-            PACKAGE="$CHART"
-          else
-            PACKAGE="${CHART}-helm"
-          fi
-
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u lerianstudio --password-stdin
-          echo "${{ secrets.DOCKER_PASSWORD }}" | oras login registry-1.docker.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-          oras cp "ghcr.io/lerianstudio/${PACKAGE}:${VERSION}" "ghcr.io/lerianstudio/${PACKAGE}:latest"
-          oras cp "registry-1.docker.io/lerianstudio/${PACKAGE}:${VERSION}" "registry-1.docker.io/lerianstudio/${PACKAGE}:latest"
 
       # Library charts (type: library) are consumed by other charts and are not
       # deployable applications, so they must not be registered in the Plugin
@@ -245,81 +224,3 @@ jobs:
       SLACK_BOT_TOKEN_HELM: ${{ secrets.SLACK_BOT_TOKEN_HELM }}
       SLACK_CHANNEL_DEVOPS: ${{ secrets.SLACK_CHANNEL_DEVOPS }}
       SLACK_GROUP_TECH_SUPPORT: ${{ secrets.SLACK_GROUP_TECH_SUPPORT }}
-
-  back-merge:
-    needs:
-      - get-changed-paths
-      - release-helm-chart
-    name: 🔀 Back Merge to Develop
-    if: needs.get-changed-paths.outputs.matrix != '[]' && github.ref == 'refs/heads/main'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-          passphrase: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-          git_committer_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          git_committer_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: Back Merge main into develop
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GIT_AUTHOR_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-        run: |
-          git fetch origin main develop
-
-          # Check if there are differences between main and develop
-          if git diff --quiet origin/main origin/develop; then
-            echo "No differences between main and develop. Skipping back-merge."
-            exit 0
-          fi
-
-          # Checkout develop and merge main directly (no PR)
-          # This way the merge is done by the bot, triggering the actor check
-          git checkout develop
-          git pull origin develop
-
-          # Merge main into develop
-          if git merge origin/main --no-edit -m "chore: back merge main into develop [skip ci]"; then
-            echo "Merge successful, pushing to develop..."
-            git push origin develop
-            echo "Back-merge completed successfully."
-          else
-            echo "Merge conflict detected. Creating PR for manual resolution."
-            git merge --abort
-
-            # Check if a back-merge PR already exists
-            EXISTING_PR=$(gh pr list --base develop --head main --state open --json number --jq '.[0].number')
-
-            if [ -n "$EXISTING_PR" ]; then
-              echo "Back-merge PR #$EXISTING_PR already exists. Skipping PR creation."
-              exit 0
-            fi
-
-            # Create PR for manual conflict resolution
-            gh pr create \
-              --base develop \
-              --head main \
-              --title "chore: back merge main into develop (conflicts)" \
-              --body "## Back Merge"$'\n\n'"This PR merges the latest changes from main back into develop."$'\n\n'"⚠️ **Manual intervention required**: There are merge conflicts that need to be resolved manually."$'\n\n'"### Auto-generated"$'\n'"This PR was automatically created by the release pipeline."
-          fi


### PR DESCRIPTION
## Summary

Workflow cleanup in `release.yml` (hotfix on `main`). Removes two things that are no longer needed:

1. **`:latest` OCI tag** — dropped the `Install oras` + `Tag chart as latest` steps that copied `<pkg>:<version>` → `<pkg>:latest` on ghcr.io and registry-1.docker.io. Charts are consumed by pinned version; `latest` is not used.
2. **main → develop back-merge** — removed the `back-merge` job that merged `main` into `develop` (and opened a back-merge PR on conflict). We're trunk-based; `develop` is retired, so the back-merge is unnecessary.

## Type of Change

- [x] Pipeline / CI

## Details

- `release.yml`: −99 lines. Removed the oras/latest steps from the `release-helm-chart` job and the entire `back-merge` job.
- Untouched: `get-changed-paths`, `release-helm-chart` (chart publish, lifecycle registration), `notify-release`.
- No `oras`, `:latest`, or back-merge references remain; YAML validated.

## Notes

- The release still publishes each chart's versioned tag to ghcr.io + registry-1.docker.io (only the `latest` alias is dropped).
- Out of scope (left as-is): the `develop` entry in the `on: push` trigger, and the `SLACK_CHANNEL_DEVOPS` mapping in `notify-release` (separate concern).
