### PR TITLE
docs(doc): escape pipes in every gen-docs table cell

### DIFF
--- a/.claude/skills/productize-chart-env/scripts/gen-docs.py
+++ b/.claude/skills/productize-chart-env/scripts/gen-docs.py
@@ -120,8 +120,14 @@ def render(rows):
         out.write(f"## {sec}\n\n")
         out.write("| Key | Type | Default | Description |\n|-----|------|---------|-------------|\n")
         for key, typ, default, desc in sections[sec]:
+            # Escape pipes in EVERY cell — a `|` in a type (e.g. `enum: all|split`),
+            # default, or description otherwise reads as a column separator and shifts
+            # the whole row. (The `(enum: a|b)` annotation must keep its pipe for
+            # gen-schema, so the escaping has to happen here at render time.)
             d = default.replace("|", "\\|")
-            out.write(f"| `{key}` | {typ} | `{d}` | {desc} |\n")
+            t = typ.replace("|", "\\|")
+            ds = desc.replace("|", "\\|")
+            out.write(f"| `{key}` | {t} | `{d}` | {ds} |\n")
         out.write("\n")
     # Exactly one trailing newline (no blank line at EOF → passes `git diff --check`).
     return out.getvalue().rstrip("\n") + "\n"


### PR DESCRIPTION
## What

`productize-chart-env/scripts/gen-docs.py` escaped `|` only in the **Default** cell. A pipe in a **Type** (e.g. `enum: all|split`) or **Description** cell reads as a Markdown column separator and shifts the whole row. Escape all three cells at render time.

The `(enum: a|b)` annotation must keep its pipe (gen-schema splits the enum on it), so the fix is at render time, not in the source comment.

## Why

Surfaced on the streaming-hub productization (#1712): the `streamingHub.mode` row (`enum: all|split`) rendered a broken README.params table. That chart's README.params was regenerated with this fix; this PR makes it systemic so any chart's docs regenerate correctly.

## Verification

`py_compile` clean; a synthetic `(enum: all|split)` value now renders `enum: all\|split` (escaped) in the Type cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)