### PR TITLE
refactor(plugin-br-pix-switch): rename adapter-btg-mock to adapter-provider-mock

### DIFF
--- a/charts/plugin-br-pix-switch/README.md
+++ b/charts/plugin-br-pix-switch/README.md
@@ -21,7 +21,7 @@ per component.
 |---|---|---|---|
 | `spi` | `spi/api` | 4101 | PIX SPI service |
 | `spiSystemplane` | `spi/systemplane/api` | 4102 | Runtime config plane |
-| `adapterBtgMock` | `adapter-btg-mock/api` | 4103 | BTG provider mock (disabled by default) |
+| `adapterProviderMock` | `adapter-provider-mock/api` | 4103 | BTG provider mock (disabled by default) |
 | `dictHub` | `dict/hub/api` | 4104 | DICT hub (Postgres + Mongo + Valkey) |
 | `dictHubVsync` | `dict/hub/vsync` | 4105 | DICT verification sync worker (singleton) |
 | `dictProxy` | `dict/proxy/api` | 4106 | DICT proxy to BCB |
@@ -66,7 +66,7 @@ Default `enabled` values:
 
 - `spi`, `spiSystemplane`, `dictHub`, `dictHubVsync`, `dictProxy`,
   `dictSystemplane`, `cobHub`, `cobProxy`, `cobSystemplane`: `true`
