### PR TITLE
feat(charts): add the correios rail to the br-sfn chart

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -55,6 +55,7 @@ jobs:
             br-sta
             br-ccs
             br-slc
+            br-sfn
             new
             charts
             common

--- a/charts/br-sfn/README.md
+++ b/charts/br-sfn/README.md
@@ -32,6 +32,7 @@ A default render produces only the shared ServiceAccount.
 | SILOC rail | `siloc` | `ghcr.io/lerianstudio/br-siloc` | 9820 | dedicated (`br-siloc-migrations`) |
 | SCR rail | `scr` | `ghcr.io/lerianstudio/br-scr` | 3003 | baked (`/migrations`, table `schema_migrations_scr`) |
 | desk | `desk` | `ghcr.io/lerianstudio/br-desk` | 3002 | baked (`/migrations`) |
+| correios rail | `correios` | `ghcr.io/lerianstudio/plugin-bc-correios` | 8080 | baked (`/migrations`, db key `POSTGRES_NAME`) |
 | slc-edge | `slcEdge` | `ghcr.io/lerianstudio/br-slc-edge` | 3005 | none (stateless) |
 | cockpit SPA | `cockpit` | `ghcr.io/lerianstudio/br-sfn-cockpit` | 8080 | none (static bundle) |
 

--- a/charts/br-sfn/README.md
+++ b/charts/br-sfn/README.md
@@ -2,8 +2,9 @@
 
 Helm chart for **br-sfn** — the Lerian Brazilian SFN rails monorepo: SPB/STR
 (TED), SPI (Pix — four runtime binaries), SILOC (card settlement), SCR (credit
-information), desk (cockpit operator-state + four-eyes), slc-edge (Cabine SLC
-authenticated passthrough) and the cockpit operations SPA.
+information), desk (cockpit operator-state + four-eyes), correios (BC Correio
+regulatory mailbox), slc-edge (Cabine SLC authenticated passthrough) and the
+cockpit operations SPA.
 
 ## Modularity contract
 
@@ -45,9 +46,9 @@ one Redis and one RedPanda.
 PreSync ArgoCD hook Jobs (`hook-weight: -1`), one per rail that owns a schema,
 in two flavors:
 
-- **baked** (spb, scr, desk): an initContainer copies the migrations tree out
-  of the app image; `migrate/migrate` applies it. Postgres passwords must be
-  URL-safe (no `@ : / ? # %`).
+- **baked** (spb, scr, desk, correios): an initContainer copies the migrations
+  tree out of the app image; `migrate/migrate` applies it. Postgres passwords
+  must be URL-safe (no `@ : / ? # %`).
 - **dedicated** (spi, siloc): the rail's own migrator image runs with the
   `POSTGRES_*` env contract. The SPI migrator owns module ordering
   (global → events → spi → dict → brcode → core) and the per-module bookkeeping
@@ -56,8 +57,11 @@ in two flavors:
 
 Connection settings resolve from `<component>.migrations.postgres.*`, falling
 back to the component's `configmap` keys (`POSTGRES_HOST`, `POSTGRES_PORT`,
-`POSTGRES_USER`, `POSTGRES_DB`, `POSTGRES_SSLMODE`). Host, user and database
-are required — the render fails loud when missing.
+`POSTGRES_USER`, `POSTGRES_DB`, `POSTGRES_SSLMODE`). correios is the one
+exception: its service reads the database name from `POSTGRES_NAME`, so its
+migration Job falls back to `correios.configmap.POSTGRES_NAME` instead of
+`POSTGRES_DB`. Host, user and database are required — the render fails loud
+when missing.
 
 ## Configuration model
 
@@ -85,8 +89,8 @@ pins an environment-specific image build.
 - Chart type: `multi-component`
 - Required secrets: None for default render (all components disabled). Per
   enabled rail: `POSTGRES_PASSWORD` in `<component>.secrets` (or an
-  `existingSecretName` Secret) for spb/spi/siloc/scr/desk; slc-edge and
-  cockpit need none.
+  `existingSecretName` Secret) for spb/spi/siloc/scr/desk/correios; slc-edge
+  and cockpit need none.
 - Dependency notes: no subcharts — Postgres/Valkey/RabbitMQ/RedPanda/IBM MQ
   are external services by contract.
 - Production overrides: `<component>.enabled`, `<component>.image.tag`

