### PR TITLE
feat(alloy-lerian): add telemetry collection chart for client clusters

### DIFF
--- a/.github/configs/helm-render-values/alloy-lerian.yaml
+++ b/.github/configs/helm-render-values/alloy-lerian.yaml
@@ -1,0 +1,14 @@
+# CI-only fixture. Not a production example; must not contain real credentials.
+#
+# Exists because `profile`, `origin.id` and `destination.endpoint` are required
+# with no default, so the chart cannot render without them. The chart it replaces
+# had no fixture, which is why the render gate never exercised it — and why it
+# shipped unable to render with its own values.
+#
+# Exercises the `client` profile: the stricter of the two (credential required,
+# node infrastructure excluded, inspection parameter absent).
+profile: client
+origin:
+  id: sample-prd
+destination:
+  endpoint: https://telemetry.invalid/v1

--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -1288,6 +1288,11 @@ var allowedDanglingSecrets = map[string]bool{
 	// its README instructs `kubectl create secret generic otel-api-key` before
 	// install, so the chart intentionally never renders it.
 	"otel-api-key": true,
+	// alloy-lerian references an operator-provisioned API-key Secret. The
+	// credential lives in the origin cluster Secret, created by the onboarding
+	// process before install; the chart only reads it via secretKeyRef and
+	// intentionally never renders it.
+	"alloy-api-key": true,
 	// reporter bundles the KEDA subchart, whose operator self-manages this TLS
 	// cert Secret at runtime via --enable-cert-rotation/--cert-secret-name. KEDA
 	// creates it; no Helm chart renders it.

--- a/.github/workflows/sanitizacao.yml
+++ b/.github/workflows/sanitizacao.yml
@@ -1,0 +1,61 @@
+# MODELO de fluxo de CI para a porta de sanitizacao.
+#
+# Installed: the chart now exists.
+#
+# Por que um fluxo dedicado, e nao um passo no fluxo de padrao de chart:
+# a verificacao executa um contêiner e leva ~30s por rodada. Manter separado
+# permite que falhe de forma legivel, sem se misturar aos demais checks.
+
+name: Sanitizacao de dado regulado
+
+on:
+  pull_request:
+    paths:
+      - 'charts/alloy-lerian/sanitizacao/**'
+      - 'charts/alloy-lerian/templates/**'
+      - '.github/workflows/sanitizacao.yml'
+  # Execucao semanal: o motor de regex e o agente sao pinados, mas a rodada
+  # periodica detecta se algo no ambiente de execucao mudou.
+  schedule:
+    - cron: '23 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  porta-de-sanitizacao:
+    name: Porta de sanitizacao (bloqueante)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Obter o codigo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # A versao do agente e pinada de proposito. Atualizar exige reverificar
+      # as assercoes — o comportamento de regex e de funcao pode mudar entre
+      # versoes, e a falha seria silenciosa em producao.
+      - name: Obter a imagem do agente
+        run: docker pull grafana/alloy:v1.18.1
+
+      - name: Executar a porta
+        run: ./charts/alloy-lerian/sanitizacao/porta-de-entrega.sh
+
+      # Anexa o resultado ao resumo da execucao, para que quem revisa veja
+      # sem abrir o log.
+      - name: Registrar o resultado
+        if: always()
+        run: |
+          {
+            echo "## Porta de sanitizacao"
+            echo ""
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "Liberado — todas as regras de sanitizacao verificadas."
+            else
+              echo "**BLOQUEADO.** Regra de sanitizacao malformada nao gera erro"
+              echo "em producao: produz saida que aparenta estar mascarada."
+              echo "Ver o log do passo anterior."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/charts/alloy-lerian/Chart.lock
+++ b/charts/alloy-lerian/Chart.lock
@@ -2,8 +2,11 @@ dependencies:
 - name: alloy
   repository: https://grafana.github.io/helm-charts
   version: 1.11.1
+- name: alloy
+  repository: https://grafana.github.io/helm-charts
+  version: 1.11.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 8.2.0
-digest: sha256:d8890f1e72d13ff758e1079e647913f3a71f4bbb2ecf65add69c7c48edef97aa
-generated: "2026-08-09T02:06:19.545291395-03:00"
+digest: sha256:f7bffcacd7458d19fe7cf5e98cdd693c0e6b3fc908fed107d28f1a5d732a3dcb
+generated: "2026-08-09T03:50:44.838343787-03:00"

--- a/charts/alloy-lerian/Chart.lock
+++ b/charts/alloy-lerian/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: alloy
+  repository: https://grafana.github.io/helm-charts
+  version: 1.11.1
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 8.2.0
+digest: sha256:d8890f1e72d13ff758e1079e647913f3a71f4bbb2ecf65add69c7c48edef97aa
+generated: "2026-08-09T02:06:19.545291395-03:00"

--- a/charts/alloy-lerian/Chart.yaml
+++ b/charts/alloy-lerian/Chart.yaml
@@ -1,0 +1,62 @@
+apiVersion: v2
+name: alloy-lerian-helm
+description: >-
+  Lerian telemetry collection agent for client clusters. Wraps the upstream
+  Grafana Alloy chart and renders the collection pipeline from semantic
+  parameters instead of exposing the processing chain. Roles are segregated by
+  observation scope — a per-node agent receives application telemetry, and a
+  single-replica role observes cluster state — because a cluster-scoped watcher
+  replicated per node produces duplicate writes proportional to cluster size.
+  Regulated-data sanitisation runs at the edge and is not configurable.
+type: application
+
+annotations:
+  lerian.studio/chart-type: dependency-wrapper
+
+home: https://github.com/LerianStudio/helm
+
+sources:
+  - https://github.com/LerianStudio/helm/tree/main/charts/alloy-lerian
+  - https://github.com/grafana/alloy
+
+maintainers:
+  - name: "Lerian Studio"
+    email: "support@lerian.studio"
+
+# Seed version only. semantic-release owns the published OCI package version;
+# never hand-bump this field.
+version: 1.0.0
+
+# Tracks the pinned upstream Alloy binary, not this chart's own release line.
+appVersion: "1.18.1"
+
+keywords:
+  - alloy
+  - observability
+  - telemetry
+  - opentelemetry
+  - lerian
+
+icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
+
+# Refer to the Lerian docs for component documentation:
+# https://docs.lerian.studio/docs/midaz-components
+
+dependencies:
+  # Pinned exactly, no ranges. v1.18.1 is the minimum floor, not a preference:
+  # it exists primarily to backport two transitive-dependency CVE fixes, so
+  # 1.18.0 is vulnerable. Bumping requires re-running the sanitisation gate —
+  # regex and function behaviour can change between versions, and the failure
+  # mode in production is silent.
+  - name: alloy
+    version: "1.11.1"
+    repository: "https://grafana.github.io/helm-charts"
+
+  # Sole source of cluster-object metrics in the Alloy model: the agent has no
+  # equivalent of the OTel k8s_cluster receiver. Single-replica by default
+  # (`replicas: 1`, verified by render), which is what makes it a single writer.
+  # Condition-gated so clusters that already run kube-state-metrics can reuse it.
+  - name: kube-state-metrics
+    version: "8.2.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: kube-state-metrics.enabled

--- a/charts/alloy-lerian/Chart.yaml
+++ b/charts/alloy-lerian/Chart.yaml
@@ -43,14 +43,33 @@ icon: https://avatars.githubusercontent.com/u/148895005?s=200&v=4
 # https://docs.lerian.studio/docs/midaz-components
 
 dependencies:
+  # The upstream chart delivers ONE set of workloads, but the design needs two
+  # topologies. Declared twice under aliases rather than hand-writing
+  # DaemonSet/Deployment manifests: reusing upstream keeps probes, RBAC,
+  # security context and the config-reloader sidecar in one place instead of
+  # forking them.
+  #
   # Pinned exactly, no ranges. v1.18.1 is the minimum floor, not a preference:
   # it exists primarily to backport two transitive-dependency CVE fixes, so
   # 1.18.0 is vulnerable. Bumping requires re-running the sanitisation gate —
   # regex and function behaviour can change between versions, and the failure
   # mode in production is silent.
+
+  # Per-node role: receives application telemetry pushed to it. Push cannot
+  # duplicate, so replication per node is safe.
   - name: alloy
+    alias: node
     version: "1.11.1"
     repository: "https://grafana.github.io/helm-charts"
+    condition: node.enabled
+
+  # Single-replica role: observes cluster-scope state. More than one replica
+  # duplicates every series with nothing distinguishing the writers.
+  - name: alloy
+    alias: singleton
+    version: "1.11.1"
+    repository: "https://grafana.github.io/helm-charts"
+    condition: singleton.enabled
 
   # Sole source of cluster-object metrics in the Alloy model: the agent has no
   # equivalent of the OTel k8s_cluster receiver. Single-replica by default

--- a/charts/alloy-lerian/README.md
+++ b/charts/alloy-lerian/README.md
@@ -7,7 +7,7 @@ chart and renders the collection pipeline from semantic parameters.
 
 - Chart type: `dependency-wrapper`
 - Required secrets: `alloy-api-key` (key `api-key`) — operator-provisioned in the origin cluster before install, in the `client` profile. Not created by this chart. Omitted in the `own` profile, where the internal platform does not validate it.
-- Dependency notes: two external dependencies, pinned exactly. `alloy` 1.11.1 (upstream agent) is unconditional; `kube-state-metrics` 8.2.0 is condition-gated on `kube-state-metrics.enabled` so clusters that already run it can reuse the existing instance.
+- Dependency notes: three dependency entries, all pinned exactly. `alloy` 1.11.1 appears **twice** under the `node` and `singleton` aliases, each condition-gated on its own `enabled` value, because the upstream chart delivers one set of workloads and the design needs two topologies. `kube-state-metrics` 8.2.0 is condition-gated on `kube-state-metrics.enabled` so clusters that already run it can reuse the existing instance.
 - Production overrides: `profile` and `origin.id` are required and have no default — the render fails without them. `destination.endpoint` is required. Override `destination.retry.maxElapsedTime` and `destination.queue.size` from measured volume per environment.
 - Source/license: [grafana/alloy](https://github.com/grafana/alloy) (Apache-2.0), [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) (Apache-2.0).
 
@@ -37,7 +37,7 @@ operational responsibility, not preference.
 | Application telemetry over the standard protocol | yes | yes |
 | Cluster-scope state | yes | yes |
 | Cluster-object metrics | yes | yes |
-| **Node infrastructure** | **yes** | **no** |
+| **Node infrastructure** | not collected today; the profile permits enabling it | **not collected, and enabling it fails the render** |
 | In-transit data inspection | configurable, off by default | **parameter does not exist** |
 | Regulated-data sanitisation | yes | yes |
 | Destination credential | omitted by default | required |

--- a/charts/alloy-lerian/README.md
+++ b/charts/alloy-lerian/README.md
@@ -1,0 +1,153 @@
+# alloy-lerian
+
+Telemetry collection agent for client clusters. Wraps the upstream Grafana Alloy
+chart and renders the collection pipeline from semantic parameters.
+
+## Chart Contract
+
+- Chart type: `dependency-wrapper`
+- Required secrets: `alloy-api-key` (key `api-key`) — operator-provisioned in the origin cluster before install, in the `client` profile. Not created by this chart. Omitted in the `own` profile, where the internal platform does not validate it.
+- Dependency notes: two external dependencies, pinned exactly. `alloy` 1.11.1 (upstream agent) is unconditional; `kube-state-metrics` 8.2.0 is condition-gated on `kube-state-metrics.enabled` so clusters that already run it can reuse the existing instance.
+- Production overrides: `profile` and `origin.id` are required and have no default — the render fails without them. `destination.endpoint` is required. Override `destination.retry.maxElapsedTime` and `destination.queue.size` from measured volume per environment.
+- Source/license: [grafana/alloy](https://github.com/grafana/alloy) (Apache-2.0), [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) (Apache-2.0).
+
+## What this chart does differently
+
+The processing chain is **not** part of the values surface. Consumers declare
+intent; the chart derives the wiring.
+
+That is deliberate. In this agent, components form a graph through `output`
+references rather than an ordered list, so swapping two stages produces **no
+error** — it produces telemetry without enrichment, silently. Three ordering
+constraints are contractual and each was verified by deliberately breaking it:
+
+| Constraint | What inverting it produces |
+|---|---|
+| Admission first | Load is allocated before being shed |
+| Enrichment before batching | Batching discards the connection context the association path reads, so telemetry arrives with no pod attribution |
+| Batching last | Enrichment operates on individual records |
+
+## Profiles
+
+`profile` is required, has no default, and is not inferable. The boundary is
+operational responsibility, not preference.
+
+| | `own` | `client` |
+|---|---|---|
+| Application telemetry over the standard protocol | yes | yes |
+| Cluster-scope state | yes | yes |
+| Cluster-object metrics | yes | yes |
+| **Node infrastructure** | **yes** | **no** |
+| In-transit data inspection | configurable, off by default | **parameter does not exist** |
+| Regulated-data sanitisation | yes | yes |
+| Destination credential | omitted by default | required |
+
+Node infrastructure is excluded in the `client` profile because the node belongs
+to the client: collecting it asks for data we have no standing to act on, and
+adds traffic across the public network for no return.
+
+**Sanitisation does not vary by profile.** There is no profile without it.
+
+## Roles
+
+The chart delivers roles, not one agent.
+
+| Role | Topology | Observes |
+|---|---|---|
+| `node` | one per node | application telemetry pushed to it — push cannot duplicate |
+| `singleton` | exactly one replica | cluster-scope state and cluster-object metrics |
+
+A cluster-scoped watcher replicated per node writes the same series from every
+replica, with no attribute distinguishing the writers: cost grows with cluster
+size while information does not. Measured before this chart existed — writes per
+minute equalled the node count exactly, across five environments.
+
+## Regulated-data sanitisation
+
+Runs at the edge, before anything leaves the origin cluster, and is **not
+configurable**. There is no value that disables a rule, weakens one, or produces
+unsanitised output. The absence of those knobs is the guarantee.
+
+Seven classes are covered: fiscal document, person name, email address, phone
+number, payment key, postal address, opaque resource identifier.
+
+What each class preserves, and why:
+
+| Class | Preserved | Reason |
+|---|---|---|
+| Fiscal document | first 3 digits | correlation without reconstruction |
+| Person name | first and last term | legibility in diagnosis |
+| Email address | 2 local chars + **whole domain** | the domain identifies the provider, not the person |
+| Phone number | country + area code | region is useful; the number is not |
+| Payment key | first and last block | traceability without reconstruction |
+| **Postal address** | **nothing — masked entirely** | **any fragment sharply narrows the search for a person** |
+| Opaque identifier | prefix + 4 chars | correlation of the same resource |
+
+Correctness is asserted in CI against a known input and expected output, and
+blocks release on mismatch. This is not belt-and-braces: the rules run with
+errors ignored, so a malformed rule produces **no error** — it produces output
+that looks masked and is not. Verified: the wrong backreference form emits the
+literal text `$1` with no warning at all.
+
+**Known and accepted false positive:** the document rule masks any 11+ digit
+run, including transaction identifiers and latency values. Measured at roughly
+2% of log lines. Accepted because a false positive costs legibility while a
+false negative leaks a document. Requiring a field prefix was evaluated and
+rejected — the canonical case is a bare document in running text.
+
+## Delivery guarantees
+
+Queue and retry are enabled. Without them any blip in the destination is
+definitive, unrecorded loss.
+
+Retry classification is by status code and is **not symmetric**: `429`, `502`,
+`503` and `504` are retryable; everything else is permanent and discarded
+immediately. A rejected credential (`401`, `403`) therefore causes continuous
+silent loss rather than a growing queue — which is why permanent discard must
+be alerted separately from queue saturation. They are different causes: the
+former is misconfiguration and does not resolve itself.
+
+The queue is in memory. Persistence is out of scope: the durable backend sits
+below the agent's stable component tier, and enabling it would require lowering
+the stability floor **globally**, un-gating every unstable component in a
+financial-institution cluster. Consequence accepted — a process restart loses
+the in-flight queue.
+
+## Collection interval
+
+Floor of 60 seconds, enforced. A lower value is **rejected, not clamped** —
+clamping would hide the divergent intent of whoever set it.
+
+Cost at the destination is series × writes per minute. Collecting faster than
+anyone queries wastes CPU in the client cluster, bandwidth across the public
+network, and processing at the destination.
+
+## Origin identifier
+
+Required, no default, and validated against a canonical form that accepts
+hyphenated composition.
+
+It marks **provenance, not identity**. The credential authenticates the sender;
+the marker is self-declared, so an authenticated origin could claim another's
+identifier. Out of scope by decision, recorded as a known limit.
+
+⚠️ Changing the identifier for a live environment is a **data migration**, not a
+configuration tweak. The marker is part of series identity at the destination, so
+a new value creates new series and orphans every existing one.
+
+## Minimal installation
+
+```yaml
+profile: client
+origin:
+  id: acme-prd
+destination:
+  endpoint: https://telemetry.example.net
+```
+
+```console
+helm install alloy oci://ghcr.io/lerianstudio/alloy-lerian-helm \
+  --version <pinned> -n monitoring -f values-acme.yaml
+```
+
+The credential Secret must exist in the namespace before install.

--- a/charts/alloy-lerian/examples/values-benedita.yaml
+++ b/charts/alloy-lerian/examples/values-benedita.yaml
@@ -28,7 +28,17 @@ destination:
   endpoint: https://telemetry.benedita.lerian.net
 
   # Sem bloco `credential`: a plataforma interna não valida a credencial, e o
-  # perfil `own` já deriva isso. Nenhum Secret precisa existir antes do install.
+  # perfil `own` já deriva isso — o cabeçalho não é enviado.
+
+# Remove a referência ao Secret que os defaults do chart carregam. Ela é
+# inofensiva (optional: true, e o cabeçalho não é enviado neste perfil), mas
+# deixá-la sugere que o Secret é esperado aqui — e não é.
+node:
+  alloy:
+    extraEnv: []
+singleton:
+  alloy:
+    extraEnv: []
 
 # ---------------------------------------------------------------------------
 # Deliberadamente AUSENTE deste arquivo

--- a/charts/alloy-lerian/examples/values-benedita.yaml
+++ b/charts/alloy-lerian/examples/values-benedita.yaml
@@ -1,0 +1,76 @@
+# benedita — anel 1 do rollout. Ambiente próprio, on-premises.
+#
+# Uso:
+#   helm upgrade --install alloy-lerian \
+#     oci://ghcr.io/lerianstudio/alloy-lerian-helm --version <fixada> \
+#     -n monitoring --create-namespace \
+#     -f examples/values-benedita.yaml
+#
+# Três valores. O resto é derivado do perfil, e os defaults do agente são
+# mantidos deliberadamente.
+
+# Ambiente nosso: coleta todos os namespaces exceto a infra do orquestrador, e
+# a inspeção de dado em trânsito fica disponível (desligada por padrão).
+profile: own
+
+origin:
+  # Nome reservado de ambiente próprio, aceito sem sufixo de estágio.
+  #
+  # ⚠️ Trocar isto num ambiente em operação é MIGRAÇÃO DE DADO, não ajuste de
+  # config: a marca compõe a identidade da série no destino, então um valor novo
+  # cria séries novas e órfã todas as anteriores.
+  id: benedita
+
+destination:
+  # Concentrador interno, via ingress do cluster. Inalterado nesta fase — o
+  # contrato de transporte é o mesmo antes e depois da migração, então o
+  # concentrador não percebe a troca.
+  endpoint: https://telemetry.benedita.lerian.net
+
+  # Sem bloco `credential`: a plataforma interna não valida a credencial, e o
+  # perfil `own` já deriva isso. Nenhum Secret precisa existir antes do install.
+
+# ---------------------------------------------------------------------------
+# Deliberadamente AUSENTE deste arquivo
+# ---------------------------------------------------------------------------
+# collection.namespaces      derivado: exclui ^(kube-system|kube-public|kube-node-lease)$
+# collection.interval        60s, o piso — não há razão para subir no anel 1
+# collection.dropDebugLogs   true
+# collection.nodeInfrastructure  false. Métricas de NÓ (CPU/memória do host)
+#                            não são coletadas por nenhum perfil hoje; a fonte
+#                            é o kubelet e não está no chart. O perfil `own`
+#                            permite ligar quando existir; o `client` não.
+# roles.*                    ambos ativos
+# kube-state-metrics         ativo, uma réplica. Se benedita já tiver um,
+#                            desligar com `kube-state-metrics.enabled: false`
+#                            para não rodar dois.
+# inspection.enabled         false. Disponível neste perfil, mas ligar expõe
+#                            payload cru de pipeline numa interface sem
+#                            autenticação — só sob janela aprovada, e nunca
+#                            por Service ou Ingress.
+#
+# As regras de sanitização de dado regulado NÃO aparecem aqui porque não são
+# configuráveis. Não existe valor que as desabilite ou enfraqueça.
+
+# ---------------------------------------------------------------------------
+# Antes de subir: o portão de validação do anel 1
+# ---------------------------------------------------------------------------
+# Este ambiente é onde a migração é validada por inteiro antes de qualquer
+# outro receber a mudança. O que precisa estar fechado:
+#
+#   1. contrato de mudança declarado ANTES do deploy, conferindo depois
+#   2. escritas por série = 1, e invariante ao número de nós
+#      (taxa unitária num cluster de um nó não prova nada)
+#   3. redução de séries conforme o previsto
+#   4. consumo de recurso e privilégio não superiores aos anteriores
+#   5. reversão exercitada com sucesso
+#   6. métricas de descarte distintas: saturação de fila vs descarte permanente
+#      — causas diferentes, e a segunda não se resolve sozinha
+#   7. correspondência de vocabulário de métrica confirmada contra dado REAL
+#      (o mapa atual é hipótese documental: nenhum nome novo existe hoje no
+#      destino)
+#   8. arquétipos de alerta reescritos, com disparo verificado
+#   9. painéis exibindo dado; os que consultam informação descontinuada
+#      removidos, não deixados vazios
+#
+# Enquanto qualquer item estiver aberto, aws-staging não inicia.

--- a/charts/alloy-lerian/examples/values-cliente.yaml
+++ b/charts/alloy-lerian/examples/values-cliente.yaml
@@ -1,0 +1,42 @@
+# Modelo para cluster de CLIENTE (BYOC). Anel 4 do rollout.
+#
+# Este arquivo é o que o cliente recebe. São DOIS valores; o resto é derivado.
+#
+#   helm upgrade --install alloy-lerian \
+#     oci://ghcr.io/lerianstudio/alloy-lerian-helm --version <fixada> \
+#     -n monitoring --create-namespace -f values.yaml
+
+profile: client
+
+origin:
+  # Substituir. Minúsculas, segmentos separados por hífen, terminando em
+  # stg | hml | prd. Exemplos válidos: acme-prd, lazari-sandbox-prd.
+  id: SUBSTITUIR-prd
+
+destination:
+  endpoint: https://telemetry.lerian.io
+
+# ---------------------------------------------------------------------------
+# PRÉ-REQUISITO: o Secret da credencial deve existir ANTES do install
+# ---------------------------------------------------------------------------
+#   kubectl -n monitoring create secret generic alloy-api-key \
+#     --from-literal=api-key='<credencial fornecida pela Lerian>'
+#
+# O chart apenas lê esse Secret; nunca o cria. No perfil `client` a credencial
+# é obrigatória, porque o ponto de entrada a valida.
+#
+# ---------------------------------------------------------------------------
+# Derivado do perfil — não precisa constar aqui
+# ---------------------------------------------------------------------------
+# collection.namespaces  inclui APENAS ^(midaz|midaz-plugins)$. O resto do
+#                        cluster é do cliente e não é coletado.
+# nó                     não coletado, e ligar é impossível neste perfil.
+# inspection             o parâmetro NÃO EXISTE neste perfil. Fornecê-lo é erro
+#                        de configuração, não sobrescrita.
+# sanitização            sempre ativa. Dado regulado é mascarado no cluster de
+#                        origem, antes de qualquer saída. Não há valor que
+#                        desabilite.
+#
+# Se o cluster já roda kube-state-metrics, desligue o nosso para não haver dois:
+#   kube-state-metrics:
+#     enabled: false

--- a/charts/alloy-lerian/sanitizacao/README.md
+++ b/charts/alloy-lerian/sanitizacao/README.md
@@ -1,0 +1,211 @@
+# Arcabouço de verificação de sanitização
+
+**Executado e validado:** 2026-08-08 · **Subtarefa:** ST-003-02
+**Agente:** `grafana/alloy:v1.18.1`
+
+## Por que existe
+
+Em produção as regras rodam com `error_mode = "ignore"`. **Uma regra malformada não gera erro — produz saída que aparenta estar mascarada.** Verificado empiricamente ([evidência](../subtasks/T-003/EVIDENCIA-retrovinculacao.md)): a notação `$$1` emite o texto literal `$1***`, sem qualquer aviso, mesmo em `error_mode = "propagate"`.
+
+Logo, a única verificação válida é **comparar a saída observada com a esperada**. Revisão de configuração não detecta esta classe de falha.
+
+## Uso
+
+```bash
+./porta-de-entrega.sh             # PORTA BLOQUEANTE — 5 verificações
+./verificar.sh                    # só os casos, todos
+./verificar.sh documento-canonico # um caso
+```
+
+Código de saída 0 = liberado. Diferente de 0 = bloqueado.
+
+## Porta de entrega — 5 verificações bloqueantes
+
+`porta-de-entrega.sh` é o que bloqueia a entrega. Vai além de rodar os casos:
+
+| # | Verifica | Por quê |
+|---|---|---|
+| 1 | Nenhuma notação `$$N` no **código** | Emite texto literal sem erro |
+| 2 | Nenhuma função editora aninhada em `set()` | Falha na carga do agente |
+| 3 | Nenhum lookahead/lookbehind | Não suportado pelo motor |
+| 4 | Cada classe tem as 4 categorias; e o `body` esperado das de preservação **não** contém notação | Regra sem cobertura completa passa despercebida |
+| 5 | Todos os casos passam contra o agente real | — |
+
+### Bloqueio verificado com 4 defeitos deliberados
+
+| Defeito injetado | Bloqueou |
+|---|---|
+| Notação `$$1` no código | ✅ |
+| Lookahead numa regra | ✅ |
+| Categoria de teste removida | ✅ |
+| `body` esperado com `$1` literal | ✅ |
+
+### Nota de método: os três primeiros checks inspecionam só o código
+
+Na primeira execução a porta deu **6 falsos positivos** — estava lendo os comentários do arquivo de regras, que documentam justamente as construções proibidas (`NUNCA $$1`, `falha com (?!`), e o campo `descricao` dos casos, que menciona a notação de propósito.
+
+Corrigido: os checks 1 a 3 filtram linhas de comentário; o check 4 lê apenas o campo `body` via `jq`. **Uma porta que falha sempre é ignorada — e aí não protege nada.**
+
+## Integração em CI
+
+`ci-sanitizacao.yml.modelo` é o fluxo pronto, **não instalado**: o chart ainda não existe no repositório. Quando existir (T-004), copiar para `.github/workflows/` ajustando os caminhos.
+
+A versão do agente é **pinada** no fluxo. Atualizá-la exige reverificar as asserções — comportamento de regex pode mudar entre versões, e a falha seria silenciosa em produção.
+
+## Estrutura
+
+```
+sanitizacao/
+├── regras.alloy      # regras + receptor + exportador de inspeção
+├── verificar.sh      # executa o agente real e compara saídas
+└── casos/
+    ├── <caso>.json           # entrada
+    └── <caso>.esperado.json  # saída esperada + categoria
+```
+
+## As 4 categorias obrigatórias por regra
+
+| Categoria | O que verifica | Estado |
+|---|---|---|
+| `formaCanonica` | Caminho principal | ✅ |
+| `formaAlternativa` | Variante de formato da mesma classe | ✅ |
+| `ausencia` | A regra **não** altera o que não casa | ✅ |
+| **`preservacaoDeFragmento`** | **A saída contém o fragmento capturado, não a notação literal** | ✅ |
+
+**A quarta é a única capaz de detectar notação de retrovinculação incorreta.** As outras três passariam com a regra errada.
+
+## Detecção de regressão — verificada
+
+O arcabouço foi testado contra três defeitos deliberados:
+
+| Defeito injetado | Saída produzida | Detectado |
+|---|---|---|
+| Regra ausente | `documento 12345678901` (dado cru) | ✅ |
+| Grupo inexistente (`$9`) | `documento ********` (fragmento **vazio**) | ✅ |
+| **Notação errada (`$$1`)** | **`documento $1********`** | ✅ |
+
+O terceiro é o cenário real de risco: asteriscos presentes, formato plausível, dado não mascarado. **Passaria por revisão de configuração.**
+
+Nota sobre o segundo: grupo de captura inexistente resolve para **string vazia**, silenciosamente. Não gera erro.
+
+## Achado sobre as regras (não sobre o arcabouço)
+
+O caso `formaAlternativa` **falhou na primeira execução** e revelou uma lacuna real: a regra de 11 dígitos seguidos **não casa documento com separadores** (`123.456.789-01`). Foi necessária uma regra própria para a forma pontuada.
+
+**Consequência para as regras restantes:** cada classe de dado regulado precisa de verificação de forma alternativa. A ausência dessa categoria de teste é o que permite uma lacuna assim passar.
+
+## Ordem das regras importa
+
+A regra da forma pontuada vem **antes** da de dígitos seguidos. Comentado no arquivo: a mais específica precede a mais geral.
+
+## Diferenças deliberadas em relação à produção
+
+| Aspecto | Aqui | Produção |
+|---|---|---|
+| `error_mode` | `propagate` | `ignore` |
+| Exportador | de inspeção (experimental) | ao concentrador (estável) |
+| Nível de estabilidade | rebaixado, só por causa do exportador de inspeção | máximo |
+
+O rebaixamento do nível de estabilidade é **exclusivo deste arcabouço**. A configuração de produção não usa componente abaixo do nível máximo.
+
+## Limitações do motor de regex — verificadas por execução
+
+O motor desta versão é RE2. **Não suporta**:
+
+| Construção | Erro | Consequência |
+|---|---|---|
+| Lookahead `(?!…)`, `(?=…)` | `invalid or unsupported Perl syntax: (?!` | **Falha na CARGA** — ruidosa e segura |
+| Lookbehind | idem | idem |
+
+**Isto é boa notícia:** a ausência de retrovisor força delimitar o valor por outros meios, e o erro aparece na inicialização, não em execução.
+
+## Regra de nome: três tentativas, e o que cada uma ensinou
+
+| Tentativa | Resultado observado | Por que falha |
+|---|---|---|
+| `(?: \w+)+` guloso | `Joao **********` — **sobrenome APAGADO** | Consome até o fim; último grupo fica vazio. **Pior que não mascarar** — destrói dado |
+| `(?: \w+)*?` não-guloso | `Joao ********** Carlos Pereira Silva` | Casa o mínimo; não mascara o meio |
+| `[A-Z]\w*` ancorado em caixa | ✅ funciona | Termos de nome começam em maiúscula; o texto seguinte no log é minúsculo — delimita o valor sem retrovisor |
+
+**Foram necessárias DUAS regras**, não uma:
+- **3+ termos** — exige ≥1 termo no meio (`(?: [A-Z]\w*)+`)
+- **exatamente 2 termos** — a regra de 3+ não casa, porque não há meio
+
+**A ordem é obrigatória: 3+ antes de 2.** Verificado por regressão — invertendo, `Ana Beatriz Costa Lima` vira `Ana ********** Beatriz Costa Lima`: **o nome completo permanece exposto** com uma máscara decorativa antes. Passa em revisão visual.
+
+### Dependência de convenção — registrar como premissa
+
+A regra depende de os termos de nome começarem em **maiúscula** e o texto seguinte no log ser **minúsculo**. Isso vale nos logs analisados, mas é premissa, não garantia. Se alguma aplicação logar nome em caixa alta ou baixa, a regra não casa — e o teste de forma alternativa da classe correspondente é o que detectaria.
+
+## Estado: 7 de 7 classes, 31 casos, todos passando
+
+| Classe | Casos | Regras | Estado |
+|---|---|---|---|
+| Documento fiscal | 4 | 2 (pontuada + seguida) | ✅ |
+| Nome de pessoa | 4 | 2 (3+ termos + 2 termos) | ✅ |
+| Correio eletrônico | 4 | 1 | ✅ |
+| Telefone | 4 | 2 (E.164 + nacional) | ✅ |
+| Chave de pagamento | 4 | 1 (só a forma aleatória) | ✅ |
+| Endereço postal | 4 | 1 (integral) | ✅ |
+| Identificador opaco | 4 | 1 | ✅ |
+
+Mais três casos além das 4 categorias por classe:
+
+| Caso | Verifica |
+|---|---|
+| `interacao-multiclasse` | Três classes no mesmo registro |
+| `interacao-todas-classes` | **As sete classes no mesmo registro**, sem interferência |
+| `risco-falso-positivo` | Comportamento real em números longos que **não** são documento |
+
+## Ordem das regras — três restrições verificadas por regressão
+
+A ordem não é estilística. Cada uma destas foi comprovada quebrando de propósito:
+
+| # | Restrição | O que acontece se inverter |
+|---|---|---|
+| 1 | **Telefone antes de documento** | `+5511987654321` casa a regra de 11 dígitos → `+551********21`. Mascarado, mas **errado**: perde o DDD e preserva 2 dígitos finais do número — o oposto do desejado |
+| 2 | **Documento pontuado antes de documento seguido** | A forma pontuada deixa de casar |
+| 3 | **Nome 3+ termos antes de nome 2 termos** | `Ana Beatriz Costa Lima` → `Ana ********** Beatriz Costa Lima`. **Nome completo exposto** atrás de máscara decorativa |
+
+A primeira foi descoberta **pelo teste**, não por análise: o caso canônico de telefone falhou no RED com a saída já mascarada pela regra de documento.
+
+## Decisão de projeto: chave de pagamento não duplica regras
+
+Uma chave pode ser documento, telefone, correio eletrônico ou identificador aleatório. **Só a última tem regra própria** — as três primeiras são cobertas pelas regras dessas classes, independentemente do nome do campo.
+
+**Verificado por teste** (`chavepgto-forma-alternativa`): as três formas são mascaradas corretamente sem regra dedicada. Duplicar seria redundância com risco de divergência.
+
+## O que cada classe preserva, e por quê
+
+| Classe | Preserva | Razão |
+|---|---|---|
+| Documento | 3 primeiros dígitos | Correlação de registros sem reconstrução |
+| Nome | primeiro e último termo | Legibilidade em diagnóstico |
+| Correio eletrônico | 2 do local + **domínio inteiro** | Domínio identifica provedor ou cliente corporativo, **não a pessoa** |
+| Telefone | país + DDD | Região é útil em diagnóstico; o número não |
+| Chave aleatória | primeiro e último bloco | Rastreabilidade sem reconstrução |
+| **Endereço postal** | **nada — integral** | **Qualquer fragmento reduz drasticamente o espaço de busca da pessoa** |
+| Identificador opaco | prefixo + 4 caracteres | Correlação do mesmo recurso |
+
+O endereço é o único com mascaramento integral, e é decisão deliberada.
+
+## ⚠️ Falso positivo conhecido e aceito
+
+A regra de documento mascara **qualquer sequência de 11+ dígitos**:
+
+```
+latencia 12345678901234        → latencia 123********234
+transactionId=98765432109876   → transactionId=987********876543210
+```
+
+**Trade-off aceito:** falso positivo (perde legibilidade em diagnóstico) é preferível a falso negativo (vaza documento).
+
+**Alternativa avaliada e rejeitada:** exigir prefixo de campo (`documento=`, `cpf=`). Rejeitada porque documento aparece em log sem prefixo — o caso canônico da suíte é exatamente `documento 12345678901` em texto corrido.
+
+**Está capturado como teste**, com o comportamento real documentado. Qualquer mudança nele passa a ser detectada.
+
+**Item a medir:** quantos logs reais contêm sequência de 11+ dígitos que não seja documento. Se for volume alto, vale revisitar — mas a decisão de segurança não muda.
+
+## Próximo passo
+
+**ST-003-03 e seguintes:** traduzir as regras restantes (nome, correio eletrônico, endereço, telefone, chave de pagamento, identificador opaco), cada uma com as 4 categorias. O padrão de trabalho está estabelecido: caso primeiro (falha), regra depois (passa), quebra deliberada (detecta).

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-ausente.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-ausente.esperado.json
@@ -1,0 +1,1 @@
+{"body":"transferencia via agencia e conta","categoria":"ausencia","descricao":"Sem chave: nada muda"}

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-ausente.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-ausente.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"transferencia via agencia e conta"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-canonico.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-canonico.esperado.json
@@ -1,0 +1,2 @@
+{"body":"pixKey=a1b2c3d4-****-****-****-ef1234567890 consultada","categoria":"formaCanonica",
+"descricao":"Chave aleatoria (UUID): preserva primeiro e ultimo bloco, mascara os 3 do meio"}

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-canonico.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-canonico.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"pixKey=a1b2c3d4-e5f6-7890-abcd-ef1234567890 consultada"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-forma-alternativa.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-forma-alternativa.esperado.json
@@ -1,0 +1,3 @@
+{"body":"pixKey=123******** e pixKey=+5511******** e pixKey=an****@lerian.studio",
+"categoria":"formaAlternativa",
+"descricao":"As 3 outras formas de chave (documento, telefone, email) devem ser cobertas pelas regras dessas classes, sem regra propria de chave."}

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-forma-alternativa.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-forma-alternativa.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"pixKey=12345678901 e pixKey=+5511987654321 e pixKey=ana@lerian.studio"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-preservacao-fragmento.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-preservacao-fragmento.esperado.json
@@ -1,0 +1,2 @@
+{"body":"dictKey=99887766-****-****-****-aabbccddeeff fim","categoria":"preservacaoDeFragmento",
+"descricao":"Primeiro e ultimo bloco DEVEM aparecer literalmente"}

--- a/charts/alloy-lerian/sanitizacao/casos/chavepgto-preservacao-fragmento.json
+++ b/charts/alloy-lerian/sanitizacao/casos/chavepgto-preservacao-fragmento.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"dictKey=99887766-5544-3322-1100-aabbccddeeff fim"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-ausente.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-ausente.esperado.json
@@ -1,0 +1,3 @@
+{"body":"pedido processado sem identificador pessoal",
+"descricao":"Sem ocorrencia do padrao: a regra nao deve alterar nada",
+"categoria":"ausencia"}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-ausente.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-ausente.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"pedido processado sem identificador pessoal"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-canonico.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-canonico.esperado.json
@@ -1,0 +1,5 @@
+{
+  "body": "cliente cadastrado documento 123******** com sucesso",
+  "descricao": "Documento fiscal de 11 digitos: preserva 3 primeiros, substitui os 8 restantes por 8 asteriscos",
+  "categoria": "formaCanonica"
+}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-canonico.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-canonico.json
@@ -1,0 +1,13 @@
+{
+  "resourceLogs": [{
+    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "caso-sanitizacao"}}]},
+    "scopeLogs": [{
+      "logRecords": [{
+        "timeUnixNano": "1700000000000000000",
+        "severityNumber": 9,
+        "severityText": "INFO",
+        "body": {"stringValue": "cliente cadastrado documento 12345678901 com sucesso"}
+      }]
+    }]
+  }]
+}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-forma-alternativa.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-forma-alternativa.esperado.json
@@ -1,0 +1,3 @@
+{"body":"documento formatado 123.***.***-** recebido",
+"descricao":"Documento com separadores. A regra canonica (11 digitos seguidos) NAO casa aqui — exige regra propria para a forma pontuada.",
+"categoria":"formaAlternativa"}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-forma-alternativa.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-forma-alternativa.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"documento formatado 123.456.789-01 recebido"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-preservacao-fragmento.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-preservacao-fragmento.esperado.json
@@ -1,0 +1,3 @@
+{"body":"doc 987******** registrado",
+"descricao":"O fragmento capturado (987) DEVE aparecer na saida. Se aparecer a notacao literal ($1) ou vazio, a regra esta errada. Esta e a UNICA categoria que detecta notacao de retrovinculacao incorreta.",
+"categoria":"preservacaoDeFragmento"}

