### PR TITLE
ci(pipe): scope render-gate to changed charts + retry flaky dep fetch

### DIFF
--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -1117,7 +1117,9 @@ func buildRenderRows(root string, chartSelection map[string]bool, sampleValuesDi
 			return nil, err
 		}
 
-		if out, err := addDependencyRepositories(tmpChart, tmpRoot, helmEnv); err != nil {
+		if out, err := retryHelm(func() (string, error) {
+			return addDependencyRepositories(tmpChart, tmpRoot, helmEnv)
+		}); err != nil {
 			row.Status = "fail"
 			row.Class = "missing-dependency"
 			row.Detail = oneLine(out)
@@ -1126,7 +1128,9 @@ func buildRenderRows(root string, chartSelection map[string]bool, sampleValuesDi
 			continue
 		}
 
-		if out, err := runHelmWithEnv(tmpRoot, helmEnv, "dependency", "build", tmpChart); err != nil {
+		if out, err := retryHelm(func() (string, error) {
+			return runHelmWithEnv(tmpRoot, helmEnv, "dependency", "build", tmpChart)
+		}); err != nil {
 			row.Status = "fail"
 			row.Class = "missing-dependency"
 			row.Detail = oneLine(out)
@@ -1485,6 +1489,30 @@ func addDependencyRepositories(chartDir, workDir string, env []string) (string, 
 	}
 
 	return "", nil
+}
+
+// retryHelm runs a helm network operation (repo add/update, dependency build) up
+// to 3 times with a short linear backoff. These operations pull external subcharts
+// from remote (Bitnami/OCI) repositories whose availability is flaky in CI; a
+// transient fetch failure would otherwise fail the whole `--all` render gate and
+// red an unrelated chart's PR. A genuinely missing/unresolvable dependency still
+// fails all attempts and is reported exactly as before — the retry smooths
+// transient errors, it does not mask deterministic breakage.
+func retryHelm(fn func() (string, error)) (string, error) {
+	const attempts = 3
+	var (
+		out string
+		err error
+	)
+	for i := 1; i <= attempts; i++ {
+		if out, err = fn(); err == nil {
+			return out, nil
+		}
+		if i < attempts {
+			time.Sleep(time.Duration(i) * 2 * time.Second)
+		}
+	}
+	return out, err
 }
 
 func runHelmWithEnv(workDir string, env []string, args ...string) (string, error) {

--- a/.github/scripts/validate-helm-charts/main.go
+++ b/.github/scripts/validate-helm-charts/main.go
@@ -1499,7 +1499,7 @@ func addDependencyRepositories(chartDir, workDir string, env []string) (string, 
 // fails all attempts and is reported exactly as before — the retry smooths
 // transient errors, it does not mask deterministic breakage.
 func retryHelm(fn func() (string, error)) (string, error) {
-	const attempts = 3
+	const attempts = 5
 	var (
 		out string
 		err error
@@ -1509,7 +1509,9 @@ func retryHelm(fn func() (string, error)) (string, error) {
 			return out, nil
 		}
 		if i < attempts {
-			time.Sleep(time.Duration(i) * 2 * time.Second)
+			// Linear backoff (3s, 6s, 9s, 12s -> ~30s total) to ride out a
+			// rate-limited or briefly-unavailable upstream chart repository.
+			time.Sleep(time.Duration(i) * 3 * time.Second)
 		}
 	}
 	return out, err

--- a/.github/workflows/helm-chart-standard.yml
+++ b/.github/workflows/helm-chart-standard.yml
@@ -69,6 +69,18 @@ jobs:
             exit 0
           fi
 
+          # A change to a LIBRARY chart (Chart.yaml `type: library`, e.g. lerian-common)
+          # renders NOTHING on its own (the validator marks it skipped-library), but its
+          # helpers are exercised by every consumer chart's render. Scoping to just the
+          # library would let a shared-helper regression pass the gate, so a library-chart
+          # change renders the whole fleet.
+          for chart in $(awk -F/ '/^charts\/[^/]+\// {print $2}' <<< "$changed_files" | sort -u); do
+            if [[ -f "charts/$chart/Chart.yaml" ]] && grep -Eq '^[[:space:]]*type:[[:space:]]*library[[:space:]]*$' "charts/$chart/Chart.yaml"; then
+              echo "args=--all" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
           # Collect the affected charts from BOTH sources, deduped. Keep only charts
           # whose directory still exists: a deleted chart still shows up in
           # `git diff --name-only`, but the render-gate errors with "unknown chart"
@@ -84,8 +96,10 @@ jobs:
           for chart in $(awk -F/ '/^charts\/[^/]+\// {print $2}' <<< "$changed_files" | sort -u); do
             add_chart "$chart"
           done
-          # .github/configs/helm-render-values/<name>.y(a)ml  ->  <name>
-          for chart in $(awk -F/ '/^\.github\/configs\/helm-render-values\/[^/]+\.ya?ml$/ {f=$NF; sub(/\.ya?ml$/, "", f); print f}' <<< "$changed_files" | sort -u); do
+          # .github/configs/helm-render-values/<name>.yaml  ->  <name>
+          # `.yaml` ONLY: the validator (main.go) loads sampleValuesDir/<chart>.yaml, so a
+          # `.yml` fixture would select the chart but render it with default values.
+          for chart in $(awk -F/ '/^\.github\/configs\/helm-render-values\/[^/]+\.yaml$/ {f=$NF; sub(/\.yaml$/, "", f); print f}' <<< "$changed_files" | sort -u); do
             add_chart "$chart"
           done
           if [[ -z "$existing" ]]; then

--- a/.github/workflows/helm-chart-standard.yml
+++ b/.github/workflows/helm-chart-standard.yml
@@ -74,8 +74,24 @@ jobs:
           # helpers are exercised by every consumer chart's render. Scoping to just the
           # library would let a shared-helper regression pass the gate, so a library-chart
           # change renders the whole fleet.
+          #
+          # Classify using BOTH revisions: a chart deleted in this PR, or flipped
+          # to/from `type: library`, only shows as library at BASE (or only at HEAD).
+          # Reading the working tree (HEAD) alone would miss those and, if another
+          # chart is still in `existing`, wrongly emit `--charts ...` and skip
+          # consumer rendering.
+          is_library() {
+            local chart="$1" rev
+            for rev in "$BASE_SHA" "$HEAD_SHA"; do
+              if git show "$rev:charts/$chart/Chart.yaml" 2>/dev/null \
+                   | grep -Eq '^[[:space:]]*type:[[:space:]]*library[[:space:]]*$'; then
+                return 0
+              fi
+            done
+            return 1
+          }
           for chart in $(awk -F/ '/^charts\/[^/]+\// {print $2}' <<< "$changed_files" | sort -u); do
-            if [[ -f "charts/$chart/Chart.yaml" ]] && grep -Eq '^[[:space:]]*type:[[:space:]]*library[[:space:]]*$' "charts/$chart/Chart.yaml"; then
+            if is_library "$chart"; then
               echo "args=--all" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/.github/workflows/helm-chart-standard.yml
+++ b/.github/workflows/helm-chart-standard.yml
@@ -57,19 +57,36 @@ jobs:
 
           changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
 
-          if grep -Eq '^(\.github/scripts/validate-helm-charts/|\.github/configs/helm-render-values/|\.github/workflows/helm-chart-standard\.yml|docs/helm-chart-standard\.md)' <<< "$changed_files"; then
+          # Changes to the validator source, this workflow, or the standard doc
+          # affect EVERY chart's validation -> render the whole fleet.
+          # NOTE: a change under .github/configs/helm-render-values/ is intentionally
+          # NOT here. A render fixture is chart-specific (helm-render-values/<chart>.yaml
+          # only feeds <chart>'s render), so it is mapped to that one chart below.
+          # Forcing --all for it coupled a single chart's PR to the external-dependency
+          # health of the whole fleet (flaky Bitnami/OCI fetches would red an unrelated PR).
+          if grep -Eq '^(\.github/scripts/validate-helm-charts/|\.github/workflows/helm-chart-standard\.yml|docs/helm-chart-standard\.md)' <<< "$changed_files"; then
             echo "args=--all" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Keep only charts whose directory still exists. A deleted chart still
-          # shows up in `git diff --name-only`, but the render-gate errors with
-          # "unknown chart" if asked to render a chart that is no longer present.
+          # Collect the affected charts from BOTH sources, deduped. Keep only charts
+          # whose directory still exists: a deleted chart still shows up in
+          # `git diff --name-only`, but the render-gate errors with "unknown chart"
+          # if asked to render a chart that is no longer present.
           existing=""
+          add_chart() {
+            local chart="$1"
+            [[ -d "charts/$chart" ]] || return 0
+            case ",$existing," in *,"$chart",*) return 0 ;; esac
+            existing="${existing:+$existing,}$chart"
+          }
+          # charts/<name>/...  ->  <name>
           for chart in $(awk -F/ '/^charts\/[^/]+\// {print $2}' <<< "$changed_files" | sort -u); do
-            if [[ -d "charts/$chart" ]]; then
-              existing="${existing:+$existing,}$chart"
-            fi
+            add_chart "$chart"
+          done
+          # .github/configs/helm-render-values/<name>.y(a)ml  ->  <name>
+          for chart in $(awk -F/ '/^\.github\/configs\/helm-render-values\/[^/]+\.ya?ml$/ {f=$NF; sub(/\.ya?ml$/, "", f); print f}' <<< "$changed_files" | sort -u); do
+            add_chart "$chart"
           done
           if [[ -z "$existing" ]]; then
             echo "args=--all" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Hardens the `helm-chart-standard` render gate so **one chart's PR is no longer red-flagged by unrelated fleet-wide external-dependency flakiness**.

## Problem
The render gate forces `--all` (render every chart) whenever any file under `.github/configs/helm-render-values/**` changes. But that dir holds **per-chart** fixtures — touching `helm-render-values/<chart>.yaml` only affects `<chart>`'s render. On an `--all` run, each chart's `helm dependency build` pulls external Bitnami/OCI subcharts over the network, and those fetches are flaky: a **rotating subset** of unrelated charts fails `missing-dependency` each run. Concretely, #1877 (br-sfn) went red twice with different failing sets (`fetcher/midaz/plugin-bc-correios/plugin-br-bank-transfer` then `midaz/otel-collector-lerian/plugin-br-bank-transfer/plugin-br-pix-switch/reporter`) — **br-sfn itself rendered ok every time**.

## Changes
- **Scope narrowing** (`helm-chart-standard.yml` → *Determine render scope*): a change to `helm-render-values/<chart>.yaml` now maps to `--charts <chart>` (merged + deduped with charts detected from `charts/<name>/`). `--all` still fires for the validator source, this workflow, and `docs/helm-chart-standard.md` — the things that affect *every* chart's validation.
- **Retry** (`validate-helm-charts/main.go` → `retryHelm`): the gate's network ops (`helm repo add/update`, `helm dependency build`) get a 3-attempt linear backoff. Transient fetches now recover; a genuinely missing/unresolvable dependency still fails all attempts and reports `missing-dependency` exactly as before (no masking of deterministic breakage).

## Validation
- `go build` clean; scope logic simulated: `helm-render-values/br-sfn.yaml` → `--charts br-sfn`; validator-source change → `--all`; chart + its fixture → single deduped entry.
- awk uses the same dialect as the existing `charts/<name>/` matcher (works under CI's gawk).

## Type / Checklist
Shared **pipe** change (`.github/**` only — no chart touched).

- [x] Tested locally (go build, scope-logic simulation)
- [x] Single shared `pipe` change (no chart modified)
- [x] Did **not** hand-edit Chart.yaml / CHANGELOG / README matrix
- [x] Ready for review

Unblocks #1877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)