--- a/charts/br-sfn/templates/_helpers.tpl
+++ b/charts/br-sfn/templates/_helpers.tpl
@@ -459,7 +459,8 @@ hook-weight -1 puts the Job after any PreSync Secret and before the main-sync
 Deployments, so no rail boots unmigrated.
 
 Input dict: root, name (component), comp, shared, sharedCfg, flavor
-("baked"|"dedicated").
+("baked"|"dedicated"), dbCfgKey (optional — the ConfigMap key holding the
+database name; defaults to POSTGRES_DB, correios reads POSTGRES_NAME).
 */}}
 {{- define "br-sfn.componentMigrationJob" -}}
 {{- $mig := .comp.migrations | default dict -}}
@@ -479,9 +480,10 @@ Input dict: root, name (component), comp, shared, sharedCfg, flavor
 {{- if not $pgUser -}}
 {{- fail (printf "br-sfn: %s migrations need a Postgres user — set %s.migrations.postgres.user or %s.configmap.POSTGRES_USER" .name .name .name) -}}
 {{- end -}}
-{{- $pgDb := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "database" "cfg" $cfg "cfgKey" "POSTGRES_DB" "fallback" "") -}}
+{{- $dbCfgKey := .dbCfgKey | default "POSTGRES_DB" -}}
+{{- $pgDb := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "database" "cfg" $cfg "cfgKey" $dbCfgKey "fallback" "") -}}
 {{- if not $pgDb -}}
-{{- fail (printf "br-sfn: %s migrations need a Postgres database — set %s.migrations.postgres.database or %s.configmap.POSTGRES_DB" .name .name .name) -}}
+{{- fail (printf "br-sfn: %s migrations need a Postgres database — set %s.migrations.postgres.database or %s.configmap.%s" .name .name .name $dbCfgKey) -}}
 {{- end -}}
 {{- $pgSsl := include "br-sfn.migrationPgValue" (dict "mig" $mig "key" "sslMode" "cfg" $cfg "cfgKey" "POSTGRES_SSLMODE" "fallback" "disable") -}}
 {{- $pwSecret := ($mig.passwordSecret | default dict) -}}

--- a/charts/br-sfn/templates/correios/configmap.yaml
+++ b/charts/br-sfn/templates/correios/configmap.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.correios.enabled -}}
+{{ include "br-sfn.componentConfigmap" (dict "root" $ "name" "correios" "comp" $.Values.correios) }}
+{{- end -}}

--- a/charts/br-sfn/templates/correios/deployment.yaml
+++ b/charts/br-sfn/templates/correios/deployment.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.correios.enabled -}}
+{{ include "br-sfn.componentDeployment" (dict "root" $ "name" "correios" "comp" $.Values.correios "defaultPort" 8080 "livenessPath" "/health" "readyPath" "/readyz") }}
+{{- end -}}

--- a/charts/br-sfn/templates/correios/hpa.yaml
+++ b/charts/br-sfn/templates/correios/hpa.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.correios.enabled -}}
+{{ include "br-sfn.componentHpa" (dict "root" $ "name" "correios" "comp" $.Values.correios) }}
+{{- end -}}

--- a/charts/br-sfn/templates/correios/ingress.yaml
+++ b/charts/br-sfn/templates/correios/ingress.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.correios.enabled -}}
+{{ include "br-sfn.componentIngress" (dict "root" $ "name" "correios" "comp" $.Values.correios "defaultPort" 8080) }}
+{{- end -}}