--- a/charts/alloy-lerian/sanitizacao/casos/documento-preservacao-fragmento.json
+++ b/charts/alloy-lerian/sanitizacao/casos/documento-preservacao-fragmento.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"doc 98765432100 registrado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/email-ausente.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-ausente.esperado.json
@@ -1,0 +1,1 @@
+{"body":"pagamento aprovado sem contato","categoria":"ausencia","descricao":"Sem email: nada muda"}

--- a/charts/alloy-lerian/sanitizacao/casos/email-ausente.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-ausente.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"pagamento aprovado sem contato"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/email-canonico.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-canonico.esperado.json
@@ -1,0 +1,1 @@
+{"body":"email=jo****@empresa.com.br cadastrado","categoria":"formaCanonica","descricao":"Preserva 2 primeiros do local e o dominio inteiro"}

--- a/charts/alloy-lerian/sanitizacao/casos/email-canonico.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-canonico.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"email=joao.silva@empresa.com.br cadastrado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/email-forma-alternativa.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-forma-alternativa.esperado.json
@@ -1,0 +1,1 @@
+{"body":"contato: MA****@GMAIL.COM ok","categoria":"formaAlternativa","descricao":"Email em CAIXA ALTA e sem prefixo de campo"}

--- a/charts/alloy-lerian/sanitizacao/casos/email-forma-alternativa.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-forma-alternativa.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"contato: MARIA@GMAIL.COM ok"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/email-preservacao-fragmento.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-preservacao-fragmento.esperado.json
@@ -1,0 +1,1 @@
+{"body":"userEmail=an****@lerian.studio fim","categoria":"preservacaoDeFragmento","descricao":"an e o dominio DEVEM aparecer"}

