### PR TITLE
fix(product-console): use Docker Hub OCI registry in install docs

### DIFF
--- a/charts/product-console/README.md
+++ b/charts/product-console/README.md
@@ -20,8 +20,7 @@ A Helm chart for deploying Product Console - Lerian Studio's web interface for m
 To install the chart with the release name `product-console`:
 
 ```bash
-helm repo add lerianstudio https://charts.lerian.studio
-helm install product-console lerianstudio/product-console-helm
+helm install product-console oci://registry-1.docker.io/lerianstudio/product-console-helm --version <version> -n midaz --create-namespace
 ```
 
 ## Configuration
@@ -35,7 +34,7 @@ Copy `values-template.yaml` and customize it for your deployment:
 ```bash
 cp values-template.yaml my-values.yaml
 # Edit my-values.yaml with your configuration
-helm install product-console lerianstudio/product-console-helm -f my-values.yaml
+helm install product-console oci://registry-1.docker.io/lerianstudio/product-console-helm --version <version> -f my-values.yaml -n midaz --create-namespace
 ```
 
 ### Key Configuration Options

--- a/charts/product-console/README.md
+++ b/charts/product-console/README.md
@@ -13,7 +13,7 @@ A Helm chart for deploying Product Console - Lerian Studio's web interface for m
 ## Prerequisites
 
 - Kubernetes 1.19+
-- Helm 3.2.0+
+- Helm 3.8.0+ (OCI registry support is enabled by default)
 
 ## Installing the Chart
 


### PR DESCRIPTION
The product-console install docs pointed at the `charts.lerian.studio` Helm repo:
```
helm repo add lerianstudio https://charts.lerian.studio
helm install product-console lerianstudio/product-console-helm
```
Every other chart in this repo installs straight from the Docker Hub OCI registry. Align product-console:
```
helm install product-console oci://registry-1.docker.io/lerianstudio/product-console-helm --version <version> -n midaz --create-namespace
```
Docs-only (README install + values quick-start). Chart `lerianstudio/product-console-helm` on Docker Hub.