-- `adapterBtgMock`: `false` (it's a mock — only enable in dev/staging)
+- `adapterProviderMock`: `false` (it's a mock — only enable in dev/staging)
 - `adapterLerian`, `adapterLerianConsumer`, `adapterLerianSystemplane`: `false`
   (Lerian provider adapter — enable per environment)
 
@@ -116,7 +116,7 @@ This chart follows the multi-component layout used by
 
 ```sh
 # Render with all components and one disabled
-helm template my-release ./plugin-br-pix-switch --set adapterBtgMock.enabled=true
+helm template my-release ./plugin-br-pix-switch --set adapterProviderMock.enabled=true
 
 # Lint
 helm lint ./plugin-br-pix-switch

--- a/charts/plugin-br-pix-switch/templates/NOTES.txt
+++ b/charts/plugin-br-pix-switch/templates/NOTES.txt
@@ -16,7 +16,7 @@ Service, ConfigMap, and Secret.
 ------------------------------------------------------------
 {{ if .Values.spi.enabled }}  ✓ spi                  port {{ .Values.spi.service.port }}{{ else }}  ✗ spi                  (disabled){{ end }}
 {{ if .Values.spiSystemplane.enabled }}  ✓ spi-systemplane      port {{ .Values.spiSystemplane.service.port }}{{ else }}  ✗ spi-systemplane      (disabled){{ end }}
-{{ if .Values.adapterBtgMock.enabled }}  ✓ adapter-btg-mock     port {{ .Values.adapterBtgMock.service.port }}{{ else }}  ✗ adapter-btg-mock     (disabled){{ end }}
+{{ if .Values.adapterProviderMock.enabled }}  ✓ adapter-provider-mock port {{ .Values.adapterProviderMock.service.port }}{{ else }}  ✗ adapter-provider-mock (disabled){{ end }}
 {{ if .Values.dictHub.enabled }}  ✓ dict-hub             port {{ .Values.dictHub.service.port }}{{ else }}  ✗ dict-hub             (disabled){{ end }}
 {{ if .Values.dictHubVsync.enabled }}  ✓ dict-hub-vsync       port {{ .Values.dictHubVsync.service.port }}{{ else }}  ✗ dict-hub-vsync       (disabled){{ end }}
 {{ if .Values.dictProxy.enabled }}  ✓ dict-proxy           port {{ .Values.dictProxy.service.port }}{{ else }}  ✗ dict-proxy           (disabled){{ end }}

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/configmap.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/configmap.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.adapterBtgMock.enabled }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if .Values.adapterProviderMock.enabled }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/deployment.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/deployment.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.adapterBtgMock.enabled }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if .Values.adapterProviderMock.enabled }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -94,7 +94,7 @@ spec:
             {{- toYaml $values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: {{ $values.readinessProbe.path | default "/btg-mock/readyz" }}
+              path: {{ $values.readinessProbe.path | default "/provider-mock/readyz" }}
               port: http
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ $values.readinessProbe.periodSeconds | default 5 }}
@@ -103,7 +103,7 @@ spec:
             failureThreshold: {{ $values.readinessProbe.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
-              path: {{ $values.livenessProbe.path | default "/btg-mock/health" }}
+              path: {{ $values.livenessProbe.path | default "/provider-mock/health" }}
               port: http
             initialDelaySeconds: {{ $values.livenessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ $values.livenessProbe.periodSeconds | default 10 }}

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/hpa.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/hpa.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.adapterBtgMock.enabled .Values.adapterBtgMock.autoscaling.enabled }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if and .Values.adapterProviderMock.enabled .Values.adapterProviderMock.autoscaling.enabled }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/ingress.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/ingress.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.adapterBtgMock.enabled .Values.adapterBtgMock.ingress.enabled }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if and .Values.adapterProviderMock.enabled .Values.adapterProviderMock.ingress.enabled }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 {{- $fullName := include "plugin-br-pix-switch.componentFullname" (dict "context" $ "component" $component) }}
 {{- $svcPort := $values.service.port }}
 apiVersion: networking.k8s.io/v1

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/pdb.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/pdb.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.adapterBtgMock.enabled .Values.adapterBtgMock.pdb.enabled }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if and .Values.adapterProviderMock.enabled .Values.adapterProviderMock.pdb.enabled }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/secrets.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/secrets.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.adapterBtgMock.enabled (not .Values.adapterBtgMock.useExistingSecret) }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if and .Values.adapterProviderMock.enabled (not .Values.adapterProviderMock.useExistingSecret) }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/service.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/service.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.adapterBtgMock.enabled }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if .Values.adapterProviderMock.enabled }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/plugin-br-pix-switch/templates/adapter-provider-mock/serviceaccount.yaml
+++ b/charts/plugin-br-pix-switch/templates/adapter-provider-mock/serviceaccount.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.adapterBtgMock.enabled .Values.adapterBtgMock.serviceAccount.create }}
-{{- $component := "adapter-btg-mock" }}
-{{- $values := .Values.adapterBtgMock }}
+{{- if and .Values.adapterProviderMock.enabled .Values.adapterProviderMock.serviceAccount.create }}
+{{- $component := "adapter-provider-mock" }}
+{{- $values := .Values.adapterProviderMock }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/plugin-br-pix-switch/templates/ingress-apps.yaml
+++ b/charts/plugin-br-pix-switch/templates/ingress-apps.yaml
@@ -10,7 +10,7 @@ false or no routes resolve to enabled components.
 No path rewriting is performed at the ingress — apps own their /<component>
 path namespace (e.g. SPI's router registers /spi/health, /spi/keys/lookup).
 
-adapter-btg-mock retains its own per-component ingress block; this shared
+adapter-provider-mock retains its own per-component ingress block; this shared
 ingress only covers the externally-facing application components.
 */}}
 {{- if .Values.appsIngress.enabled }}

--- a/charts/plugin-br-pix-switch/values-template.yaml
+++ b/charts/plugin-br-pix-switch/values-template.yaml
@@ -1,7 +1,7 @@
 # Production values template for plugin-br-pix-switch (chart 2.0.0-beta.1+)
 #
 # Override only the fields you need to change from values.yaml defaults.
-# All 13 components are enabled by default except adapter-btg-mock and the
+# All 13 components are enabled by default except adapter-provider-mock and the
 # adapter-lerian trio (adapterLerian / adapterLerianConsumer /
 # adapterLerianSystemplane); disable any component by setting `enabled: false`.
 
@@ -27,7 +27,7 @@ spi:
     LICENSE_ORGANIZATION_IDS: "global"
     ORGANIZATION_ID: "<your-org-id>"
     ISPB: "<8-digit-ispb>"
-    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-btg-mock:4103"
+    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-provider-mock:4103"
     DICT_BASE_URL: "http://plugin-br-pix-switch-dict-hub:4104"
     COB_BASE_URL: "http://plugin-br-pix-switch-cob-hub:4108"
     MIDAZ_BASE_URL: "http://midaz-onboarding.midaz.svc.cluster.local:3000"
@@ -62,9 +62,9 @@ spiSystemplane:
     SYSTEMPLANE_SECRET_MASTER_KEY: ""
 
 # ------------------------------------------------------------
-# adapter-btg-mock (disabled in production!)
+# adapter-provider-mock (disabled in production!)
 # ------------------------------------------------------------
-adapterBtgMock:
+adapterProviderMock:
   enabled: false
 
 # ------------------------------------------------------------
@@ -79,7 +79,7 @@ dictHub:
     LICENSE_ORGANIZATION_IDS: "global"
     ORGANIZATION_ID: "<your-org-id>"
     ISPB: "<8-digit-ispb>"
-    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-btg-mock:4103"
+    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-provider-mock:4103"
     KEY_CACHE_TTL_SEC: "60"
     MONGO_DB_NAME: "pix-dict"
   secrets:

--- a/charts/plugin-br-pix-switch/values.schema.json
+++ b/charts/plugin-br-pix-switch/values.schema.json
@@ -40,7 +40,7 @@
       },
       "additionalProperties": true
     },
-    "adapterBtgMock": {
+    "adapterProviderMock": {
       "type": "object",
       "properties": {
         "configmap": {

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -1323,8 +1323,9 @@ cobSystemplane:
 #
 # Two ingress objects, both routed by path prefix:
 #
-#   appsIngress         — user-facing traffic (SPI, DICT/COB hub+proxy, optional
-#                         adapter-provider-mock). Single hostname.
+#   appsIngress         — user-facing traffic (SPI, DICT/COB hub+proxy). Single
+#                         hostname. adapter-provider-mock is routed separately
+#                         under providersIngress, below.
 #   systemplaneIngress  — admin/runtime-config traffic (SPI/DICT/COB systemplanes).
 #                         Separate hostname so operators can apply stricter
 #                         annotations (auth, IP allowlist, WAF) than the apps

--- a/charts/plugin-br-pix-switch/values.yaml
+++ b/charts/plugin-br-pix-switch/values.yaml
@@ -5,7 +5,7 @@
 #
 #   spi/api                  Single Person Interface (PIX SPI)
 #   spi/systemplane/api      Runtime config plane for SPI
-#   adapter-btg-mock/api     BTG provider mock (dev/staging only)
+#   adapter-provider-mock/api BTG provider mock (dev/staging only)
 #   dict/hub/api             DICT hub (key directory operations)
 #   dict/hub/vsync           DICT verification sync worker
 #   dict/proxy/api           DICT proxy to BCB
@@ -229,7 +229,7 @@ spi:
     ORGANIZATION_ID: ""
     ISPB: ""
     # Sibling services
-    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-btg-mock:4103"
+    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-provider-mock:4103"
     DICT_BASE_URL: "http://plugin-br-pix-switch-dict-hub:4104"
     COB_BASE_URL: "http://plugin-br-pix-switch-cob-hub:4108"
     # Upstream integrations
@@ -390,17 +390,17 @@ spiSystemplane:
   extraEnvVars: {}
 
 # -----------------------------------------------------------------------------
-# adapter-btg-mock/api — BTG provider mock (DO NOT enable in production)
+# adapter-provider-mock/api — BTG provider mock (DO NOT enable in production)
 # -----------------------------------------------------------------------------
-adapterBtgMock:
+adapterProviderMock:
   enabled: false   # safety default — explicitly enable in dev/staging values
-  name: "adapter-btg-mock"
+  name: "adapter-provider-mock"
   description: "BTG provider mock"
   replicaCount: 1
   revisionHistoryLimit: 10
 
   image:
-    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-btg-mock-api"
+    repository: "ghcr.io/lerianstudio/plugin-br-pix-switch-adapter-provider-mock-api"
     pullPolicy: ""
     tag: ""
 
@@ -453,9 +453,9 @@ adapterBtgMock:
     maxReplicas: 1
 
   readinessProbe:
-    path: "/btg-mock/readyz"
+    path: "/provider-mock/readyz"
   livenessProbe:
-    path: "/btg-mock/health"
+    path: "/provider-mock/health"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -468,14 +468,14 @@ adapterBtgMock:
   configmap:
     PLUGIN_AUTH_ENABLED: "false"
     PLUGIN_AUTH_URL: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
-    APPLICATION_NAME: "pix-adapter-btg-mock"
+    APPLICATION_NAME: "pix-adapter-provider-mock"
     SERVER_ADDRESS: ":4103"
     LOG_LEVEL: "info"
     ENV_NAME: "development"
     DEPLOYMENT_MODE: "byoc"
     REQUEST_TIMEOUT_SEC: "30"
     TELEMETRY_ENABLED: "false"
-    OTEL_RESOURCE_SERVICE_NAME: "pix-adapter-btg-mock"
+    OTEL_RESOURCE_SERVICE_NAME: "pix-adapter-provider-mock"
     OTEL_LIBRARY_NAME: "github.com/LerianStudio/plugin-br-pix-switch"
     OTEL_RESOURCE_DEPLOYMENT_ENVIRONMENT: "development"
     OTEL_EXPORTER_OTLP_ENDPOINT: ""
@@ -586,7 +586,7 @@ dictHub:
     LICENSE_ORGANIZATION_IDS: "global"
     ORGANIZATION_ID: ""
     ISPB: ""
-    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-btg-mock:4103"
+    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-provider-mock:4103"
     CRM_BASE_URL: ""
     CRM_CLIENT_ID: ""
     CRM_ORGANIZATION_ID: ""
@@ -716,7 +716,7 @@ dictHubVsync:
     PLUGIN_AUTH_ENABLED: "false"
     PLUGIN_AUTH_URL: "http://plugin-access-manager-auth.midaz-plugins.svc.cluster.local:4000"
     ORGANIZATION_ID: ""
-    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-btg-mock:4103"
+    ADAPTER_BASE_URL: "http://plugin-br-pix-switch-adapter-provider-mock:4103"
     CRM_BASE_URL: ""
     CRM_CLIENT_ID: ""
     CRM_ORGANIZATION_ID: ""
@@ -1324,7 +1324,7 @@ cobSystemplane:
 # Two ingress objects, both routed by path prefix:
 #
 #   appsIngress         — user-facing traffic (SPI, DICT/COB hub+proxy, optional
-#                         adapter-btg-mock). Single hostname.
+#                         adapter-provider-mock). Single hostname.
 #   systemplaneIngress  — admin/runtime-config traffic (SPI/DICT/COB systemplanes).
 #                         Separate hostname so operators can apply stricter
 #                         annotations (auth, IP allowlist, WAF) than the apps
@@ -1750,13 +1750,13 @@ systemplaneIngress:
       serviceName: adapter-lerian-systemplane
 
 # -----------------------------------------------------------------------------
-# Providers Ingress — outbound-provider adapters (BTG mock, BACEN, JD, ...).
+# Providers Ingress — outbound-provider adapters (provider mock, BACEN, JD, ...).
 #
 # Single hostname routes provider traffic by path prefix. Each route names a
 # component already defined in the chart (or one a future PR adds) and the
 # kebab-case Service name suffix.
 #
-# Today only adapter-btg-mock is shipped; BACEN and JD providers will be
+# Today only adapter-provider-mock is shipped; BACEN and JD providers will be
 # added as components in future PRs and exposed here under their own paths.
 # -----------------------------------------------------------------------------
 providersIngress:
@@ -1767,12 +1767,12 @@ providersIngress:
   tls: []
   routes:
     # Path must match the source-side routePrefix:
-    #   apps/adapter-btg-mock/components/api/bootstrap/server.go
-    #     const routePrefix = "/btg-mock"
-    - path: /btg-mock
+    #   apps/adapter-provider-mock/components/api/bootstrap/server.go
+    #     const routePrefix = "/provider-mock"
+    - path: /provider-mock
       pathType: Prefix
-      component: adapterBtgMock
-      serviceName: adapter-btg-mock
+      component: adapterProviderMock
+      serviceName: adapter-provider-mock
     - path: /lerian
       pathType: Prefix
       component: adapterLerian


### PR DESCRIPTION
## Pull Request Type

- [x] Plugin BR PIX Switch

## Description

Phase 2 of a 3-repo rename (Phase 1, `plugin-br-pix-switch`, already merged): renames the `adapterBtgMock` Helm values key, Service/Deployment name, and `providersIngress` route to `adapterProviderMock` / `/provider-mock`, matching the app-identity rename already shipped in `plugin-br-pix-switch`.

This project is not in production yet — no environment applies this chart version, so this is a plain rename with no real upgrade path to document. No breaking-change marker, no version bump, no migration guide.

### Breaking Changes

None. Not marked as a breaking-change commit — nothing is deployed against this chart yet.

## Testing

- `helm lint` with `adapterProviderMock.enabled=true` + `providersIngress` enabled: 0 chart(s) failed
- `helm template` rendered: providers Ingress path `/provider-mock` backing the renamed Service; Service `plugin-br-pix-switch-adapter-provider-mock` renders; all three sibling `ADAPTER_BASE_URL` (spi, dict-hub, dict-hub-vsync ConfigMaps) print `http://plugin-br-pix-switch-adapter-provider-mock:4103`
- Full default-values render (53 resources): zero leftover `btg-mock`/`BtgMock` strings
- minikube install not run (not available in this environment) — install-time smoke test deferred

## Related Issues

Phase 1: https://github.com/LerianStudio/plugin-br-pix-switch/pull/367