### PR TITLE
feat(plugin-br-pix-indirect-btg): add WEBHOOK_REPORT_TEMPOSTRANSACOES configuration keys

### DIFF
--- a/charts/plugin-br-pix-indirect-btg/templates/outbound/configmap.yaml
+++ b/charts/plugin-br-pix-indirect-btg/templates/outbound/configmap.yaml
@@ -313,6 +313,21 @@ data:
   WEBHOOK_SCHEDULE_CASHOUT_BACKOFF_MULTIPLIER: {{ .Values.outbound.configmap.WEBHOOK_SCHEDULE_CASHOUT_BACKOFF_MULTIPLIER | default "2" | quote }}
   WEBHOOK_SCHEDULE_CASHOUT_MAX_CONCURRENT: {{ .Values.outbound.configmap.WEBHOOK_SCHEDULE_CASHOUT_MAX_CONCURRENT | default "2" | quote }}
 
+  # ==============================================================================
+  # REPORT_TEMPOSTRANSACOES - APIX TemposTransacoes report-job completion delivery
+  # ==============================================================================
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_ENABLED: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_ENABLED | default "true" | quote }}
+  # WARNING: Webhook URL must be explicitly set in values.yaml or values-<env>.yaml
+  # Leaving empty disables external webhook delivery for safety
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_URL: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_URL | default "" | quote }}
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_WORKER_COUNT: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_WORKER_COUNT | default "1" | quote }}
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_BATCH_SIZE: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_BATCH_SIZE | default "50" | quote }}
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_POLLING_INTERVAL: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_POLLING_INTERVAL | default "1s" | quote }}
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_REQUEST_TIMEOUT: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_REQUEST_TIMEOUT | default "5s" | quote }}
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_MAX_RETRIES: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_MAX_RETRIES | default "10" | quote }}
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_BACKOFF_MULTIPLIER: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_BACKOFF_MULTIPLIER | default "2" | quote }}
+  WEBHOOK_REPORT_TEMPOSTRANSACOES_MAX_CONCURRENT: {{ .Values.outbound.configmap.WEBHOOK_REPORT_TEMPOSTRANSACOES_MAX_CONCURRENT | default "2" | quote }}
+
   # Security Tier Configuration (lib-commons v4.4.0)
   SECURITY_TIER: {{ .Values.outbound.configmap.SECURITY_TIER | default "" | quote }}
   SECURITY_ENFORCEMENT: {{ .Values.outbound.configmap.SECURITY_ENFORCEMENT | default "false" | quote }}

--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -511,6 +511,7 @@ outbound:
     WEBHOOK_DICT_RECONCILIATION_JOB_URL: ""
     WEBHOOK_DICT_FUNDS_RECOVERY_URL: ""
     WEBHOOK_DICT_FUNDS_RECOVERY_EVENTS_URL: ""
+    WEBHOOK_REPORT_TEMPOSTRANSACOES_URL: ""
   # -- Secrets for storing sensitive data
   # -- All secrets are declared in the templates/secrets.yaml
   # @default -- templates/secrets.yaml


### PR DESCRIPTION
## Summary
- Adds the `WEBHOOK_REPORT_TEMPOSTRANSACOES_*` block to the outbound worker's configmap (`charts/plugin-br-pix-indirect-btg/templates/outbound/configmap.yaml`), mirroring `WEBHOOK_DICT_INFRACTION_REPORT_*`'s shape.
- Adds `WEBHOOK_REPORT_TEMPOSTRANSACOES_URL: ""` to `values.yaml`, matching the existing per-flow URL placeholder convention.

Backing app change: `plugin-br-pix-indirect-btg` PR (branch `feat/apix-statistics`) added a completion webhook (`FlowType=REPORT`/`EntityType=TEMPOSTRANSACOES`) for the APIX TemposTransacoes report-job pipeline, delivered by the existing outbound worker — this chart change is required so the new env block is deployable, not hardcoded only in the app repo's `.env.example`.

## Test plan
- [ ] `helm lint charts/plugin-br-pix-indirect-btg` (not run locally — no `helm` binary available in this session; verified template `{{ }}` brace balance and `values.yaml` YAML validity instead)
- [ ] `helm template charts/plugin-br-pix-indirect-btg` renders the new configmap keys with defaults
- [ ] Confirm with a real deploy that the outbound worker logs the new `REPORT_TEMPOSTRANSACOES` binding at boot