### PR TITLE
feat(otel-collector-lerian): valida client.id contra padrão canônico (minúsculo + -stg/-hml/-prd)

### DIFF
--- a/charts/otel-collector-lerian/values.schema.json
+++ b/charts/otel-collector-lerian/values.schema.json
@@ -5,7 +5,55 @@
   "properties": {
     "opentelemetry-collector": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "processors": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "resource/add_client_id": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "attributes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                          "key": { "type": "string" },
+                          "value": { "type": "string" }
+                        },
+                        "allOf": [
+                          {
+                            "$comment": "Se este item for o client.id, o value DEVE seguir o padrao canonico: nome tudo-minusculo + sufixo -stg/-hml/-prd, OU um dos 3 ambientes internos Lerian (aws-production/aws-staging/aws-devops). Bloqueia maiusculas e sufixos nao-canonicos (Dev/development/staging/production por extenso). Validado no helm install/upgrade/template/lint.",
+                            "if": {
+                              "properties": { "key": { "const": "client.id" } },
+                              "required": ["key"]
+                            },
+                            "then": {
+                              "properties": {
+                                "value": {
+                                  "type": "string",
+                                  "pattern": "^(aws-production|aws-staging|aws-devops|[a-z0-9]+-(stg|hml|prd))$"
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "global": {
       "type": "object",


### PR DESCRIPTION
## Objetivo

Padronizar o `client.id` que o cliente informa no **collector-client** (chart `otel-collector-lerian`), impondo um formato canônico via **validação de schema** (`values.schema.json`). O `client.id` vira o label `client_id` multi-tenant — hoje ele está inconsistente (maiúsculas, sufixos `Dev`/`prd`/`production` misturados), o que quebra regras de custo, roteamento de alerta e filtros no Grafana Cloud.

## Regra

```
pattern: ^(aws-production|aws-staging|aws-devops|[a-z0-9]+-(stg|hml|prd))$
```

- **Nome (prefixo): tudo minúsculo** — `[a-z0-9]+`
- **Sufixo canônico**: `-stg` | `-hml` | `-prd`
- **Exceção**: os 3 ambientes internos Lerian — `aws-production`, `aws-staging`, `aws-devops`

## O que passa / o que bloqueia

| ✅ passa | 🔴 bloqueia | motivo |
|---|---|---|
| `cappta-prd`, `voluti-prd`, `cappta-hml`, `cliente-stg` | `Cappta-Prd` | maiúscula |
| `aws-production`, `aws-staging`, `aws-devops` | `SRM-Dev`, `banqi-Dev` | sufixo `dev` não é canônico |
| | `cliente-production`, `cliente-dev` | sufixo por extenso |
| | `Cliente-Prd`, `cappta_prd` | maiúscula / separador inválido |

## Onde e como valida

O `client.id` mora em `opentelemetry-collector.config.processors.resource/add_client_id.attributes[].value`. O schema usa `if/then` sobre o item cujo `key == "client.id"`, aplicando o `pattern` só ao `value` dele. A validação roda em `helm install/upgrade/template/lint` e **falha** com mensagem apontando o campo e o pattern:

```
at '/opentelemetry-collector/config/processors/resource~1add_client_id/attributes/0/value':
'Cappta-Prd' does not match pattern '^(aws-production|aws-staging|aws-devops|[a-z0-9]+-(stg|hml|prd))$'
```

## Impacto (intencional)

Clientes **já instalados seguem rodando** — a validação só morde no **próximo upgrade** para esta versão do chart. Nesse momento, o `client.id` de cada cliente é ajustado ao padrão (ex.: `Cappta-Prd`→`cappta-prd`). É a janela natural pra padronizar.

## Validação

`helm template` (v3.19), **15 casos**: 7 válidos passam, 8 inválidos bloqueiam. Detecção por **exit code** (fonte de verdade). Só o `values.schema.json` muda — sem tocar em templates/values/Chart.yaml (version fica pra pipeline de release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
