### PR TITLE
fix(plugin-br-bank-transfer): update plugin-br-bank-transfer@1.2.1

### DIFF
--- a/charts/plugin-br-bank-transfer/Chart.yaml
+++ b/charts/plugin-br-bank-transfer/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 
 version: 1.4.0
 
-appVersion: "1.2.0"
+appVersion: "1.2.1"
 
 keywords:
   - bank-transfer

--- a/charts/plugin-br-bank-transfer/values.yaml
+++ b/charts/plugin-br-bank-transfer/values.yaml
@@ -82,7 +82,7 @@ bankTransfer:
     # -- Image pull policy
     pullPolicy: IfNotPresent
     # -- Image tag used for deployment
-    tag: "1.2.0"
+    tag: "1.2.1"
   # -- PostgreSQL migrations job (Helm hook pre-install,pre-upgrade; ArgoCD PreSync).
   # The chart-managed Secret is rendered as an earlier hook (weight -5 / sync-wave -5),
   # so it exists before this migration hook (weight -1) — migrations run against the


### PR DESCRIPTION
## What

Bumps `plugin-br-bank-transfer` **appVersion** and the bank-transfer image **tag** from `1.2.0` to `1.2.1`.

## Why / context

Recreated on `main` from the bot PR **#1845**, which targeted `develop` (being retired) and bumped from `1.1.9`. `main` was already at `1.2.0`, so on main the update is the `1.2.0 → 1.2.1` patch. Only `appVersion` + the image tag change; the chart `version` is left to the release pipeline (auto-bumped on merge). The bundled valkey image (`8.0.2`) is untouched.

Supersedes #1845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)