--- a/charts/br-sfn/templates/correios/migrations-job.yaml
+++ b/charts/br-sfn/templates/correios/migrations-job.yaml
@@ -1,0 +1,4 @@
+{{- if $.Values.correios.enabled -}}
+{{/* dbCfgKey: the correios config reads POSTGRES_NAME, not POSTGRES_DB. */}}
+{{ include "br-sfn.componentMigrationJob" (dict "root" $ "name" "correios" "comp" $.Values.correios "flavor" "baked" "dbCfgKey" "POSTGRES_NAME") }}
+{{- end -}}

--- a/charts/br-sfn/templates/correios/pdb.yaml
+++ b/charts/br-sfn/templates/correios/pdb.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.correios.enabled -}}
+{{ include "br-sfn.componentPdb" (dict "root" $ "name" "correios" "comp" $.Values.correios) }}
+{{- end -}}

--- a/charts/br-sfn/templates/correios/secrets.yaml
+++ b/charts/br-sfn/templates/correios/secrets.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.correios.enabled -}}
+{{ include "br-sfn.componentSecrets" (dict "root" $ "name" "correios" "comp" $.Values.correios) }}
+{{- end -}}

--- a/charts/br-sfn/templates/correios/service.yaml
+++ b/charts/br-sfn/templates/correios/service.yaml
@@ -1,0 +1,3 @@
+{{- if $.Values.correios.enabled -}}
+{{ include "br-sfn.componentService" (dict "root" $ "name" "correios" "comp" $.Values.correios "defaultPort" 8080) }}
+{{- end -}}

--- a/charts/br-sfn/values-template.yaml
+++ b/charts/br-sfn/values-template.yaml
@@ -64,6 +64,21 @@
 #   secrets:
 #     POSTGRES_PASSWORD: ""
 
+# correios:
+#   enabled: true
+#   configmap:
+#     POSTGRES_HOST: ""
+#     POSTGRES_PORT: "5432"
+#     POSTGRES_USER: ""
+#     POSTGRES_NAME: ""      # NOT POSTGRES_DB — this rail reads POSTGRES_NAME
+#     CACHE_ADDR: ""         # valkey/redis host:port
+#     OBJECT_STORAGE_ENDPOINT: ""
+#     OBJECT_STORAGE_BUCKET: ""
+#   secrets:
+#     POSTGRES_PASSWORD: ""  # required when correios.enabled (URL-safe)
+#     ENCRYPTION_KEY: ""     # AES-256, 32 bytes
+#     RABBITMQ_URL: ""
+
 # slcEdge:
 #   enabled: true
 #   configmap:

--- a/charts/br-sfn/values.schema.json
+++ b/charts/br-sfn/values.schema.json
@@ -97,6 +97,18 @@
       },
       "additionalProperties": true
     },