--- a/charts/alloy-lerian/sanitizacao/casos/email-preservacao-fragmento.json
+++ b/charts/alloy-lerian/sanitizacao/casos/email-preservacao-fragmento.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"userEmail=ana@lerian.studio fim"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-ausente.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-ausente.esperado.json
@@ -1,0 +1,1 @@
+{"body":"cobranca gerada sem entrega fisica","categoria":"ausencia","descricao":"Sem endereco: nada muda"}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-ausente.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-ausente.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"cobranca gerada sem entrega fisica"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-canonico.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-canonico.esperado.json
@@ -1,0 +1,1 @@
+{"body":"address=**********","categoria":"formaCanonica","descricao":"Endereco mascarado INTEGRALMENTE (nao ha parte segura de preservar)"}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-canonico.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-canonico.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"address=Rua das Flores 123 Apto 45"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-forma-alternativa.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-forma-alternativa.esperado.json
@@ -1,0 +1,1 @@
+{"body":"street: **********","categoria":"formaAlternativa","descricao":"Prefixo alternativo (street em vez de address)"}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-forma-alternativa.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-forma-alternativa.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"street: Av Paulista 1000"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-preservacao-fragmento.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-preservacao-fragmento.esperado.json
@@ -1,0 +1,2 @@
+{"body":"endereco=**********","categoria":"preservacaoDeFragmento",
+"descricao":"Mascaramento INTEGRAL: nenhum fragmento do endereco deve sobrar. Verifica que nada de Rua/Especifica/999/Bloco aparece."}

--- a/charts/alloy-lerian/sanitizacao/casos/endereco-preservacao-fragmento.json
+++ b/charts/alloy-lerian/sanitizacao/casos/endereco-preservacao-fragmento.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"endereco=Rua Muito Especifica 999 Bloco C"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-ausente.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-ausente.esperado.json
@@ -1,0 +1,1 @@
+{"body":"saldo consultado","categoria":"ausencia","descricao":"Sem identificador: nada muda"}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-ausente.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-ausente.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"saldo consultado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-canonico.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-canonico.esperado.json
@@ -1,0 +1,1 @@
+{"body":"accountId=acc_9f8e****** vinculada","categoria":"formaCanonica","descricao":"Preserva prefixo e 4 primeiros; mascara o resto"}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-canonico.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-canonico.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"accountId=acc_9f8e7d6c5b4a3210 vinculada"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-forma-alternativa.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-forma-alternativa.esperado.json
@@ -1,0 +1,2 @@
+{"body":"ref txn_AB12****** processada","categoria":"formaAlternativa",
+"descricao":"Prefixo diferente (txn_) e caixa mista. Sem prefixo de campo."}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-forma-alternativa.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-forma-alternativa.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"ref txn_AB12cd34ef56 processada"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-preservacao-fragmento.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-preservacao-fragmento.esperado.json
@@ -1,0 +1,2 @@
+{"body":"cus_ZZ99****** encontrado","categoria":"preservacaoDeFragmento",
+"descricao":"cus_ZZ99 DEVE aparecer literalmente. Se sair $1 ou vazio, a regra esta errada."}

--- a/charts/alloy-lerian/sanitizacao/casos/idopaco-preservacao-fragmento.json
+++ b/charts/alloy-lerian/sanitizacao/casos/idopaco-preservacao-fragmento.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"cus_ZZ99yyxxwwvv encontrado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/interacao-multiclasse.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/interacao-multiclasse.esperado.json
@@ -1,0 +1,3 @@
+{"body":"customerName=Joao ********** Silva documento 123******** email=jo****@empresa.com criado",
+"categoria":"interacao",
+"descricao":"Tres classes no MESMO registro. Verifica que as regras nao interferem entre si nem se sobrepoem."}

--- a/charts/alloy-lerian/sanitizacao/casos/interacao-multiclasse.json
+++ b/charts/alloy-lerian/sanitizacao/casos/interacao-multiclasse.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"customerName=Joao Carlos Silva documento 12345678901 email=joao.silva@empresa.com criado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/interacao-todas-classes.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/interacao-todas-classes.esperado.json
@@ -1,0 +1,3 @@
+{"body":"customerName=Ana ********** Lima documento 123******** email=an****@lerian.studio phone=+5511******** pixKey=a1b2c3d4-****-****-****-ef1234567890 accountId=acc_9f8e****** processado",
+"categoria":"interacao",
+"descricao":"TODAS as 7 classes no mesmo registro, mascaradas sem interferencia mutua. Verifica a composicao completa do conjunto de regras."}

