### PR TITLE
feat(plugin-access-manager): expose PLATFORM_INTERNAL_CIDRS on auth

### DIFF
--- a/charts/plugin-access-manager/templates/auth/configmap.yaml
+++ b/charts/plugin-access-manager/templates/auth/configmap.yaml
@@ -1,3 +1,8 @@
+{{- $idCidrs := .Values.identity.configmap.PLATFORM_INTERNAL_CIDRS | default "" -}}
+{{- $authCidrs := .Values.auth.configmap.PLATFORM_INTERNAL_CIDRS | default "" -}}
+{{- if ne $idCidrs $authCidrs -}}
+{{- fail "PLATFORM_INTERNAL_CIDRS must be identical on identity.configmap and auth.configmap: a skew leaks the platform ranges into the enforcement entry set, which on proxy-fronted environments allows everyone" -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/plugin-access-manager/templates/auth/configmap.yaml
+++ b/charts/plugin-access-manager/templates/auth/configmap.yaml
@@ -120,6 +120,7 @@ data:
   # RUNTIME
   DEPLOYMENT_MODE: {{ .Values.auth.configmap.DEPLOYMENT_MODE | default "local" | quote }}
   TRUSTED_PROXIES: {{ .Values.auth.configmap.TRUSTED_PROXIES | default "" | quote }}
+  PLATFORM_INTERNAL_CIDRS: {{ .Values.auth.configmap.PLATFORM_INTERNAL_CIDRS | default "" | quote }}
   SWAGGER_ENABLED: {{ .Values.auth.configmap.SWAGGER_ENABLED | default "true" | quote }}
 
   # CACHE (0 = use built-in default from constant)


### PR DESCRIPTION
Companion to #1853 (identity). The platform-CIDR subtraction is moving from org tags to the environment value on **both** components — product decision: tags stay reserved for the scope semantics (`ip-allowlist-scope:*`); the platform ranges are infrastructure and live in env.

One template line in `auth/configmap.yaml`, empty default, same shape as `TRUSTED_PROXIES` beside it. Without it the chart silently drops the key — and on this feature that failure mode means the co-stored ranges leak into the enforcement entry set, which on proxy-fronted environments allows everyone.

App-side change: plugin-access-manager PR in flight. Gitops values follow the chart release (Benedita + AWS, auth sections).