### PR TITLE
feat(plugin-access-manager): expose PLATFORM_INTERNAL_CIDRS on identity

### DIFF
--- a/charts/plugin-access-manager/templates/identity/configmap.yaml
+++ b/charts/plugin-access-manager/templates/identity/configmap.yaml
@@ -106,6 +106,7 @@ data:
   # RUNTIME
   DEPLOYMENT_MODE: {{ .Values.identity.configmap.DEPLOYMENT_MODE | default "local" | quote }}
   TRUSTED_PROXIES: {{ .Values.identity.configmap.TRUSTED_PROXIES | default "" | quote }}
+  PLATFORM_INTERNAL_CIDRS: {{ .Values.identity.configmap.PLATFORM_INTERNAL_CIDRS | default "" | quote }}
 
   # M2M (lib-auth/v3 middleware — identity authorizes inbound M2M calls)
   AUTH_M2M_INVERSION_ENABLED: {{ .Values.identity.configmap.AUTH_M2M_INVERSION_ENABLED | default "false" | quote }}


### PR DESCRIPTION
One template line: the identity configmap gains `PLATFORM_INTERNAL_CIDRS` (empty default), same shape as `TRUSTED_PROXIES` one line above.

## Why

Casdoor natively enforces `Organization.IpWhitelist` against the **caller's** IP on five of its endpoints (login, signup, SetPassword, auth callback, GetApplication). The tenant-manager calls Casdoor server-to-server, so the moment a customer activates their IP allowlist, every admin operation on that tenant — password resets included — gets rejected. Reproduced live on Benedita.

The fix (plugin-access-manager, in flight) has identity transparently co-store the platform's internal CIDR ranges in the same field: Casdoor's check passes for in-cluster callers, while the ranges stay invisible to the customer (subtracted on read via org tags) and inert in our own enforcement. This variable is where those ranges are configured, per environment:

- Benedita: `10.123.0.0/16,10.42.0.0/16`
- AWS staging: `10.45.0.0/16`

Empty/unset = dormant, today's behavior byte-for-byte. Only identity consumes it — the auth component subtracts platform entries via org tags and needs no env.

## Found while verifying the delivery chain

The **published** charts `8.2.0` (Benedita's pin) and `6.1.1` (AWS's pin) render **neither `TRUSTED_PROXIES` nor anything newer** — pulled both from the OCI registry and grepped the actual artifacts. The gitops values set `TRUSTED_PROXIES` on both environments, but on those chart versions the key is silently dropped, so it has never reached the pods; the login-path allowlist enforcement has been sitting dormant (fail-open) on Benedita because of it. `main` already fixed `TRUSTED_PROXIES` in b49b644b — so the version bump that ships this key also switches that one on. The gitops pin bumps will follow this release.