### PR TITLE
fix(pipe): send release Slack message to OPS channel

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -15,7 +15,7 @@ on:
       SLACK_BOT_TOKEN_HELM:
         description: 'Slack Bot Token for Helm notifications'
         required: true
-      SLACK_CHANNEL_DEVOPS:
+      SLACK_CHANNEL_OPS:
         description: 'Slack channel ID for notifications'
         required: true
       SLACK_GROUP_TECH_SUPPORT:
@@ -130,7 +130,7 @@ jobs:
           # Build Slack payload with blocks at root level (avoids "show more" collapse)
           # Use attachment only for the color bar indicator
           SLACK_PAYLOAD=$(jq -n \
-            --arg channel "${{ secrets.SLACK_CHANNEL_DEVOPS }}" \
+            --arg channel "${{ secrets.SLACK_CHANNEL_OPS }}" \
             --arg chart_name "$CHART_NAME" \
             --arg chart_version "$CHART_VERSION" \
             --arg release_url "$RELEASE_URL" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,5 +222,5 @@ jobs:
       chart_path: ${{ matrix.chart.working_dir }}
     secrets:
       SLACK_BOT_TOKEN_HELM: ${{ secrets.SLACK_BOT_TOKEN_HELM }}
-      SLACK_CHANNEL_DEVOPS: ${{ secrets.SLACK_CHANNEL_DEVOPS }}
+      SLACK_CHANNEL_OPS: ${{ secrets.SLACK_CHANNEL_OPS }}
       SLACK_GROUP_TECH_SUPPORT: ${{ secrets.SLACK_GROUP_TECH_SUPPORT }}


### PR DESCRIPTION
## What

Switches the **release-opened** Slack notification (\"New Release :rocket:\") from \`SLACK_CHANNEL_DEVOPS\` to \`SLACK_CHANNEL_OPS\`.

Changes:
- \`release-notification.yml\`: rename the required secret \`SLACK_CHANNEL_DEVOPS\` → \`SLACK_CHANNEL_OPS\` (declaration + usage in the Slack payload).
- \`release.yml\` (\`notify-release\` caller): map \`SLACK_CHANNEL_OPS: \${{ secrets.SLACK_CHANNEL_OPS }}\`.

## Why

The release notification should land in the OPS channel. The **release-PR** notification stays on the previous channel (not touched here). \`app-sync.yml\` still uses \`SLACK_CHANNEL_DEVOPS\` and is intentionally left unchanged.

## Note

Requires the \`SLACK_CHANNEL_OPS\` repo secret to be configured (already referenced by \`helm-upgrade-doc.yml\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)