### PR TITLE
fix(midaz): run ledger/tracer migrations as ArgoCD Sync hooks

### DIFF
--- a/charts/midaz/templates/ledger/migrations-job.yaml
+++ b/charts/midaz/templates/ledger/migrations-job.yaml
@@ -43,14 +43,20 @@ metadata:
   labels:
     {{- include "midaz.labels" (dict "context" . "component" (printf "%s-migrations" .Values.ledger.name) "name" (printf "%s-migrations" .Values.ledger.name) ) | nindent 4 }}
   annotations:
-    {{- /* The Job name is pinned to the migrations image tag, so a chart-only bump
-       (new alpha) keeps the name but changes the pod template — via the volatile
-       helm.sh/chart label the shared labels helper stamps into spec.template. A Job
-       spec is immutable, so ArgoCD's apply/patch fails with
-       "spec.template: field is immutable" and the sync stalls. Replace=true,Force=true
-       makes ArgoCD delete+recreate the Job instead of patching it; re-running is safe
-       because golang-migrate tracks progress in schema_migrations, not on disk. */}}
-    argocd.argoproj.io/sync-options: Replace=true,Force=true
+    {{- /* Run the migration as an ArgoCD Sync hook so it is excluded from the app's
+       desired-state diff. As a plain tracked resource the tag-pinned Job name
+       (…-migrations-<tag>) left every prior release's Job live with no Git source,
+       so ArgoCD held them OutOfSync ("ignored (requires pruning)") and the app never
+       reached Synced — the sync-wait gate then timed out even though the deploy was
+       Healthy. A hook never enters the diff. hook-delete-policy keeps hooks from
+       piling up: HookSucceeded removes the Job once it completes, BeforeHookCreation
+       clears a same-named leftover before a re-sync recreates it (a Job spec is
+       immutable, so recreate — not patch — is required on a chart-only bump). Sync
+       phase, not PreSync, keeps the Job in the same wave as the password Secret it
+       reads, so fresh installs are unaffected. Re-running is safe: golang-migrate
+       tracks progress in schema_migrations. */}}
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
     {{- with $migrations.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/midaz/templates/tracer/migrations-job.yaml
+++ b/charts/midaz/templates/tracer/migrations-job.yaml
@@ -37,11 +37,16 @@ metadata:
   labels:
     {{- include "midaz-tracer.labels" (dict "context" . "name" (printf "%s-migrations" .Values.tracer.name) ) | nindent 4 }}
   annotations:
-    {{- /* Same immutable-Job guard as the ledger migrations: the tag-pinned Job name
-       survives chart-only bumps while the volatile helm.sh/chart label changes the
-       (immutable) pod template. Replace=true,Force=true has ArgoCD recreate rather
-       than patch; re-running is idempotent (progress lives in schema_migrations). */}}
-    argocd.argoproj.io/sync-options: Replace=true,Force=true
+    {{- /* Run the migration as an ArgoCD Sync hook so it is excluded from the app's
+       desired-state diff — same rationale as the ledger migrations Job. Tag-pinned
+       names left prior releases' Jobs OutOfSync ("ignored (requires pruning)"), so
+       the app never reached Synced and the sync-wait gate timed out. A hook never
+       enters the diff; HookSucceeded removes the Job on completion and
+       BeforeHookCreation clears a same-named leftover before recreate (Job spec is
+       immutable). Sync phase keeps it in the same wave as the password Secret, so
+       fresh installs are unaffected. Re-running is idempotent (schema_migrations). */}}
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
     {{- with $migrations.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Problem

The `update_gitops` deploy job for `midaz` fails at the ArgoCD sync-wait step:

```
timed out (600s) waiting for app "benedita-midaz-dev-st" match desired state
Timeout waiting for sync completion of benedita-midaz-dev-st after 3 attempts
```

The rollout itself is fine — app `Health: Healthy`, sync operation `Phase: Succeeded`, migrations applied. But the app stays `OutOfSync` forever because of stale migration Jobs:

```
batch  Job  midaz-ledger-migrations-4.0.0-beta.31  OutOfSync  Healthy  ignored (requires pruning)
batch  Job  midaz-ledger-migrations-4.0.0-beta.32  OutOfSync  Healthy  ignored (requires pruning)
batch  Job  midaz-tracer-migrations-4.0.0-beta.31  OutOfSync  Healthy  ignored (requires pruning)
batch  Job  midaz-tracer-migrations-4.0.0-beta.32  OutOfSync  Healthy  ignored (requires pruning)
```

Migration Job names are pinned to the image tag (`…-migrations-<tag>`), so each release renders a new Job and prior ones drop out of the desired state. They require pruning (disabled), so they linger `OutOfSync` and the app never reaches `Synced` — the CI sync-wait gate then times out on every deploy. Verified live on benedita `midaz-dev-st`.

## Fix

Mark both migration Jobs as ArgoCD **Sync hooks** so they are excluded from the desired-state diff:

- `argocd.argoproj.io/hook: Sync`
- `argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded` — `HookSucceeded` deletes the Job on completion (no accumulation); `BeforeHookCreation` clears a same-named leftover before a re-sync recreates it (a Job spec is immutable, so recreate, not patch).
- Drop `argocd.argoproj.io/sync-options: Replace=true,Force=true` — no longer needed, hooks recreate rather than patch.

This mirrors the existing pattern in `charts/br-sisbajud/templates/migrations/job.yaml`. `Sync` (not `PreSync`) is deliberate: the midaz ledger/tracer password Secrets are plain tracked resources, so `Sync` keeps the migration in the same wave as the Secret it reads and fresh installs are unaffected.

## Scope

- `charts/midaz/templates/ledger/migrations-job.yaml`
- `charts/midaz/templates/tracer/migrations-job.yaml`

Annotations only — Job name, helpers, and pod spec unchanged.

## Notes

- Existing clusters: the 4 stale beta.31/beta.32 Jobs still need a one-time `kubectl delete` (or they age out via `ttlSecondsAfterFinished`); after this lands, new releases self-clean.
- `helm template` not run here (helm not installed locally) — change is annotations-only.