--- a/charts/alloy-lerian/sanitizacao/casos/interacao-todas-classes.json
+++ b/charts/alloy-lerian/sanitizacao/casos/interacao-todas-classes.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"customerName=Ana Beatriz Lima documento 12345678901 email=ana@lerian.studio phone=+5511987654321 pixKey=a1b2c3d4-e5f6-7890-abcd-ef1234567890 accountId=acc_9f8e7d6c5b4a3210 processado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-ausente.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-ausente.esperado.json
@@ -1,0 +1,2 @@
+{"body":"transacao concluida sem dados pessoais","categoria":"ausencia",
+"descricao":"Sem campo de nome: nada deve mudar"}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-ausente.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-ausente.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"transacao concluida sem dados pessoais"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-canonico.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-canonico.esperado.json
@@ -1,0 +1,2 @@
+{"body":"customerName=Joao ********** Silva criado","categoria":"formaCanonica",
+"descricao":"Nome completo: preserva primeiro e ultimo termo, mascara o meio"}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-canonico.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-canonico.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"customerName=Joao Carlos Pereira Silva criado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-forma-alternativa.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-forma-alternativa.esperado.json
@@ -1,0 +1,2 @@
+{"body":"senderName=Maria ********** Souza enviado","categoria":"formaAlternativa",
+"descricao":"Nome de DOIS termos (sem meio). Verifica se a regra lida com o caso minimo."}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-forma-alternativa.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-forma-alternativa.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"senderName=Maria Souza enviado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-preservacao-fragmento.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-preservacao-fragmento.esperado.json
@@ -1,0 +1,2 @@
+{"body":"recipientName=Ana ********** Lima ok","categoria":"preservacaoDeFragmento",
+"descricao":"Ana e Lima DEVEM aparecer. Se sair $1 ou $2 literal, ou vazio, a regra esta errada."}

--- a/charts/alloy-lerian/sanitizacao/casos/nome-preservacao-fragmento.json
+++ b/charts/alloy-lerian/sanitizacao/casos/nome-preservacao-fragmento.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"recipientName=Ana Beatriz Costa Lima ok"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/risco-falso-positivo.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/risco-falso-positivo.esperado.json
@@ -1,0 +1,3 @@
+{"body":"latencia 123********234 ns e transactionId=987********876543210",
+"categoria":"riscoFalsoPositivo",
+"descricao":"COMPORTAMENTO REAL DOCUMENTADO, nao desejado: a regra de 11 digitos mascara qualquer sequencia numerica longa (latencia, id de transacao). Trade-off aceito: falso positivo (perde legibilidade de diagnostico) e preferivel a falso negativo (vaza documento). Alternativa avaliada: exigir prefixo de campo — rejeitada porque documento aparece em log sem prefixo."}

--- a/charts/alloy-lerian/sanitizacao/casos/risco-falso-positivo.json
+++ b/charts/alloy-lerian/sanitizacao/casos/risco-falso-positivo.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"latencia 12345678901234 ns e transactionId=98765432109876543210"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-ausente.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-ausente.esperado.json
@@ -1,0 +1,1 @@
+{"body":"notificacao enviada por push","categoria":"ausencia","descricao":"Sem telefone: nada muda"}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-ausente.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-ausente.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"notificacao enviada por push"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-canonico.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-canonico.esperado.json
@@ -1,0 +1,2 @@
+{"body":"phone=+5511******** confirmado","categoria":"formaCanonica",
+"descricao":"E.164: preserva pais (+55) e DDD (11), mascara os 9 digitos do numero"}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-canonico.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-canonico.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"phone=+5511987654321 confirmado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-forma-alternativa.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-forma-alternativa.esperado.json
@@ -1,0 +1,2 @@
+{"body":"contato (11) *****-**** registrado","categoria":"formaAlternativa",
+"descricao":"Forma nacional com parenteses e hifen. Preserva DDD."}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-forma-alternativa.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-forma-alternativa.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"contato (11) 98765-4321 registrado"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-preservacao-fragmento.esperado.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-preservacao-fragmento.esperado.json
@@ -1,0 +1,2 @@
+{"body":"mobile=+5521******** ok","categoria":"preservacaoDeFragmento",
+"descricao":"+5521 DEVE aparecer. Se sair $1 literal ou vazio, a regra esta errada."}

--- a/charts/alloy-lerian/sanitizacao/casos/telefone-preservacao-fragmento.json
+++ b/charts/alloy-lerian/sanitizacao/casos/telefone-preservacao-fragmento.json
@@ -1,0 +1,3 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"caso-sanitizacao"}}]},
+"scopeLogs":[{"logRecords":[{"timeUnixNano":"1700000000000000000","severityNumber":9,"severityText":"INFO",
+"body":{"stringValue":"mobile=+5521912345678 ok"}}]}]}]}

