### PR TITLE
fix(plugin-br-pix-indirect-btg): update plugin-br-pix-indirect-btg@1.9.1

### DIFF
--- a/charts/plugin-br-pix-indirect-btg/Chart.yaml
+++ b/charts/plugin-br-pix-indirect-btg/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # to the chart and its templates, including the app version.
 version: 3.7.0
 # This is the version number of the application being deployed.
-appVersion: "1.9.0"
+appVersion: "1.9.1"
 # A list of keywords about the chart. This helps others discover the chart.
 keywords:
   - midaz

--- a/charts/plugin-br-pix-indirect-btg/values.yaml
+++ b/charts/plugin-br-pix-indirect-btg/values.yaml
@@ -86,7 +86,7 @@ pix:
     # -- Image pull policy
     pullPolicy: Always
     # -- Image tag used for deployment
-    tag: "1.9.0"
+    tag: "1.9.1"
   # -- Secrets for pulling images from a private registry
   imagePullSecrets: []
   # -- Overrides the default generated name by Helm


### PR DESCRIPTION
## Summary
- Bumps `plugin-br-pix-indirect-btg` chart `appVersion` and `pix` component image tag to `1.9.1`.
- inbound/outbound/reconciliation/schedule stay at `1.9.0` — the v1.9.1 CI release run only rebuilt/published the `pix` image (monorepo path-filter); no `1.9.1` image exists for the other four components.

Mirrors the automated bump in the equivalent `develop` PR (#1846), scoped to the current `main`.

## Test plan
- [ ] `helm lint charts/plugin-br-pix-indirect-btg`
- [ ] `helm template charts/plugin-br-pix-indirect-btg` renders pix at 1.9.1, workers at 1.9.0