+    "correios": {
+      "type": "object",
+      "properties": {
+        "configmap": {
+          "type": "object"
+        },
+        "secrets": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
     "slcEdge": {
       "type": "object",
       "properties": {

--- a/charts/br-sfn/values.yaml
+++ b/charts/br-sfn/values.yaml
@@ -587,6 +587,90 @@ desk:
     resources: {}
 
 # =============================================================================
+# correios — BC Correio regulatory mailbox (BCB SOAP polling, attachment
+# storage, search, audit trail and transmission). Postgres + Valkey/Redis cache
+# + RabbitMQ + S3-compatible object storage, all external.
+#
+# The image name stays `plugin-bc-correios`: it predates the monorepo move and
+# renaming it would have to land in three repos at once. The rail's values key,
+# resources and env contract are br-sfn's.
+#
+# Migrations are baked at /migrations and applied out-of-process — the app
+# binary never drives them (see deploy/docker/correios.Dockerfile). The rail
+# reads POSTGRES_NAME (not POSTGRES_DB), which is why its Job passes
+# dbCfgKey=POSTGRES_NAME.
+# =============================================================================
+correios:
+  enabled: false
+  replicaCount: 1
+  revisionHistoryLimit: 10
+  image:
+    repository: ghcr.io/lerianstudio/plugin-bc-correios
+    tag: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podAnnotations: {}
+  deploymentUpdate:
+    type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+  service:
+    type: ClusterIP
+    # Matches the Dockerfile EXPOSE 8080 (config.ServerPort default).
+    port: 8080
+  configmap: {}
+  secrets: {}
+  useExistingSecret: false
+  existingSecretName: ""
+  extraEnvVars: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  livenessProbe: {}
+  readinessProbe: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  migrations:
+    enabled: true
+    sourcePath: /migrations
+    table: ""
+    postgres:
+      host: ""
+      port: ""
+      user: ""
+      # Falls back to configmap.POSTGRES_NAME, the key this rail reads.
+      database: ""
+      sslMode: ""
+    passwordSecret:
+      name: ""
+      key: POSTGRES_PASSWORD
+    imagePullSecrets: []
+    backoffLimit: 3
+    activeDeadlineSeconds: 600
+    ttlSecondsAfterFinished: 600
+    resources: {}
+
+# =============================================================================
 # slcEdge — Cabine SLC authenticated passthrough edge (br-slc-edge). Stateless:
 # no datastore, no migrations. Renders as "slc-edge" resources.
 # =============================================================================


### PR DESCRIPTION
Moves the BC Correio regulatory mailbox into the consolidated `br-sfn` chart, so the monorepo's eighth service stops needing its own chart. Values key `correios`, resources render as `br-sfn-correios-*`, migrations as a PreSync Job — identical shape to `spb`/`desk`.

## Why this is a correction, not just consolidation

The standalone `plugin-bc-correios` chart has drifted from the service now that it is built from `br-sfn`:

| | standalone chart | service (br-sfn) |
|---|---|---|
| ConfigMap | fixed allowlist of 40 keys | emitted verbatim |
| emits but unread | `APP_ENV`, `ALLOW_INSECURE_TLS`, `RABBITMQ_USER`, `RABBITMQ_HOST`, `PLUGIN_AUTH_HOST`, `BC_CORREIO_RATE_LIMIT_*` | — |
| reads but unsettable | — | `ENV_NAME`, `DEPLOYMENT_MODE`, `BC_CORREIO_ENDPOINT_URL`, `CACHE_DB`/`_TLS`/`_CA_CERT`, `ORGANIZATION_IDS`, `METRICS_PROMETHEUS_*` |
| probes | `/health/live`, `/health/ready` on 9090 | `/health`, `/readyz` on 8080 |

The allowlist is the same class of trap that silently dropped env vars in `plugin-fees` 6→7: a key set off the list disappears with no warning.

## What changed

- `templates/correios/*` — eight one-line includes over the existing component helpers
- `values.yaml` — `correios` block, default `enabled: false`, port 8080
- `_helpers.tpl` — `componentMigrationJob` gains an optional `dbCfgKey` (this rail reads `POSTGRES_NAME`, not `POSTGRES_DB`); default unchanged, so every other rail renders byte-identically
- `values.schema.json`, `values-template.yaml`, `README.md`

Migrations use the **baked** flavor at `/migrations` — what `deploy/docker/correios.Dockerfile` documents: *"the binary never drives them; the directory is baked so a migrate sidecar can mount it."*

The image name stays `plugin-bc-correios`; renaming it would have to land in three repos at once.

## Verified

- `helm lint` clean
- `correios.enabled=true` renders 10 objects (ConfigMap, Secret, Service, Deployment, Ingress, HPA, PDB, migration Job + its PreSync Secret, ServiceAccount)
- migration Job resolves the database from `POSTGRES_NAME`
- `spb` render unchanged (7 objects), confirming the helper change is additive

## Not in this PR — the ordering is forced

`charts/plugin-bc-correios` **cannot be deleted yet**. Its only consumer is `lerian-internal-gitops` → `environments/benedita/helmfile/applications/dev-st/plugin-bc-correios`, pinned at `2.2.0`. That environment has to move to `br-sfn` first. It runs every bundled subchart and `global.externalPostgresDefinitions` disabled, so nothing it actually uses is lost in the move.

`br-sfn/.github/workflows/release-correios.yml` also still points `helm_chart` at `plugin-bc-correios`; that follows this merge.

https://claude.ai/code/session_01ABpSaU8BhcJ514v8AW8y9n