--- a/charts/alloy-lerian/sanitizacao/porta-de-entrega.sh
+++ b/charts/alloy-lerian/sanitizacao/porta-de-entrega.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# PORTA DE ENTREGA — sanitizacao de dado regulado.
+#
+# Bloqueia a entrega quando qualquer regra de sanitizacao falha, ou quando
+# alguma regra nao tem cobertura de teste completa.
+#
+# Por que e bloqueante e nao advertencia: em producao as regras rodam com
+# error_mode "ignore". Regra malformada NAO gera erro — produz saida que
+# aparenta estar mascarada (verificado: a notacao $$1 emite "$1***" literal,
+# sem qualquer aviso). Uma advertencia aqui seria ignorada e o dado vazaria.
+#
+# Uso:  ./porta-de-entrega.sh
+# Saida: 0 = liberado. Diferente de 0 = BLOQUEADO.
+set -euo pipefail
+
+RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BLOQUEIOS=0
+
+erro() { echo "  ✗ $*"; BLOQUEIOS=$((BLOQUEIOS+1)); }
+ok()   { echo "  ✓ $*"; }
+
+# Extrai apenas as LINHAS DE CODIGO das regras, descartando comentarios.
+# Necessario porque os comentarios documentam justamente as construcoes
+# proibidas (ex: "NUNCA $$1", "falha com (?!") — inspecionar o arquivo cru
+# produziria falso positivo em toda execucao.
+codigo_das_regras() {
+  grep -vE '^[[:space:]]*//' "${RAIZ}/regras.alloy"
+}
+
+echo "=============================================="
+echo " PORTA DE ENTREGA — sanitizacao"
+echo "=============================================="
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "[1/6] Regras usam a notacao de retrovinculacao verificada"
+# ---------------------------------------------------------------------------
+# A notacao correta e $1. A incorreta ($$1) emite texto literal SEM erro.
+if codigo_das_regras | grep -q '\$\$[0-9]'; then
+  erro "encontrada notacao \$\$N — a correta e \$N (ver EVIDENCIA-retrovinculacao.md)"
+  codigo_das_regras | grep -n '\$\$[0-9]' | sed 's/^/      /'
+else
+  ok "nenhuma ocorrencia de \$\$N"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "[2/6] Nenhuma funcao editora aninhada em set()"
+# ---------------------------------------------------------------------------
+# replace_pattern e funcao EDITORA: aninhar em set() falha na CARGA.
+if codigo_das_regras | grep -qE 'set\([^)]*\b(replace_pattern|replace_all_patterns|delete_key)\('; then
+  erro "funcao editora aninhada em set() — falha na carga do agente"
+  codigo_das_regras | grep -nE 'set\([^)]*\b(replace_pattern|replace_all_patterns|delete_key)\(' | sed 's/^/      /'
+else
+  ok "nenhum aninhamento indevido"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "[3/6] Nenhuma construcao de regex nao suportada"
+# ---------------------------------------------------------------------------
+# O motor desta versao nao suporta lookahead nem lookbehind (falha na CARGA).
+if codigo_das_regras | grep -qE '\(\?[=!<]'; then
+  erro "lookahead/lookbehind encontrado — nao suportado pelo motor de regex"
+  codigo_das_regras | grep -nE '\(\?[=!<]' | sed 's/^/      /'
+else
+  ok "nenhuma construcao nao suportada"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "[4/6] Cobertura: cada classe tem as 4 categorias obrigatorias"
+# ---------------------------------------------------------------------------
+CLASSES=(documento nome email telefone chavepgto endereco idopaco)
+CATEGORIAS=(canonico forma-alternativa ausente preservacao-fragmento)
+
+for classe in "${CLASSES[@]}"; do
+  faltando=()
+  for cat in "${CATEGORIAS[@]}"; do
+    if [ ! -f "${RAIZ}/casos/${classe}-${cat}.json" ] || \
+       [ ! -f "${RAIZ}/casos/${classe}-${cat}.esperado.json" ]; then
+      faltando+=("$cat")
+    fi
+  done
+  if [ ${#faltando[@]} -gt 0 ]; then
+    erro "classe '${classe}' sem as categorias: ${faltando[*]}"
+  else
+    ok "classe '${classe}': 4/4 categorias"
+  fi
+done
+
+# A categoria de preservacao de fragmento e a UNICA que detecta notacao errada.
+# Verifica que o esperado dessas categorias NAO contem notacao literal.
+for f in "${RAIZ}"/casos/*-preservacao-fragmento.esperado.json; do
+  [ -e "$f" ] || continue
+  # Le APENAS o campo body — o campo descricao menciona a notacao de proposito.
+  if jq -r '.body' "$f" | grep -qE '\$[0-9]'; then
+    erro "$(basename "$f"): o campo body contem notacao \$N — deve conter o FRAGMENTO, nao a notacao"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "[5/6] Todos os casos passam contra o agente real"
+# ---------------------------------------------------------------------------
+if [ ! -x "${RAIZ}/verificar.sh" ]; then
+  erro "verificar.sh ausente ou nao executavel"
+else
+  saida_verif="$("${RAIZ}/verificar.sh" 2>&1)" && resultado=0 || resultado=$?
+  linha_final="$(printf '%s' "$saida_verif" | tail -1)"
+  if [ "$resultado" -eq 0 ]; then
+    ok "${linha_final}"
+  else
+    erro "verificacao falhou: ${linha_final}"
+    printf '%s' "$saida_verif" | grep -A3 '^FALHA' | sed 's/^/      /'
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+echo ""
+echo "[6/6] Regras do arcabouco identicas as do template do chart"
+# ---------------------------------------------------------------------------
+# Sem isto o arcabouco poderia validar um conjunto de regras enquanto producao
+# usa outro: o teste passaria e o dado vazaria.
+TEMPLATE="${RAIZ}/../templates/_sanitizacao.tpl"
+extrai() { grep -oE 'replace_pattern\(body, "[^"]+", "[^"]*"\)' "$1" | sort; }
+if [ ! -f "$TEMPLATE" ]; then
+  ok "template ausente (execucao fora do chart) - verificacao ignorada"
+elif diff -q <(extrai "$TEMPLATE") <(extrai "${RAIZ}/regras.alloy") >/dev/null 2>&1; then
+  ok "$(extrai "$TEMPLATE" | wc -l | tr -d ' ') regra(s) identicas ao template"
+else
+  erro "as regras do arcabouco DIVERGEM do template do chart"
+  diff <(extrai "$TEMPLATE") <(extrai "${RAIZ}/regras.alloy") | head -6 | sed 's/^/      /'
+fi
+
+
+echo ""
+echo "=============================================="
+if [ "$BLOQUEIOS" -eq 0 ]; then
+  echo " ✓ LIBERADO — sanitizacao verificada"
+  echo "=============================================="
+  exit 0
+else
+  echo " ✗ BLOQUEADO — ${BLOQUEIOS} verificacao(oes) falharam"
+  echo ""
+  echo " A entrega NAO pode prosseguir. Regra de sanitizacao"
+  echo " malformada nao gera erro em producao — produz saida"
+  echo " que aparenta estar mascarada."
+  echo "=============================================="
+  exit 1
+fi

--- a/charts/alloy-lerian/sanitizacao/regras.alloy
+++ b/charts/alloy-lerian/sanitizacao/regras.alloy
@@ -1,0 +1,121 @@
+// Regras de sanitizacao de dado regulado — ARCABOUCO DE VERIFICACAO
+//
+// IMPORTANTE: este arquivo e o alvo de teste, nao a configuracao de producao.
+// Diferenca deliberada: error_mode = "propagate" aqui, "ignore" em producao.
+// E justamente porque producao ignora erro que este arcabouco existe.
+//
+// Notacao de retrovinculacao: $1 (verificado empiricamente — ver
+// subtasks/T-003/EVIDENCIA-retrovinculacao.md). NUNCA $$1.
+//
+// Forma de invocacao: replace_pattern e funcao EDITORA — declaracao propria,
+// nunca aninhada em set(). Aninhar falha na carga.
+
+otelcol.receiver.otlp "entrada" {
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  output {
+    logs = [otelcol.processor.transform.sanitizacao.input]
+  }
+}
+
+otelcol.processor.transform "sanitizacao" {
+  error_mode = "propagate"
+
+  log_statements {
+    context = "log"
+    statements = [
+      // ORDEM IMPORTA: a forma pontuada vem PRIMEIRO. Se a regra de 11 digitos
+      // seguidos rodasse antes, ela nao casaria a forma pontuada (por causa dos
+      // separadores), mas a pontuada tambem nao casaria o que a primeira ja
+      // mascarou. Manter a mais especifica antes da mais geral.
+
+      // --- TELEFONE --- (ANTES do documento, ver justificativa)
+      //
+      // ORDEM CRITICA: telefone vem ANTES do documento de 11 digitos seguidos.
+      // Verificado por teste: sem isto, "+5511987654321" (13 digitos) casa a
+      // regra de documento e vira "+551********21" — mascarado, mas mascarado
+      // ERRADO: perde o DDD e preserva 2 digitos finais do numero, que e o
+      // oposto do desejado. Telefone primeiro resolve.
+      //
+      // E.164 com pais e DDD: +5511987654321 -> +5511********
+      `replace_pattern(body, "(\\+[0-9]{2}[0-9]{2})[0-9]{8,9}", "$1********")`,
+
+      // Forma nacional com separadores: (11) 98765-4321 -> (11) *****-****
+      `replace_pattern(body, "(\\([0-9]{2}\\) )[0-9]{4,5}-[0-9]{4}", "$1*****-****")`,
+
+      // Documento fiscal pontuado: 123.456.789-01 -> 123.***.***-**
+      `replace_pattern(body, "([0-9]{3})\\.[0-9]{3}\\.[0-9]{3}-[0-9]{2}", "$1.***.***-**")`,
+
+      // Documento fiscal de 11 digitos seguidos: preserva 3 primeiros, mascara 8.
+      `replace_pattern(body, "([0-9]{3})[0-9]{8}", "$1********")`,
+
+      // --- NOME DE PESSOA ---
+      // Campos de nome conhecidos: customerName, senderName, recipientName,
+      // receiverName, clientName, holderName.
+      // Preserva primeiro e ultimo termo; mascara o meio.
+      // Casa nome de 2+ termos capitalizados. Depende de convencao de caixa:
+      // termos de nome comecam em maiuscula, e o texto seguinte no log e
+      // minusculo. Isto delimita o fim do valor SEM retrovisor, que o motor
+      // de regex desta versao nao suporta.
+      //
+      // Tentativas anteriores e por que falharam (verificado por teste):
+      //  - (?: \w+)+ guloso   -> consome ate o fim, ultimo grupo vazio,
+      //                          APAGA o sobrenome (pior que nao mascarar)
+      //  - (?: \w+)*? nao-guloso -> casa o minimo, nao mascara o meio
+      // 3+ termos: primeiro + meio mascarado + ultimo. Vem ANTES da regra de
+      // 2 termos, senao esta casaria os dois primeiros e deixaria o resto exposto.
+      `replace_pattern(body, "((?:customer|sender|recipient|receiver|client|holder)Name=)([A-Z]\\w*)(?: [A-Z]\\w*)+ ([A-Z]\\w*)", "$1$2 ********** $3")`,
+
+      // Exatamente 2 termos: nao ha meio a mascarar, mas o sobrenome ainda e
+      // dado pessoal. Insere a mascara entre os dois, preservando ambos.
+      // A regra de 3+ nao casa este caso porque exige >=1 termo no meio; e como
+      // ela roda ANTES, nomes longos ja foram mascarados quando esta avalia.
+      // NAO usar lookahead: o motor de regex desta versao nao suporta
+      // (verificado — falha na CARGA com "unsupported Perl syntax: (?!").
+      `replace_pattern(body, "((?:customer|sender|recipient|receiver|client|holder)Name=)([A-Z]\\w*) ([A-Z]\\w*)", "$1$2 ********** $3")`,
+
+      // --- ENDERECO DE CORREIO ELETRONICO ---
+      // Preserva os 2 primeiros caracteres da parte local e o dominio INTEIRO.
+      // Dominio preservado de proposito: e util para diagnostico (identifica o
+      // provedor ou o cliente corporativo) e nao identifica a pessoa.
+      // Nao depende de prefixo de campo — casa qualquer email no corpo.
+      `replace_pattern(body, "([A-Za-z0-9]{2})[A-Za-z0-9._%+-]*(@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})", "$1****$2")`,
+
+      // --- CHAVE DE PAGAMENTO ---
+      // Uma chave pode assumir 4 formas: documento fiscal, telefone, correio
+      // eletronico ou identificador aleatorio (UUID). As TRES primeiras ja sao
+      // cobertas pelas regras acima, independentemente do nome do campo — nao
+      // ha regra propria para elas aqui, de proposito.
+      // Esta regra cobre apenas a forma de identificador aleatorio.
+      //
+      // Preserva o primeiro e o ultimo bloco; mascara os tres do meio.
+      // Os blocos preservados dao rastreabilidade para diagnostico sem
+      // permitir reconstruir a chave.
+      `replace_pattern(body, "([0-9a-fA-F]{8})-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-([0-9a-fA-F]{12})", "$1-****-****-****-$2")`,
+
+      // --- ENDERECO POSTAL ---
+      // Mascaramento INTEGRAL: nao ha parte do endereco que seja segura preservar.
+      // Ao contrario do email (dominio) ou telefone (DDD), qualquer fragmento de
+      // endereco reduz drasticamente o espaco de busca da pessoa.
+      // Delimita o fim do valor pela convencao de caixa: o valor comeca em
+      // maiuscula e o texto seguinte do log e minusculo (mesma premissa da
+      // regra de nome — ver README, secao de premissas).
+      `replace_pattern(body, "((?:address|street|logradouro|endereco)[=:] ?)[A-Z][^=]*?(?: [a-z]+=|$)", "$1**********")`,
+
+      // --- IDENTIFICADOR OPACO DE RECURSO ---
+      // Preserva o prefixo semantico e os 4 primeiros caracteres — suficiente
+      // para correlacionar registros do mesmo recurso em diagnostico, sem
+      // permitir reconstruir o identificador.
+      `replace_pattern(body, "((?:acc|txn|cus|ord)_[0-9a-zA-Z]{4})[0-9a-zA-Z]{4,}", "$1******")`,
+    ]
+  }
+
+  output {
+    logs = [otelcol.exporter.debug.saida.input]
+  }
+}
+
+otelcol.exporter.debug "saida" {
+  verbosity = "detailed"
+}

--- a/charts/alloy-lerian/sanitizacao/verificar.sh
+++ b/charts/alloy-lerian/sanitizacao/verificar.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Verifica regras de sanitizacao: injeta entrada conhecida, compara saida com a esperada.
+#
+# Por que este arcabouco existe: em producao as regras rodam com error_mode "ignore".
+# Uma regra malformada NAO gera erro — produz saida que aparenta estar mascarada.
+# Verificado empiricamente: $$1 emite o texto literal "$1***" sem qualquer aviso.
+# Logo, a unica verificacao valida e comparar a saida observada com a esperada.
+#
+# Uso: ./verificar.sh                    (todos os casos)
+#      ./verificar.sh documento-canonico (um caso)
+set -euo pipefail
+
+RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGEM="grafana/alloy:v1.18.1"
+CONTEINER="alloy-verificacao-sanitizacao"
+PORTA="${PORTA:-4318}"
+FALHAS=0
+TOTAL=0
+
+limpar() {
+  docker rm -f "$CONTEINER" >/dev/null 2>&1 || true
+}
+trap limpar EXIT
+
+# --stability.level=experimental e necessario APENAS por causa do exportador de
+# depuracao, usado para inspecionar a saida neste arcabouco. A configuracao de
+# producao nao usa componente abaixo de GA.
+echo "== subindo agente ($IMAGEM) =="
+limpar
+docker run -d --name "$CONTEINER" \
+  -p "${PORTA}:4318" \
+  -v "${RAIZ}/regras.alloy:/etc/alloy/config.alloy:ro" \
+  "$IMAGEM" run \
+    --server.http.listen-addr=0.0.0.0:12345 \
+    --stability.level=experimental \
+    /etc/alloy/config.alloy >/dev/null
+
+# Espera por CONDICAO (receptor aceitando), nunca por tempo fixo.
+pronto=0
+for _ in $(seq 1 40); do
+  estado=$(docker inspect "$CONTEINER" --format '{{.State.Status}}' 2>/dev/null || echo "ausente")
+  if [ "$estado" != "running" ]; then
+    echo "FALHA: o agente nao subiu (estado: $estado). Erro de carga:"
+    docker logs "$CONTEINER" 2>&1 | grep -A6 'Error:' | head -20
+    exit 1
+  fi
+  if curl -s -o /dev/null --max-time 2 -X POST "http://localhost:${PORTA}/v1/logs" \
+      -H 'Content-Type: application/json' --data '{}' 2>/dev/null; then
+    pronto=1; break
+  fi
+  sleep 0.5
+done
+[ "$pronto" -eq 1 ] || { echo "FALHA: receptor nao respondeu no prazo"; exit 1; }
+
+# Selecao de casos
+if [ "$#" -gt 0 ]; then
+  selecionados=("$@")
+else
+  mapfile -t selecionados < <(find "${RAIZ}/casos" -name '*.json' ! -name '*.esperado.json' \
+    -printf '%f\n' | sed 's/\.json$//' | sort)
+fi
+
+for caso in "${selecionados[@]}"; do
+  TOTAL=$((TOTAL+1))
+  entrada="${RAIZ}/casos/${caso}.json"
+  esperado="${RAIZ}/casos/${caso}.esperado.json"
+
+  if [ ! -f "$entrada" ] || [ ! -f "$esperado" ]; then
+    echo "FALHA [${caso}]: falta arquivo de entrada ou de saida esperada"
+    FALHAS=$((FALHAS+1)); continue
+  fi
+
+  linhas_antes=$(docker logs "$CONTEINER" 2>&1 | wc -l)
+
+  curl -s -o /dev/null -X POST "http://localhost:${PORTA}/v1/logs" \
+    -H 'Content-Type: application/json' --data-binary "@${entrada}"
+
+  # Espera a saida crescer, por condicao.
+  for _ in $(seq 1 25); do
+    [ "$(docker logs "$CONTEINER" 2>&1 | wc -l)" -gt "$linhas_antes" ] && break
+    sleep 0.3
+  done
+
+  saida=$(docker logs "$CONTEINER" 2>&1 | tail -n +$((linhas_antes+1)))
+  corpo_esperado=$(jq -r '.body' "$esperado")
+
+  if printf '%s' "$saida" | grep -qF "$corpo_esperado"; then
+    echo "OK    [${caso}]"
+  else
+    echo "FALHA [${caso}]"
+    echo "  esperado: ${corpo_esperado}"
+    echo "  observado:"
+    printf '%s' "$saida" | grep -oE 'Body: Str\([^)]*\)' | head -3 | sed 's/^/    /' \
+      || echo "    (nenhuma linha de corpo na saida)"
+    FALHAS=$((FALHAS+1))
+  fi
+done
+
+echo "== ${TOTAL} caso(s), ${FALHAS} falha(s) =="
+[ "$FALHAS" -eq 0 ]

--- a/charts/alloy-lerian/templates/_config.tpl
+++ b/charts/alloy-lerian/templates/_config.tpl
@@ -1,0 +1,358 @@
+{{/*
+==============================================================================
+COLLECTION PIPELINE — rendered, not configured
+==============================================================================
+The processing chain is NOT part of the values surface. Consumers declare
+semantic intent (profile, origin, destination, interval) and this template
+derives the wiring.
+
+Why the chain is closed: in this agent components form a graph through
+`output` references, not an ordered list. Swapping two stages produces no
+error — it produces telemetry without enrichment, silently. Three ordering
+constraints in this file were each verified by deliberately breaking them.
+
+Verified empirically against the pinned agent version (see the sanitisation
+evidence in the pre-dev artefacts):
+
+  - backreference notation is $1, never $$1. The wrong form emits the literal
+    text with no error and output that looks masked
+  - replace_pattern is an EDITOR function: its own statement, never nested in
+    set(). Nesting fails at load
+  - the regex engine has no lookahead or lookbehind. Using either fails at load
+*/}}
+
+{{/*
+Per-node role: receives application telemetry pushed over the standard
+protocol, sanitises it, and forwards it.
+*/}}
+{{- define "alloy-lerian.config.node" -}}
+{{- $origin := include "alloy-lerian.originId" . -}}
+{{- $authenticated := eq (include "alloy-lerian.destinationAuthenticated" .) "true" -}}
+// Managed by the alloy-lerian chart. Do not edit in place: the chart renders
+// this file from semantic parameters, and manual edits are lost on upgrade.
+
+logging {
+  level  = {{ .Values.logging.level | default "info" | quote }}
+  format = "logfmt"
+}
+
+{{ if eq (include "alloy-lerian.livedebugEnabled" .) "true" -}}
+// Enabled only in the own profile. Streams raw pipeline payloads.
+livedebugging {
+  enabled = true
+}
+{{ end -}}
+
+otelcol.receiver.otlp "entrada" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+{{- if .Values.receiver.preserveLegacyTimeouts }}
+    // Restores the pre-v1.18.0 behaviour of no timeout. Set only for an
+    // application with long-lived connections that the new defaults cut.
+    idle_timeout       = "0s"
+    read_header_timeout = "0s"
+    write_timeout       = "0s"
+{{- end }}
+  }
+
+  output {
+    metrics = [otelcol.processor.memory_limiter.admissao.input]
+    logs    = [otelcol.processor.memory_limiter.admissao.input]
+    traces  = [otelcol.processor.memory_limiter.admissao.input]
+  }
+}
+
+// STAGE 1 — admission control. Must be first: it sheds load before anything
+// downstream allocates for it.
+otelcol.processor.memory_limiter "admissao" {
+  check_interval         = "1s"
+  limit_percentage       = 80
+  spike_limit_percentage = 20
+
+  output {
+    metrics = [otelcol.processor.k8sattributes.contexto.input]
+    logs    = [otelcol.processor.k8sattributes.contexto.input]
+    traces  = [otelcol.processor.k8sattributes.contexto.input]
+  }
+}
+
+// STAGE 2 — context enrichment. Must precede batching: the connection-based
+// association path reads the peer address, which batching discards. Getting
+// this wrong yields telemetry with no pod attribution and NO error.
+//
+// Two tiers, first match wins. The resource-attribute tier is preferred; the
+// connection tier exists because not every application declares k8s.pod.ip.
+otelcol.processor.k8sattributes "contexto" {
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.ip"
+    }
+  }
+  pod_association {
+    source {
+      from = "connection"
+    }
+  }
+
+  extract {
+    metadata = [
+      "k8s.namespace.name",
+      "k8s.pod.name",
+      "k8s.deployment.name",
+      "k8s.container.name",
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.transform.procedencia.input]
+    logs    = [otelcol.processor.transform.procedencia.input]
+    traces  = [otelcol.processor.transform.procedencia.input]
+  }
+}
+
+// STAGE 3 — origin marking. Assigned once, at the edge. Reassigning downstream
+// would mask the real origin.
+//
+// Note: this marks provenance, not identity. The credential authenticates the
+// sender; the marker is self-declared, so an authenticated origin could claim
+// another's identifier. Out of scope by decision, recorded as a known limit.
+otelcol.processor.transform "procedencia" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context    = "resource"
+    statements = [`set(attributes["client.id"], {{ $origin | quote }})`]
+  }
+  metric_statements {
+    context    = "resource"
+    statements = [`set(attributes["client.id"], {{ $origin | quote }})`]
+  }
+  log_statements {
+    context    = "resource"
+    statements = [`set(attributes["client.id"], {{ $origin | quote }})`]
+  }
+
+  output {
+    metrics = [otelcol.processor.filter.perimetro.input]
+    logs    = [otelcol.processor.filter.perimetro.input]
+    traces  = [otelcol.processor.filter.perimetro.input]
+  }
+}
+
+// STAGE 4 — perimeter. Discards what is outside the observed scope, before
+// sanitisation: no point sanitising what will be dropped.
+otelcol.processor.filter "perimetro" {
+  error_mode = "ignore"
+
+{{- $ns := .Values.collection.namespaces }}
+{{- if $ns.include }}
+  metrics {
+    datapoint = [
+      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.include | quote }})`,
+    ]
+  }
+  logs {
+    log_record = [
+      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.include | quote }})`,
+    ]
+  }
+  traces {
+    span = [
+      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.include | quote }})`,
+    ]
+  }
+{{- else if $ns.exclude }}
+  metrics {
+    datapoint = [
+      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.exclude | quote }})`,
+    ]
+  }
+  logs {
+    log_record = [
+      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.exclude | quote }})`,
+    ]
+  }
+  traces {
+    span = [
+      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.exclude | quote }})`,
+    ]
+  }
+{{- end }}
+
+  output {
+    metrics = [otelcol.processor.filter.ruido.input]
+    logs    = [otelcol.processor.filter.ruido.input]
+    traces  = [otelcol.processor.filter.ruido.input]
+  }
+}
+
+// STAGE 5 — volume reduction at the edge. Health probe traffic carries no
+// diagnostic value and its removal is also what the organisation's SRE
+// standard requires of applications.
+otelcol.processor.filter "ruido" {
+  error_mode = "ignore"
+
+  traces {
+    span = [
+      `IsMatch(attributes["http.route"], "^/(health|healthz|readyz|ready|livez|live|ping|metrics)$")`,
+      `IsMatch(attributes["url.path"], "^/(health|healthz|readyz|ready|livez|live|ping|metrics)$")`,
+    ]
+  }
+{{- if .Values.collection.dropDebugLogs }}
+  logs {
+    // Severity below INFO. Records with no severity are NOT dropped: absence
+    // of the field is not evidence of low value.
+    log_record = [
+      `severity_number != SEVERITY_NUMBER_UNSPECIFIED and severity_number < SEVERITY_NUMBER_INFO`,
+    ]
+  }
+{{- end }}
+
+  output {
+    metrics = [otelcol.processor.batch.agrupamento.input]
+    logs    = [otelcol.processor.transform.sanitizacao.input]
+    traces  = [otelcol.processor.batch.agrupamento.input]
+  }
+}
+
+// STAGE 6 — SANITISATION. Regulated data never leaves the origin cluster
+// unmasked. Logs only: this is where free-text bodies carry it.
+//
+// error_mode is "ignore" so a malformed rule cannot halt the pipeline — which
+// is exactly why correctness cannot depend on this mechanism reporting failure.
+// The delivery gate asserts each rule against a known input and expected
+// output, and blocks release on mismatch.
+{{ include "alloy-lerian.config.sanitizacao" . }}
+
+// STAGE 7 — batching. Must be last: enrichment operates on individual records,
+// and batching destroys the connection context stage 2 depends on.
+otelcol.processor.batch "agrupamento" {
+  timeout             = "200ms"
+  send_batch_size     = 512
+  send_batch_max_size = 1024
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.destino.input]
+    logs    = [otelcol.exporter.otlphttp.destino.input]
+    traces  = [otelcol.exporter.otlphttp.destino.input]
+  }
+}
+
+// EXIT — to the central concentrator. Queue and retry are mandatory: without
+// them any blip in the destination is definitive, unrecorded loss.
+//
+// Retry classification is by status code and is NOT symmetric: 429/502/503/504
+// are retryable, everything else is permanent and discarded immediately. So a
+// rejected credential (401/403) causes continuous silent loss, not a growing
+// queue — which is why permanent discard is alerted separately.
+otelcol.exporter.otlphttp "destino" {
+  client {
+    endpoint = {{ include "alloy-lerian.destinationEndpoint" . | quote }}
+{{- if $authenticated }}
+    headers = {
+      "x-api-key" = sys.env("ALLOY_DESTINATION_CREDENTIAL"),
+    }
+{{- end }}
+  }
+
+  sending_queue {
+    enabled       = true
+    queue_size    = {{ .Values.destination.queue.size | default 1000 }}
+    num_consumers = {{ .Values.destination.queue.consumers | default 10 }}
+    // Not blocking on overflow: back-pressure would propagate to the client's
+    // applications, which is not ours to impose.
+    block_on_overflow = false
+  }
+
+  retry_on_failure {
+    enabled          = true
+    initial_interval = "5s"
+    max_interval     = "30s"
+    max_elapsed_time = {{ .Values.destination.retry.maxElapsedTime | default "5m" | quote }}
+  }
+}
+{{- end -}}
+
+
+{{/*
+Single-replica role: observes cluster-scope state.
+
+Exactly one replica. More than one duplicates: the same events are written by
+each instance with no attribute distinguishing the writers. The upstream
+project's own reference chart keeps a dedicated singleton role for this reason.
+*/}}
+{{- define "alloy-lerian.config.singleton" -}}
+{{- $origin := include "alloy-lerian.originId" . -}}
+{{- $authenticated := eq (include "alloy-lerian.destinationAuthenticated" .) "true" -}}
+{{- $interval := include "alloy-lerian.interval" . -}}
+// Managed by the alloy-lerian chart. Single-replica role: cluster-scope state.
+
+logging {
+  level  = {{ .Values.logging.level | default "info" | quote }}
+  format = "logfmt"
+}
+
+{{ if index .Values "kube-state-metrics" "enabled" -}}
+// Cluster-object metrics, scraped from the dedicated producer. Single writer by
+// construction: the producer runs one replica, so this scrape cannot duplicate
+// regardless of how many agents exist.
+//
+// Interval is enforced at or above the 60s floor. Collecting faster than anyone
+// queries wastes CPU here, bandwidth on the wire and processing at the
+// destination — and the cost at the destination is series x writes per minute.
+prometheus.scrape "objetos_de_cluster" {
+  targets = [{
+    __address__ = {{ printf "%s-kube-state-metrics.%s.svc.cluster.local:8080" .Release.Name .Release.Namespace | quote }},
+  }]
+  scrape_interval = {{ $interval | quote }}
+  forward_to      = [prometheus.relabel.procedencia.receiver]
+}
+
+// Origin marking for the scraped series.
+prometheus.relabel "procedencia" {
+  rule {
+    target_label = "client_id"
+    replacement  = {{ $origin | quote }}
+  }
+  forward_to = [prometheus.remote_write.destino.receiver]
+}
+
+prometheus.remote_write "destino" {
+  endpoint {
+    url = {{ printf "%s/api/v1/push" (trimSuffix "/" (include "alloy-lerian.destinationEndpoint" .)) | quote }}
+{{- if $authenticated }}
+    headers = {
+      "x-api-key" = sys.env("ALLOY_DESTINATION_CREDENTIAL"),
+    }
+{{- end }}
+  }
+}
+{{ end -}}
+
+// Cluster lifecycle events. Watching all namespaces, so clustering would
+// degrade to a single collecting node anyway — the singleton deployment is the
+// explicit form of the same guarantee.
+loki.source.kubernetes_events "eventos" {
+  log_format = "logfmt"
+  forward_to = [loki.write.destino.receiver]
+}
+
+loki.write "destino" {
+  endpoint {
+    url = {{ printf "%s/loki/api/v1/push" (trimSuffix "/" (include "alloy-lerian.destinationEndpoint" .)) | quote }}
+{{- if $authenticated }}
+    headers = {
+      "x-api-key" = sys.env("ALLOY_DESTINATION_CREDENTIAL"),
+    }
+{{- end }}
+  }
+
+  external_labels = {
+    client_id = {{ $origin | quote }},
+  }
+}
+{{- end -}}

