### PR TITLE
feat(pipe): release legacy chart lines from hotfix branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+      # Chart line branches for legacy patches, e.g. hotfix/midaz-5.7.x
+      - 'hotfix/*.x'
     paths-ignore:
       - 'README.md'
       - '**/CHANGELOG.md'
@@ -24,7 +26,9 @@ jobs:
     name: Get Changed Paths
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
-      matrix: ${{ steps.changed-paths.outputs.matrix }}
+      matrix: ${{ steps.restrict.outputs.matrix }}
+      chart_line_chart: ${{ steps.restrict.outputs.chart_line_chart }}
+      chart_line_range: ${{ steps.restrict.outputs.chart_line_range }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -38,6 +42,50 @@ jobs:
           filter_paths: charts/
           get_app_name: true
           path_level: 2
+
+      - name: Restrict matrix on chart line branches
+        id: restrict
+        env:
+          MATRIX: ${{ steps.changed-paths.outputs.matrix }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          CHART=""
+          RANGE=""
+
+          case "${REF_NAME}" in
+            hotfix/*.x)
+              STEM="${REF_NAME#hotfix/}"
+              CHART=$(printf '%s' "${STEM}" | sed -nE 's/^(.+)-[0-9]+\.[0-9]+\.x$/\1/p')
+              RANGE=$(printf '%s' "${STEM}" | sed -nE 's/^.+-([0-9]+\.[0-9]+\.x)$/\1/p')
+              ;;
+          esac
+
+          if [ -z "${CHART}" ]; then
+            {
+              echo "matrix=${MATRIX}"
+              echo "chart_line_chart="
+              echo "chart_line_range="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::notice::Chart line branch — restricting the release matrix to '${CHART}' in range ${RANGE}"
+
+          # A chart line branch releases only its own chart. Anything else that
+          # changed on the branch would be released with the wrong version range.
+          RESTRICTED=$(printf '%s' "${MATRIX}" | jq -c --arg chart "${CHART}" '[.[] | select(.name == $chart)]')
+
+          if [ "${RESTRICTED}" = "[]" ]; then
+            echo "::notice::No change to charts/${CHART} in this push — nothing to release"
+          fi
+
+          {
+            echo "matrix=${RESTRICTED}"
+            echo "chart_line_chart=${CHART}"
+            echo "chart_line_range=${RANGE}"
+          } >> "$GITHUB_OUTPUT"
 
   release-helm-chart:
     needs: get-changed-paths
@@ -139,6 +187,9 @@ jobs:
           go build -o update-chart-version-readme-bin ./update-chart-version-readme
 
       - name: Generate .releaserc file
+        env:
+          CHART_LINE_RANGE: ${{ needs.get-changed-paths.outputs.chart_line_range }}
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           CHART_NAME="${{ matrix.chart.name }}"
           CHART_PATH="${{ matrix.chart.working_dir }}"
@@ -160,6 +211,18 @@ jobs:
               .plugins[3][1].successCmd = $successCmd |
               .plugins[3][1].prepareCmd = $prepareCmd' \
             .github/configs/.releaserc.json > .releaserc
+
+          # On a chart line branch, register it as a semantic-release maintenance
+          # branch so the next version stays inside its range (e.g. 5.7.x -> 5.7.1)
+          if [ -n "${CHART_LINE_RANGE}" ]; then
+            jq \
+              --arg name "${BRANCH_NAME}" \
+              --arg range "${CHART_LINE_RANGE}" \
+              '.branches += [{name: $name, range: $range, channel: $range}]' \
+              .releaserc > .releaserc.tmp && mv .releaserc.tmp .releaserc
+          fi
+
+          jq . .releaserc
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,14 @@ jobs:
               STEM="${REF_NAME#hotfix/}"
               CHART=$(printf '%s' "${STEM}" | sed -nE 's/^(.+)-[0-9]+\.[0-9]+\.x$/\1/p')
               RANGE=$(printf '%s' "${STEM}" | sed -nE 's/^.+-([0-9]+\.[0-9]+\.x)$/\1/p')
+
+              # The trigger glob is looser than this parser, so a branch such as
+              # hotfix/foo.x or hotfix/midaz-5.x reaches here unparsed. Falling
+              # through would release every changed chart without a range.
+              if [ -z "${CHART}" ] || [ -z "${RANGE}" ]; then
+                echo "::error::'${REF_NAME}' looks like a chart line branch but does not match <chart>-<major>.<minor>.x — refusing to release"
+                exit 1
+              fi
               ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,9 @@ jobs:
           case "${REF_NAME}" in
             hotfix/*.x)
               STEM="${REF_NAME#hotfix/}"
-              CHART=$(printf '%s' "${STEM}" | sed -nE 's/^(.+)-[0-9]+\.[0-9]+\.x$/\1/p')
-              RANGE=$(printf '%s' "${STEM}" | sed -nE 's/^.+-([0-9]+\.[0-9]+\.x)$/\1/p')
+              # Leading zeros are rejected: semver reads 01.02.x as an invalid range
+              CHART=$(printf '%s' "${STEM}" | sed -nE 's/^(.+)-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.x$/\1/p')
+              RANGE=$(printf '%s' "${STEM}" | sed -nE 's/^.+-((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.x)$/\1/p')
 
               # The trigger glob is looser than this parser, so a branch such as
               # hotfix/foo.x or hotfix/midaz-5.x reaches here unparsed. Falling


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type
[//]: # (Check the appropriate box for the type of pull request.)

- [ ] Midaz
- [ ] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [x] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] BR STA
- [ ] BR CCS
- [ ] BR SLC

## Checklist
Please check each item after it's completed.

- [x] I have tested these changes locally.
- [ ] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

### Why this targets `main`

Same change as #1870, which landed on `develop`. It has to be on `main` to have any effect.

`helm-update-chart` creates a chart line branch **from `main`** (`legacy_branch_source: main`). GitHub runs a workflow from the copy that exists on the ref receiving the push, so a `hotfix/<chart>-<major>.<minor>.x` branch seeded from `main` would carry `main`'s `release.yml` — without the `hotfix/*.x` trigger and without the maintenance range. With the change only on `develop`, the whole legacy-patch path is inert.

`main` is also the authoritative copy of this file: it already carries `fix(pipe): drop chart :latest OCI tagging and main->develop back-merge` (215a2387), which `develop` does not. These two commits are cherry-picked onto `main`'s version, so the `Detect library chart` / Plugin Lifecycle Management steps and the absence of the `latest` OCI tagging are preserved as they are on `main`.

### What changes

**Trigger** — `release.yml` also triggers on `push` to `hotfix/*.x`. The glob requires the `.x` suffix, so ordinary hotfix branches such as `hotfix/product-console-dockerhub-install` are unaffected.

**Matrix restriction** — new `Restrict matrix on chart line branches` step in `get-changed-paths`. On a chart line branch it derives the chart and the range from the branch name and filters the release matrix down to that chart; anything else that changed on the branch would otherwise be released under the wrong version range. A branch that matches the trigger glob but not `<chart>-<major>.<minor>.x` (e.g. `hotfix/foo.x`, `hotfix/midaz-5.x`) fails the run instead of silently falling through to the full matrix. Off a chart line branch the matrix passes through untouched.

**Maintenance range** — `Generate .releaserc file` appends the branch to `.branches` as a semantic-release maintenance branch when a range was derived:

```json
{ "name": "hotfix/midaz-5.7.x", "range": "5.7.x", "channel": "5.7.x" }
```

so the next version stays inside the line: `5.7.0` → `5.7.1`. The generated config is printed for auditability.

`Publish Release in Plugin Lifecycle Management` and `notify-release` are already gated on `refs/heads/main`, so a legacy patch is never registered or announced as latest.

### Local validation

Branch-name parsing:

| Branch | Result |
|---|---|
| `hotfix/midaz-5.7.x` | chart `midaz`, range `5.7.x` |
| `hotfix/plugin-br-pix-indirect-btg-3.4.x` | chart `plugin-br-pix-indirect-btg`, range `3.4.x` |
| `hotfix/foo.x` | error, exit 1 |
| `hotfix/midaz-5.x` | error, exit 1 |
| `hotfix/product-console-dockerhub-install` | full-matrix pass-through |
| `develop` / `main` | full-matrix pass-through |

The pre-existing `hotfix/pix-btg-3.4.x` branch parses to chart `pix-btg`, which is not a chart directory, so the matrix restricts to `[]` and nothing is released from it.

`.releaserc` generation verified against `.github/configs/.releaserc.json` — the injected entry lands correctly alongside `main` and the `develop` prerelease entry.

`actionlint` (with shellcheck) reports no new findings on `release.yml`; the remaining ones are pre-existing (`blacksmith-*` runner labels, `actions/checkout@v3`, the `setup-helm` step id).

### Sequencing

1. Companion PR in the shared workflows: LerianStudio/github-actions-shared-workflows#662
2. This PR — safe to merge independently. Until the shared workflow ships, no `hotfix/*.x` branch exists, so the new trigger has nothing to fire on. `.github/workflows/**` is in `paths-ignore`, so merging this does not itself trigger a release.
3. Once the shared workflows cut a release, bump the pin in `app-sync.yml` (currently `@v1.36.8`) to that version. **Not included here** — the version does not exist yet.

Supersedes the effect of #1870, which is already merged into `develop` and left in place — harmless there, but not sufficient on its own.
