### PR TITLE
ci(charts): allow alloy-lerian scope and out-of-band secret

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -45,6 +45,7 @@ jobs:
             templates
             dependencies
             otel-collector
+            alloy-lerian
             plugins
             pipe
             doc

--- a/docs/helm-chart-standard.md
+++ b/docs/helm-chart-standard.md
@@ -393,6 +393,7 @@ The render gate runs `helm dependency build` + `helm template` per chart and ass
 A documented allowlist exempts Secrets that are intentionally provisioned out of band (each entry must carry a justification):
 
 - `otel-api-key` — operator-provisioned before install (`otel-collector-lerian`).
+- `alloy-api-key` — operator-provisioned before install (`alloy-lerian`); the credential lives in the origin cluster Secret and the chart only references it.
 - `kedaorg-certs` — self-managed at runtime by the KEDA operator's cert rotation (`reporter`).
 
 Charts with required production values use dummy CI-only fixtures under `.github/configs/helm-render-values/<chart>.yaml`. These files are not production examples and must not contain real credentials.


### PR DESCRIPTION
## What

Two one-line additions that unblock creating the `alloy-lerian` chart. **No chart files are touched.**

| File | Change |
|---|---|
| `.github/workflows/pr-title.yml` | Adds `alloy-lerian` to the closed scope allowlist |
| `docs/helm-chart-standard.md` | Registers `alloy-api-key` in the out-of-band secret allowlist |

## Why

Both are repository gates that would reject the new chart before it exists:

1. **PR title validation is a closed allowlist** with `requireScope: true`. Without the scope, every pull request for this chart — including the one that creates it — fails title validation.

2. **The render gate rejects references to Secrets not rendered in the same release.** The chart references `alloy-api-key`, which is provisioned in the origin cluster Secret before install: the chart only reads it, never creates it. This is the same pattern already documented for `otel-api-key`.

## Verification

- `go run ./validate-helm-charts --root ../.. --strict` → **0 violations, 0 baseline entries**
- Workflow file parses as valid YAML; 29 scopes, `requireScope` still `true`
- Title validation simulated: `feat(alloy-lerian): …` accepted, `feat(alloy): …` rejected, existing scopes unaffected

## Scope

This PR does **not** create the chart and does **not** modify `otel-collector-lerian`, which stays in production untouched throughout the migration.

Part of the collector-client migration to Grafana Alloy (phase 1 of 2).