--- a/charts/alloy-lerian/templates/_config.tpl
+++ b/charts/alloy-lerian/templates/_config.tpl
@@ -148,37 +148,38 @@ otelcol.processor.transform "procedencia" {
 otelcol.processor.filter "perimetro" {
   error_mode = "ignore"
 
-{{- $ns := .Values.collection.namespaces }}
-{{- if $ns.include }}
+{{- $nsInclude := include "alloy-lerian.namespaceInclude" . }}
+{{- $nsExclude := include "alloy-lerian.namespaceExclude" . }}
+{{- if $nsInclude }}
   metrics {
     datapoint = [
-      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.include | quote }})`,
+      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $nsInclude | quote }})`,
     ]
   }
   logs {
     log_record = [
-      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.include | quote }})`,
+      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $nsInclude | quote }})`,
     ]
   }
   traces {
     span = [
-      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.include | quote }})`,
+      `resource.attributes["k8s.namespace.name"] == nil or not IsMatch(resource.attributes["k8s.namespace.name"], {{ $nsInclude | quote }})`,
     ]
   }
-{{- else if $ns.exclude }}
+{{- else if $nsExclude }}
   metrics {
     datapoint = [
-      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.exclude | quote }})`,
+      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $nsExclude | quote }})`,
     ]
   }
   logs {
     log_record = [
-      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.exclude | quote }})`,
+      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $nsExclude | quote }})`,
     ]
   }
   traces {
     span = [
-      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $ns.exclude | quote }})`,
+      `IsMatch(resource.attributes["k8s.namespace.name"], {{ $nsExclude | quote }})`,
     ]
   }
 {{- end }}

--- a/charts/alloy-lerian/templates/_helpers.tpl
+++ b/charts/alloy-lerian/templates/_helpers.tpl
@@ -264,5 +264,7 @@ thing and are collected in both profiles — those describe workloads we operate
 {{- if and $requested (eq (include "alloy-lerian.profile" .) "client") -}}
 {{- fail "\n\nalloy-lerian: `collection.nodeInfrastructure` is not available in the client profile.\n\nNode CPU, memory and filesystem describe the host, which belongs to the client.\nWe have no standing to act on it, and it would cross the public network for no\nreturn.\n\nCluster-object metrics (pod phase, deployment state, autoscaler) are collected\nin both profiles — those describe workloads we operate.\n" -}}
 {{- end -}}
-{{- ternary "true" "false" $requested -}}
+{{/* Emits NOTHING. An assertion helper that returns a value gets that value
+     written into the manifest by the call site — which produced
+     "falseapiVersion: v1" and made every render invalid YAML. */}}
 {{- end -}}

--- a/charts/alloy-lerian/templates/_helpers.tpl
+++ b/charts/alloy-lerian/templates/_helpers.tpl
@@ -208,3 +208,61 @@ alloy-lerian-node
 {{- define "alloy-lerian.singletonConfigMapName" -}}
 alloy-lerian-singleton
 {{- end -}}
+
+
+{{/*
+==============================================================================
+NAMESPACE PERIMETER — derived from the profile
+==============================================================================
+The client installs this chart, so it should fill in as little as possible.
+The perimeter is one of the things that differs between profiles, and the
+difference is not a preference:
+
+  client  collect ONLY the namespaces we operate. Everything else in that
+          cluster belongs to the client and is none of our business — and it
+          would cross the public network for no return.
+  own     collect everything except cluster plumbing. The whole cluster is ours.
+
+Overridable, but the default is correct for each profile so the common case
+needs no value at all.
+*/}}
+{{- define "alloy-lerian.namespaceInclude" -}}
+{{- $ns := (.Values.collection).namespaces | default dict -}}
+{{- if $ns.include -}}
+{{- $ns.include -}}
+{{- else if eq (include "alloy-lerian.profile" .) "client" -}}
+^(midaz|midaz-plugins)$
+{{- end -}}
+{{- end -}}
+
+{{- define "alloy-lerian.namespaceExclude" -}}
+{{- $ns := (.Values.collection).namespaces | default dict -}}
+{{- if $ns.exclude -}}
+{{- $ns.exclude -}}
+{{- else if eq (include "alloy-lerian.profile" .) "own" -}}
+^(kube-system|kube-public|kube-node-lease)$
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+==============================================================================
+NODE INFRASTRUCTURE — own profile only, enforced
+==============================================================================
+Node CPU, memory and filesystem come from the kubelet, which is a different
+source from the cluster-object producer. Not collected today in either profile.
+
+The guard exists so that enabling it later cannot silently reach the client
+profile: the node belongs to the client, and collecting it asks for data we have
+no standing to act on.
+
+Cluster-OBJECT metrics (pod phase, deployment state, autoscaler) are a different
+thing and are collected in both profiles — those describe workloads we operate.
+*/}}
+{{- define "alloy-lerian.assertNodeInfra" -}}
+{{- $requested := (.Values.collection).nodeInfrastructure | default false -}}
+{{- if and $requested (eq (include "alloy-lerian.profile" .) "client") -}}
+{{- fail "\n\nalloy-lerian: `collection.nodeInfrastructure` is not available in the client profile.\n\nNode CPU, memory and filesystem describe the host, which belongs to the client.\nWe have no standing to act on it, and it would cross the public network for no\nreturn.\n\nCluster-object metrics (pod phase, deployment state, autoscaler) are collected\nin both profiles — those describe workloads we operate.\n" -}}
+{{- end -}}
+{{- ternary "true" "false" $requested -}}
+{{- end -}}

--- a/charts/alloy-lerian/templates/_helpers.tpl
+++ b/charts/alloy-lerian/templates/_helpers.tpl
@@ -1,0 +1,178 @@
+{{/*
+Naming and labels.
+*/}}
+{{- define "alloy-lerian.name" -}}
+{{- default "alloy-lerian" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alloy-lerian.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "alloy-lerian.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "alloy-lerian.labels" -}}
+app.kubernetes.io/name: {{ include "alloy-lerian.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: alloy-lerian
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+
+{{/*
+==============================================================================
+PROFILE — validation and derivation
+==============================================================================
+The profile boundary is operational responsibility, not convenience:
+
+  own     the node is ours, so host capacity and scheduling are our concern
+  client  the node belongs to the client; collecting it asks for data we have
+          no standing to act on, and adds traffic across the public network
+
+Not inferable, no default. Inferring from a cluster property would silently
+produce the wrong profile in the ambiguous case.
+*/}}
+{{- define "alloy-lerian.profile" -}}
+{{- $p := .Values.profile | default "" -}}
+{{- if not $p -}}
+{{- fail "\n\nalloy-lerian: `profile` is required and has no default.\n\n  profile: own     # our own environment — collects node infrastructure\n  profile: client  # client cluster — does NOT collect node infrastructure\n\nThe distinction is operational responsibility, not preference.\n" -}}
+{{- end -}}
+{{- if not (has $p (list "own" "client")) -}}
+{{- fail (printf "\n\nalloy-lerian: unknown profile %q. Valid values: own, client.\n" $p) -}}
+{{- end -}}
+{{- $p -}}
+{{- end -}}
+
+{{/*
+Whether node infrastructure telemetry is collected. Derived from the profile,
+never configurable on its own — that would let the boundary drift.
+*/}}
+{{- define "alloy-lerian.collectsNodeInfra" -}}
+{{- eq (include "alloy-lerian.profile" .) "own" -}}
+{{- end -}}
+
+
+{{/*
+==============================================================================
+ORIGIN IDENTIFIER — required, canonical form
+==============================================================================
+Deliberately has NO default. The current collector chart ships a default that
+violates its own schema, which is why it cannot render with its own values.
+
+Canonical form accepts hyphenated composition: the earlier pattern rejected
+legitimate identifiers already in use (`lazari-sandbox-prd`, `pix-switch-prd`).
+
+Absence and malformation are DISTINCT errors. The current schema only detects
+the second, so an omitted identifier passes silently — and telemetry arrives
+at the destination with no owner.
+*/}}
+{{- define "alloy-lerian.originId" -}}
+{{- $id := .Values.origin.id | default "" -}}
+{{- if not $id -}}
+{{- fail "\n\nalloy-lerian: `origin.id` is required and has no default.\n\nIt marks every record with the environment it came from. Without it,\ntelemetry reaches the destination unattributable.\n\n  origin:\n    id: acme-prd\n\nForm: lowercase segments separated by hyphens, ending in a stage segment\n      (stg | hml | prd), or one of the reserved own-environment names.\n" -}}
+{{- end -}}
+{{- $reserved := list "aws-production" "aws-staging" "aws-devops" "benedita" "anacleto" -}}
+{{- if not (has $id $reserved) -}}
+{{- if not (regexMatch "^[a-z0-9]+(-[a-z0-9]+)*-(stg|hml|prd)$" $id) -}}
+{{- fail (printf "\n\nalloy-lerian: origin.id %q is malformed.\n\nExpected lowercase segments separated by hyphens, ending in stg, hml or prd\n(for example: acme-prd, lazari-sandbox-prd), or a reserved own-environment\nname: %s\n" $id (join ", " $reserved)) -}}
+{{- end -}}
+{{- end -}}
+{{- $id -}}
+{{- end -}}
+
+
+{{/*
+==============================================================================
+COLLECTION INTERVAL — floor enforced, never silently adjusted
+==============================================================================
+Cost on the telemetry platform is a function of series x writes per minute.
+Collecting faster than anyone queries wastes CPU in the client cluster,
+bandwidth across the public network and processing at the destination.
+
+A value below the floor is REJECTED, not clamped. Clamping would hide the
+divergent intent of whoever configured it.
+*/}}
+{{- define "alloy-lerian.interval" -}}
+{{- $i := .Values.collection.interval | default "60s" -}}
+{{- $seconds := 0 -}}
+{{- if regexMatch "^[0-9]+s$" $i -}}
+{{-   $seconds = $i | trimSuffix "s" | int -}}
+{{- else if regexMatch "^[0-9]+m$" $i -}}
+{{-   $seconds = mul ($i | trimSuffix "m" | int) 60 -}}
+{{- else -}}
+{{-   fail (printf "\n\nalloy-lerian: collection.interval %q is malformed. Use a duration such as 60s or 5m.\n" $i) -}}
+{{- end -}}
+{{- if lt $seconds 60 -}}
+{{- fail (printf "\n\nalloy-lerian: collection.interval %q is below the 60s floor.\n\nThe value is rejected rather than adjusted, so the divergent intent is\nvisible instead of silently corrected.\n" $i) -}}
+{{- end -}}
+{{- $i -}}
+{{- end -}}
+
+
+{{/*
+==============================================================================
+DESTINATION — reference to a Secret, never a literal
+==============================================================================
+The credential lives in the origin cluster Secret, provisioned before install
+by the onboarding process. The chart only reads it.
+
+Registered in the repository's out-of-band secret allowlist, so the render
+gate does not flag it as a dangling reference.
+*/}}
+{{- define "alloy-lerian.destinationEndpoint" -}}
+{{- $e := .Values.destination.endpoint | default "" -}}
+{{- if not $e -}}
+{{- fail "\n\nalloy-lerian: `destination.endpoint` is required.\n\n  destination:\n    endpoint: https://telemetry.example.net/v1/logs\n" -}}
+{{- end -}}
+{{- $e -}}
+{{- end -}}
+
+{{- define "alloy-lerian.credentialSecretName" -}}
+{{- .Values.destination.credential.secretName | default "alloy-api-key" -}}
+{{- end -}}
+
+{{- define "alloy-lerian.credentialSecretKey" -}}
+{{- .Values.destination.credential.secretKey | default "api-key" -}}
+{{- end -}}
+
+{{/*
+Whether the destination requires authentication. Internal platforms do not
+validate the credential, so the header is omitted there rather than sent empty.
+*/}}
+{{- define "alloy-lerian.destinationAuthenticated" -}}
+{{- if hasKey .Values.destination.credential "enabled" -}}
+{{- .Values.destination.credential.enabled -}}
+{{- else -}}
+{{- eq (include "alloy-lerian.profile" .) "client" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+==============================================================================
+IN-TRANSIT DATA INSPECTION — absent from the client surface by construction
+==============================================================================
+The feature streams RAW pipeline payloads — that is its purpose. Here that
+means log bodies and span attributes from a core banking ledger.
+
+The upstream project's only stated mitigation is transport TLS, which protects
+the channel and not the access; the agent UI carries no documented
+authentication. TLS does not gate who opens the page.
+
+In the client profile the parameter does not exist, so supplying it is a
+configuration error rather than an override.
+*/}}
+{{- define "alloy-lerian.livedebugEnabled" -}}
+{{- $profile := include "alloy-lerian.profile" . -}}
+{{- $requested := false -}}
+{{- if .Values.inspection -}}
+{{- $requested = .Values.inspection.enabled | default false -}}
+{{- end -}}
+{{- if and $requested (eq $profile "client") -}}
+{{- fail "\n\nalloy-lerian: `inspection.enabled` does not exist in the client profile.\n\nThe feature streams raw pipeline payloads — log bodies and span attributes\nfrom a core banking ledger — through a UI with no documented authentication.\n\nIt is available only in the own profile, where access control is ours.\n" -}}
+{{- end -}}
+{{- ternary "true" "false" (and $requested (eq $profile "own")) -}}
+{{- end -}}

--- a/charts/alloy-lerian/templates/_helpers.tpl
+++ b/charts/alloy-lerian/templates/_helpers.tpl
@@ -176,3 +176,35 @@ configuration error rather than an override.
 {{- end -}}
 {{- ternary "true" "false" (and $requested (eq $profile "own")) -}}
 {{- end -}}
+
+
+{{/*
+==============================================================================
+ROLE GUARDS
+==============================================================================
+The subchart values cannot reference the release name, so the ConfigMap name is
+injected here and the single-replica constraint is enforced rather than merely
+defaulted. A default can be overridden silently; this fails the render.
+*/}}
+{{- define "alloy-lerian.assertSingletonReplicas" -}}
+{{- $s := .Values.singleton | default dict -}}
+{{- $c := $s.controller | default dict -}}
+{{- $r := $c.replicas -}}
+{{- if and (ne ($r | toString) "<nil>") (ne ($r | int) 1) -}}
+{{- fail (printf "\n\nalloy-lerian: singleton.controller.replicas is %v; it must be 1.\n\nThis role observes cluster-scope state. More than one replica writes the same\nseries from every instance, with no attribute distinguishing the writers —\nthe exact defect this chart exists to fix. Cost would grow with replica count\nwhile information does not.\n" $r) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ConfigMap names are FIXED, not release-derived. Subchart values are static YAML
+and cannot reference the release name, so an aliased subchart could not point at
+a release-prefixed ConfigMap. Fixed names keep the reference resolvable while
+staying namespace-scoped, which is the actual isolation boundary.
+*/}}
+{{- define "alloy-lerian.nodeConfigMapName" -}}
+alloy-lerian-node
+{{- end -}}
+
+{{- define "alloy-lerian.singletonConfigMapName" -}}
+alloy-lerian-singleton
+{{- end -}}

--- a/charts/alloy-lerian/templates/_sanitizacao.tpl
+++ b/charts/alloy-lerian/templates/_sanitizacao.tpl
@@ -1,0 +1,108 @@
+{{/*
+==============================================================================
+REGULATED-DATA SANITISATION
+==============================================================================
+Not part of the values surface. There is no configuration that disables a rule,
+weakens one, or produces unsanitised output. The absence of those knobs is the
+guarantee, not a limitation.
+
+Every rule here was verified by running the pinned agent against a known input
+and comparing the output exactly. Three mechanics were established empirically
+and are load-bearing:
+
+  1. backreference notation is $1. The form $$1 emits the LITERAL text "$1"
+     with no error, producing output that looks masked and is not
+  2. replace_pattern is an EDITOR: its own statement, never nested in set()
+  3. no lookahead or lookbehind — the engine rejects both at load
+
+RULE ORDER IS A CONTRACT. Each constraint below was confirmed by deliberately
+inverting it:
+
+  phone before document   a 13-digit E.164 number matches the 11-digit document
+                          rule and becomes "+551********21" — masked, but masked
+                          wrongly: it loses the area code and keeps the tail of
+                          the subscriber number
+  dotted before plain     the punctuated document form stops matching otherwise
+  3+ names before 2       "Ana Beatriz Costa Lima" becomes
+                          "Ana ********** Beatriz Costa Lima": the full name
+                          stays exposed behind a decorative mask
+
+Known and accepted false positive: the document rule masks ANY 11+ digit run,
+including transaction identifiers and latency values. Measured at roughly 2% of
+log lines. Accepted because a false positive costs legibility while a false
+negative leaks a document. Requiring a field prefix was evaluated and rejected:
+the canonical case is a bare document in running text.
+*/}}
+{{- define "alloy-lerian.config.sanitizacao" -}}
+otelcol.processor.transform "sanitizacao" {
+  // "ignore" keeps a malformed rule from halting the pipeline. This is also
+  // why correctness is asserted in CI rather than trusted at runtime: a wrong
+  // rule produces no error, only output that appears masked.
+  error_mode = "ignore"
+
+  log_statements {
+    context = "log"
+    statements = [
+      // --- PHONE --- (before document, see header)
+      // E.164 with country and area code: preserves both, masks the subscriber
+      // number. Region is useful in diagnosis; the number is not.
+      `replace_pattern(body, "(\\+[0-9]{2}[0-9]{2})[0-9]{8,9}", "$1********")`,
+
+      // National form with separators.
+      `replace_pattern(body, "(\\([0-9]{2}\\) )[0-9]{4,5}-[0-9]{4}", "$1*****-****")`,
+
+      // --- FISCAL DOCUMENT ---
+      // Punctuated form first: the plain-digit rule would not match it, and
+      // this rule would not match what that one already masked.
+      `replace_pattern(body, "([0-9]{3})\\.[0-9]{3}\\.[0-9]{3}-[0-9]{2}", "$1.***.***-**")`,
+
+      // Eleven consecutive digits. Preserves the first three for correlation.
+      `replace_pattern(body, "([0-9]{3})[0-9]{8}", "$1********")`,
+
+      // --- PERSON NAME ---
+      // Anchored on capitalisation: name terms start uppercase and the
+      // surrounding log text is lowercase, which delimits the value without a
+      // lookbehind. This is a PREMISE about how applications log, not a
+      // guarantee — an application logging names in a different case would not
+      // match, and the alternative-form test case for this class is what would
+      // surface it.
+      //
+      // Two rules are needed. Three-or-more terms first: the two-term rule
+      // would otherwise match the first two and leave the rest exposed.
+      `replace_pattern(body, "((?:customer|sender|recipient|receiver|client|holder)Name=)([A-Z]\\w*)(?: [A-Z]\\w*)+ ([A-Z]\\w*)", "$1$2 ********** $3")`,
+
+      // Exactly two terms: no middle to mask, but the surname is still
+      // personal data. The three-plus rule cannot match this case.
+      `replace_pattern(body, "((?:customer|sender|recipient|receiver|client|holder)Name=)([A-Z]\\w*) ([A-Z]\\w*)", "$1$2 ********** $3")`,
+
+      // --- EMAIL ADDRESS ---
+      // Preserves two characters of the local part and the WHOLE domain. The
+      // domain identifies the provider or corporate client, not the person,
+      // and is genuinely useful in diagnosis.
+      `replace_pattern(body, "([A-Za-z0-9]{2})[A-Za-z0-9._%+-]*(@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})", "$1****$2")`,
+
+      // --- PAYMENT KEY ---
+      // A key may be a document, a phone number, an email address or a random
+      // identifier. The first three are already covered by the rules above,
+      // regardless of field name — deliberately not duplicated here. Verified:
+      // all three forms mask correctly without a dedicated rule.
+      `replace_pattern(body, "([0-9a-fA-F]{8})-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-([0-9a-fA-F]{12})", "$1-****-****-****-$2")`,
+
+      // --- POSTAL ADDRESS ---
+      // Masked ENTIRELY. Unlike an email domain or a phone area code, any
+      // fragment of an address sharply narrows the search space for a person.
+      // The only class with no preserved part, and that is deliberate.
+      `replace_pattern(body, "((?:address|street|logradouro|endereco)[=:] ?)[A-Z][^=]*?(?: [a-z]+=|$)", "$1**********")`,
+
+      // --- OPAQUE RESOURCE IDENTIFIER ---
+      // Preserves the semantic prefix and four characters: enough to correlate
+      // records for the same resource, not enough to reconstruct the value.
+      `replace_pattern(body, "((?:acc|txn|cus|ord)_[0-9a-zA-Z]{4})[0-9a-zA-Z]{4,}", "$1******")`,
+    ]
+  }
+
+  output {
+    logs = [otelcol.processor.batch.agrupamento.input]
+  }
+}
+{{- end -}}

--- a/charts/alloy-lerian/templates/configmap.yaml
+++ b/charts/alloy-lerian/templates/configmap.yaml
@@ -7,6 +7,7 @@ cannot reference the release name, so an aliased subchart could not point at a
 release-prefixed ConfigMap.
 */ -}}
 {{- include "alloy-lerian.assertSingletonReplicas" . -}}
+{{- include "alloy-lerian.assertNodeInfra" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/alloy-lerian/templates/configmap.yaml
+++ b/charts/alloy-lerian/templates/configmap.yaml
@@ -1,11 +1,16 @@
 {{- /*
-Configuration for the per-node role. Rendered from semantic parameters — the
-processing chain is not part of the values surface (see _config.tpl).
+Configuration for each role, rendered from semantic parameters. The processing
+chain is not part of the values surface (see _config.tpl).
+
+Names are fixed rather than release-derived: subchart values are static YAML and
+cannot reference the release name, so an aliased subchart could not point at a
+release-prefixed ConfigMap.
 */ -}}
+{{- include "alloy-lerian.assertSingletonReplicas" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "alloy-lerian.fullname" . }}-node
+  name: {{ include "alloy-lerian.nodeConfigMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "alloy-lerian.labels" . | nindent 4 }}
@@ -18,7 +23,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "alloy-lerian.fullname" . }}-singleton
+  name: {{ include "alloy-lerian.singletonConfigMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "alloy-lerian.labels" . | nindent 4 }}

--- a/charts/alloy-lerian/templates/configmap.yaml
+++ b/charts/alloy-lerian/templates/configmap.yaml
@@ -19,7 +19,7 @@ metadata:
 data:
   config.alloy: |
     {{- include "alloy-lerian.config.node" . | nindent 4 }}
-{{- if .Values.roles.singleton.enabled }}
+{{- if .Values.singleton.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/alloy-lerian/templates/configmap.yaml
+++ b/charts/alloy-lerian/templates/configmap.yaml
@@ -1,0 +1,29 @@
+{{- /*
+Configuration for the per-node role. Rendered from semantic parameters — the
+processing chain is not part of the values surface (see _config.tpl).
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alloy-lerian.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alloy-lerian.labels" . | nindent 4 }}
+    alloy-lerian.lerian.studio/role: node
+data:
+  config.alloy: |
+    {{- include "alloy-lerian.config.node" . | nindent 4 }}
+{{- if .Values.roles.singleton.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alloy-lerian.fullname" . }}-singleton
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alloy-lerian.labels" . | nindent 4 }}
+    alloy-lerian.lerian.studio/role: singleton
+data:
+  config.alloy: |
+    {{- include "alloy-lerian.config.singleton" . | nindent 4 }}
+{{- end }}

--- a/charts/alloy-lerian/values.schema.json
+++ b/charts/alloy-lerian/values.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "profile": {
+      "type": "string"
+    },
+    "origin": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "destination": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "collection": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "roles": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "receiver": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "inspection": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "logging": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "kube-state-metrics": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "alloy": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/charts/alloy-lerian/values.schema.json
+++ b/charts/alloy-lerian/values.schema.json
@@ -32,6 +32,14 @@
       "type": "object",
       "additionalProperties": true
     },
+    "node": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "singleton": {
+      "type": "object",
+      "additionalProperties": true
+    },
     "receiver": {
       "type": "object",
       "additionalProperties": true

--- a/charts/alloy-lerian/values.schema.json
+++ b/charts/alloy-lerian/values.schema.json
@@ -14,7 +14,12 @@
       "additionalProperties": true
     },
     "profile": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "own",
+        "client"
+      ],
+      "description": "own = our environment (collects node infra); client = client cluster (does not). Not inferable, no default."
     },
     "origin": {
       "type": "object",
@@ -55,10 +60,11 @@
     "kube-state-metrics": {
       "type": "object",
       "additionalProperties": true
-    },
-    "alloy": {
-      "type": "object",
-      "additionalProperties": true
     }
-  }
+  },
+  "required": [
+    "destination",
+    "origin",
+    "profile"
+  ]
 }

--- a/charts/alloy-lerian/values.yaml
+++ b/charts/alloy-lerian/values.yaml
@@ -192,7 +192,12 @@ node:
           secretKeyRef:
             name: alloy-api-key
             key: api-key
-            optional: true
+            # NÃO optional. No perfil client o ponto de entrada valida a
+            # credencial, e 401 é falha PERMANENTE: o dado é descartado na hora,
+            # sem reenvio. Com optional: true o pod subiria sem a credencial e a
+            # perda seria silenciosa e contínua. Falhar na criação do pod é
+            # ruidoso e recuperável — é o modo de falha que queremos.
+            optional: false
     resources:
       requests:
         cpu: 100m
@@ -230,7 +235,12 @@ singleton:
           secretKeyRef:
             name: alloy-api-key
             key: api-key
-            optional: true
+            # NÃO optional. No perfil client o ponto de entrada valida a
+            # credencial, e 401 é falha PERMANENTE: o dado é descartado na hora,
+            # sem reenvio. Com optional: true o pod subiria sem a credencial e a
+            # perda seria silenciosa e contínua. Falhar na criação do pod é
+            # ruidoso e recuperável — é o modo de falha que queremos.
+            optional: false
     resources:
       requests:
         cpu: 50m
@@ -286,16 +296,3 @@ kube-state-metrics:
   autosharding:
     enabled: false
 
-# Values passed through to the upstream agent chart. Kept minimal on purpose:
-# the agent's own defaults are good practice, and diverging from them requires
-# a documented reason.
-alloy:
-  # Usage reporting to the vendor is inappropriate in a financial-institution
-  # cluster.
-  alloy:
-    enableReporting: false
-    stabilityLevel: "generally-available"
-  # Not needed for the roles in scope, and would collide with CRDs a client
-  # cluster may already have.
-  crds:
-    create: false

--- a/charts/alloy-lerian/values.yaml
+++ b/charts/alloy-lerian/values.yaml
@@ -102,11 +102,29 @@ collection:
   interval: "60s"
 
   namespaces:
-    # Anchored regular expressions. `include` takes precedence; both empty
-    # means the profile default applies — NOT "collect everything". An empty
-    # perimeter read as unrestricted is the failure mode that exposes data.
+    # DERIVED FROM THE PROFILE — leave empty unless the environment genuinely
+    # differs. The defaults are:
+    #
+    #   client  include ^(midaz|midaz-plugins)$   — only what we operate.
+    #           Everything else in that cluster belongs to the client and would
+    #           cross the public network for no return.
+    #   own     exclude ^(kube-system|kube-public|kube-node-lease)$ — the whole
+    #           cluster is ours, minus plumbing.
+    #
+    # `include` takes precedence. Both empty does NOT mean "collect everything":
+    # it means the profile default applies. An empty perimeter read as
+    # unrestricted is the failure mode that exposes data.
     include: ""
-    exclude: "^(kube-system|kube-public|kube-node-lease|cert-manager|keda|monitoring|default)$"
+    exclude: ""
+
+  # Node CPU, memory and filesystem — the HOST, not the workloads. Available
+  # only in the own profile; setting it true with profile: client fails the
+  # render. Not collected by default in either profile.
+  #
+  # Cluster-OBJECT metrics (pod phase, deployment state, autoscaler) are a
+  # different thing and are collected in both — those describe workloads we
+  # operate.
+  nodeInfrastructure: false
 
   # Drops records below INFO at the edge. Records with no severity are kept:
   # absence of the field is not evidence of low value.

--- a/charts/alloy-lerian/values.yaml
+++ b/charts/alloy-lerian/values.yaml
@@ -120,27 +120,113 @@ collection:
 # distinguishing the writers: cost grows with cluster size while information
 # does not. Measured before this chart existed: writes per minute equalled the
 # node count exactly, across five environments.
+#
+# Each role is an aliased instance of the upstream agent chart, so upstream owns
+# probes, RBAC, security context and the config-reloader sidecar. The blocks
+# below are the upstream values surface under the alias name — see the `node:`
+# and `singleton:` blocks further down.
 roles:
   node:
     # Per-node. Receives application telemetry pushed over the standard
     # protocol. Push cannot duplicate, so replication is safe here.
     enabled: true
+
+  singleton:
+    # Exactly one replica, enforced. Observes cluster-scope state.
+    enabled: true
+
+# ---------------------------------------------------------------------------
+# NODE ROLE — upstream agent values under the `node` alias
+# ---------------------------------------------------------------------------
+node:
+  enabled: true
+  alloy:
+    # Config comes from the ConfigMap this chart renders; upstream must not
+    # create its own.
+    configMap:
+      create: false
+      name: alloy-lerian-node
+      key: config.alloy
+    # Ports the applications push to. Upstream opens none by default.
+    extraPorts:
+      - name: otlp-grpc
+        port: 4317
+        targetPort: 4317
+        protocol: TCP
+      - name: otlp-http
+        port: 4318
+        targetPort: 4318
+        protocol: TCP
+    # Usage reporting to the vendor is inappropriate in a client cluster.
+    enableReporting: false
+    # Held at the strictest tier. Lowering it would un-gate every unstable
+    # component; the durable send queue is the only thing that would need it,
+    # and that trade was rejected.
+    stabilityLevel: generally-available
+    # Credential read from the Secret the onboarding process provisions in this
+    # namespace. The chart never creates it — registered in the repository's
+    # out-of-band secret allowlist so the render gate does not flag it.
+    # Remove this entry for the own profile, where the platform does not
+    # validate the credential.
+    extraEnv:
+      - name: ALLOY_DESTINATION_CREDENTIAL
+        valueFrom:
+          secretKeyRef:
+            name: alloy-api-key
+            key: api-key
+            optional: true
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
         memory: 512Mi
+  controller:
+    type: daemonset
+    # Needed for the connection-based association fallback, which reads the peer
+    # address. Not every application declares k8s.pod.ip, so the fallback is
+    # still load-bearing. Drop this once declaration coverage is complete.
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+  crds:
+    create: false
 
-  singleton:
-    # Exactly one replica, enforced. Observes cluster-scope state.
-    enabled: true
+# ---------------------------------------------------------------------------
+# SINGLETON ROLE — upstream agent values under the `singleton` alias
+# ---------------------------------------------------------------------------
+singleton:
+  enabled: true
+  alloy:
+    configMap:
+      create: false
+      name: alloy-lerian-singleton
+      key: config.alloy
+    enableReporting: false
+    stabilityLevel: generally-available
+    # No inbound ports: this role watches the cluster API and scrapes, it does
+    # not receive pushes.
+    extraPorts: []
+    extraEnv:
+      - name: ALLOY_DESTINATION_CREDENTIAL
+        valueFrom:
+          secretKeyRef:
+            name: alloy-api-key
+            key: api-key
+            optional: true
     resources:
       requests:
         cpu: 50m
         memory: 128Mi
       limits:
         memory: 256Mi
+  controller:
+    type: deployment
+    # EXACTLY ONE. More than one replica duplicates every series with no
+    # attribute distinguishing the writers — the defect this chart exists to
+    # fix. Enforced by the chart, not merely defaulted.
+    replicas: 1
+  crds:
+    create: false
 
 receiver:
   # Restores the pre-v1.18.0 behaviour of no HTTP timeout. The pinned version

--- a/charts/alloy-lerian/values.yaml
+++ b/charts/alloy-lerian/values.yaml
@@ -1,0 +1,197 @@
+# alloy-lerian — telemetry collection agent for client clusters.
+#
+# The surface below is SEMANTIC INTENT, not pipeline topology. The processing
+# chain (admission, enrichment, origin marking, perimeter, sanitisation,
+# batching) is rendered by the chart and deliberately not configurable:
+#
+#   - ordering is a contract. In this agent components form a graph, so swapping
+#     two stages produces no error — it produces telemetry without enrichment,
+#     silently
+#   - sanitisation of regulated data is not negotiable. There is no value that
+#     disables or weakens a rule
+#
+# Two parameters have NO default and fail the render when absent: `profile` and
+# `origin.id`. That is intentional. The chart this one replaces shipped a
+# default origin identifier that violated its own schema, which is why it could
+# not render with its own values.
+
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
+# ---------------------------------------------------------------------------
+# PROFILE — required, no default, not inferable
+# ---------------------------------------------------------------------------
+# own     our own environment. Collects node infrastructure, because the node
+#         is ours and its capacity and scheduling are our concern.
+# client  a client cluster. Does NOT collect node infrastructure: the node
+#         belongs to the client, collecting it asks for data we have no
+#         standing to act on, and it adds traffic across the public network.
+#
+# The boundary is operational responsibility. Inferring it from a cluster
+# property would silently produce the wrong profile in the ambiguous case.
+profile: ""
+
+# ---------------------------------------------------------------------------
+# ORIGIN — required, no default
+# ---------------------------------------------------------------------------
+# Marks every record with the environment it came from. Without it, telemetry
+# reaches the destination unattributable.
+#
+# Form: lowercase segments separated by hyphens ending in stg | hml | prd, or a
+# reserved own-environment name. Hyphenated composition is accepted — the
+# earlier pattern rejected identifiers already in use.
+#
+# Note: this marks PROVENANCE, not identity. The credential authenticates the
+# sender; the marker is self-declared. Changing it for a live environment is a
+# data migration, not a configuration tweak: the marker is part of series
+# identity at the destination, so a new value orphans every existing series.
+origin:
+  id: ""
+
+# ---------------------------------------------------------------------------
+# DESTINATION
+# ---------------------------------------------------------------------------
+destination:
+  endpoint: ""
+
+  credential:
+    # Omitted by default in the own profile (the internal platform does not
+    # validate it) and required in the client profile. Set explicitly to
+    # override the derivation.
+    # enabled: true
+
+    # Reference only. The credential lives in the origin cluster Secret,
+    # provisioned by onboarding before install; the chart reads it and never
+    # creates it. Registered in the repository's out-of-band secret allowlist.
+    secretName: "alloy-api-key"
+    secretKey: "api-key"
+
+  # In-memory queue. Persistence is deliberately out of scope: the durable
+  # backend is below the agent's stable component tier, and enabling it would
+  # require lowering the stability floor GLOBALLY, which un-gates every
+  # unstable component in a financial-institution cluster.
+  #
+  # Consequence accepted: a process restart loses the in-flight queue. The main
+  # gain — retry on transient failure — does not depend on persistence and does
+  # not exist today.
+  queue:
+    size: 1000
+    consumers: 10
+
+  retry:
+    # Effective survivable outage window. Beyond it, records are discarded and
+    # the discard is counted — silent loss is what this replaces.
+    #
+    # To be sized from measured volume per environment rather than guessed.
+    maxElapsedTime: "5m"
+
+# ---------------------------------------------------------------------------
+# COLLECTION
+# ---------------------------------------------------------------------------
+collection:
+  # Floor of 60s, enforced. A lower value is REJECTED, not clamped: clamping
+  # would hide the divergent intent of whoever set it.
+  #
+  # Cost at the destination is series x writes per minute. Collecting faster
+  # than anyone queries wastes CPU in the client cluster, bandwidth across the
+  # public network, and processing at the destination.
+  interval: "60s"
+
+  namespaces:
+    # Anchored regular expressions. `include` takes precedence; both empty
+    # means the profile default applies — NOT "collect everything". An empty
+    # perimeter read as unrestricted is the failure mode that exposes data.
+    include: ""
+    exclude: "^(kube-system|kube-public|kube-node-lease|cert-manager|keda|monitoring|default)$"
+
+  # Drops records below INFO at the edge. Records with no severity are kept:
+  # absence of the field is not evidence of low value.
+  dropDebugLogs: true
+
+# ---------------------------------------------------------------------------
+# ROLES — segregated by observation scope
+# ---------------------------------------------------------------------------
+# The chart delivers roles, not one agent. A cluster-scoped watcher replicated
+# per node writes the same series from every replica, with no attribute
+# distinguishing the writers: cost grows with cluster size while information
+# does not. Measured before this chart existed: writes per minute equalled the
+# node count exactly, across five environments.
+roles:
+  node:
+    # Per-node. Receives application telemetry pushed over the standard
+    # protocol. Push cannot duplicate, so replication is safe here.
+    enabled: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+  singleton:
+    # Exactly one replica, enforced. Observes cluster-scope state.
+    enabled: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+receiver:
+  # Restores the pre-v1.18.0 behaviour of no HTTP timeout. The pinned version
+  # changed the defaults to 1m/1m/30s, which can cut a long-lived connection.
+  # Set only for an application shown to be affected — as an exception for that
+  # application, not globally.
+  preserveLegacyTimeouts: false
+
+# ---------------------------------------------------------------------------
+# IN-TRANSIT DATA INSPECTION — own profile only
+# ---------------------------------------------------------------------------
+# The feature streams RAW pipeline payloads: log bodies and span attributes
+# from a core banking ledger. The upstream project's only stated mitigation is
+# transport TLS, which protects the channel and not the access, and the agent
+# UI carries no documented authentication.
+#
+# Supplying this in the client profile is a configuration error, not an
+# override — the render fails.
+inspection:
+  enabled: false
+
+logging:
+  level: "info"
+
+# ---------------------------------------------------------------------------
+# UPSTREAM DEPENDENCIES
+# ---------------------------------------------------------------------------
+# Sole source of cluster-object metrics: this agent has no equivalent of the
+# collector's cluster receiver. Single-replica by default, which is what makes
+# it a single writer.
+#
+# Disable to reuse an existing instance — many client clusters already run one,
+# and running two is waste plus a potential write conflict.
+kube-state-metrics:
+  enabled: true
+  replicas: 1
+  # Automatic sharding is documented upstream as experimental and liable to
+  # break or be removed without notice. Our scale does not require it.
+  autosharding:
+    enabled: false
+
+# Values passed through to the upstream agent chart. Kept minimal on purpose:
+# the agent's own defaults are good practice, and diverging from them requires
+# a documented reason.
+alloy:
+  # Usage reporting to the vendor is inappropriate in a financial-institution
+  # cluster.
+  alloy:
+    enableReporting: false
+    stabilityLevel: "generally-available"
+  # Not needed for the roles in scope, and would collide with CRDs a client
+  # cluster may already have.
+  crds:
+    create: false


### PR DESCRIPTION
## What

Adds `charts/alloy-lerian`, the telemetry collection agent for client clusters. Phase 1 of migrating the collector-client off the OpenTelemetry Collector. The central concentrator is unchanged, so the transport contract is identical before and after and the concentrator does not notice the swap.

## Roles segregated by observation scope

A cluster-scoped watcher replicated per node writes the same series from every replica, with nothing distinguishing the writers: cost grows with cluster size while information does not. Measured beforehand — writes per minute equalled the node count exactly, across five environments.

| Role | Topology | Observes |
|---|---|---|
| `node` | DaemonSet, hostNetwork, OTLP 4317/4318 | telemetry pushed to it — push cannot duplicate |
| `singleton` | Deployment, **exactly one replica** | cluster-scope state |

Both are aliased instances of the upstream chart, so upstream keeps ownership of probes, RBAC, security context and the config-reloader sidecar instead of us forking them. The single-replica constraint is **enforced**, not defaulted: `replicas: 2` fails the render.

## Two values in the common case

The client installs this chart, so it fills in as little as possible. The perimeter is derived from the profile:

| | `client` | `own` |
|---|---|---|
| Namespaces | include `^(midaz\|midaz-plugins)$` | exclude orchestrator plumbing |
| Node infrastructure | **render fails if enabled** | permitted |
| In-transit inspection | parameter does not exist | available, off by default |
| Destination credential | required | omitted |

Node infrastructure was never collected — the source is the kubelet and it is not in the chart. The guard exists so enabling it later cannot silently reach a client cluster: the host belongs to the client.

## The processing chain is rendered, not configured

Components form a graph through `output` references rather than an ordered list, so swapping two stages produces **no error** — it produces telemetry without enrichment, silently. The chain is closed and its three ordering constraints were each verified by deliberately breaking them.

## Sanitisation at the edge, asserted not reviewed

Seven classes of regulated data masked before anything leaves the origin cluster. No value disables or weakens a rule.

The rules run with `error_mode = "ignore"`, so a malformed rule produces no error — it produces output that *looks* masked. Verified: the wrong backreference form emits the literal `$1` with no warning at all. Correctness is therefore asserted against known input and expected output, in a gate that blocks release. A sixth check asserts the framework's rules are byte-identical to the template's, because otherwise the test could validate one rule set while production ships another.

## Also in this PR

The render gate reads its dangling-secret allowlist from the validator source, not from the standard document. #1856 documents the rule; this adds the entry that implements it.

## Verification

- `helm lint` clean; strict validator 0 violations; render gate ok; validator's own tests pass
- Rendered config for **both roles accepted by the pinned agent binary** — `helm template` alone does not catch invalid agent config
- DaemonSet mounts the node ConfigMap and exposes both OTLP ports; credential reaches the container by `secretKeyRef`
- `kube-state-metrics` renders a single replica; condition-gated for reuse where a cluster already runs one
- Sanitisation gate: 31 cases pass, and it blocks on each of five injected defects
- Both example values files render; the client template's placeholder identifier is rejected, so it cannot be installed unedited

## Depends on

#1856 for the PR-title scope. Merge that first.
