### PR TITLE
fix(pipe): route legacy patches to chart line branches on app-sync

### DIFF
--- a/.github/workflows/app-sync.yml
+++ b/.github/workflows/app-sync.yml
@@ -10,10 +10,16 @@ on:
 
 jobs:
   update:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-update-chart.yml@v1.36.8
+    # v1.55.0 honours the is_legacy_patch/version_line fields the senders already emit,
+    # routing a maintenance-line release to hotfix/<chart>-<major>.<minor>.x (cut from
+    # main) instead of overwriting the mainline chart. release.yml already releases from
+    # hotfix/*.x, so this closes the loop. Contract is additive between the two versions:
+    # only the four legacy_* inputs appear, none removed or renamed, secrets unchanged.
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-update-chart.yml@v1.55.0
     with:
       payload: ${{ inputs.payload }}
-      base_branch: develop
+      # develop is retired for this repo (see the PR template): mainline updates belong on main.
+      base_branch: main
       slack_notification: true
     secrets:
       APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [ ] Midaz
- [ ] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [x] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] BR STA
- [ ] BR CCS
- [ ] BR SLC
- [ ] Common

## Checklist

- [x] I have tested these changes locally (or cut an **Alpha Release** from my branch — see below).
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] This PR modifies **only one chart** (or is a single shared `pipe`/`doc` change).
- [x] I did **not** hand-edit `Chart.yaml` `version`, `CHANGELOG.md`, or the README version matrix (CI owns these).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Dois defeitos no receptor do dispatch, ambos visíveis no PR automático #1880.

### 1. Legacy patches sobrescrevendo o chart mainline

Os emissores já emitem `is_legacy_patch` e `version_line` — confirmado no run do `plugin-br-pix-jd`:

```
::notice::Legacy patch detected — source branch 'maintenance/v1.10.x', version line 1.10
"is_legacy_patch": true,  "version_line": "1.10"
HTTP Status: 204
```

Mas este receptor estava pinado em `helm-update-chart.yml@v1.36.8`, anterior à feature. Como os campos são **aditivos**, foram silenciosamente ignorados e o patch da linha 1.10 caiu no chart mainline — em #1880 isso apareceu como `appVersion: "1.10.5"` num chart `3.1.0-beta.3`.

`v1.55.0` honra os campos e roteia para `hotfix/<chart>-<major>.<minor>.x`, criada de `main` (`legacy_patch_enabled` default `true`, `legacy_branch_prefix: hotfix`, `legacy_branch_source: main`). O `release.yml` deste repo **já** libera a partir de `hotfix/*.x` (#1870), então este bump fecha o ciclo.

**Compatibilidade do contrato** entre `v1.36.8` e `v1.55.0` — diff dos inputs de `workflow_call`:

| Mudança | Inputs |
|---|---|
| Adicionados | `legacy_patch_enabled`, `legacy_branch_prefix`, `legacy_branch_source`, `legacy_update_readme` |
| Removidos / renomeados | nenhum |
| `secrets:` | idênticos |

Puramente aditivo, então nenhum emissor existente muda de comportamento — exceto pelo roteamento legacy, que é o objetivo.

### 2. `base_branch: develop` aponta para uma branch retirada

O template deste repo é explícito: *"Target `main`. The `develop` branch is retired — do not target it."* Os updates mainline vinham abrindo PR contra `develop` (foi o que aconteceu no #1880). Corrigido para `main`, que é um valor permitido pelo `base_branch` do workflow.

### Ressalva conhecida para `plugin-br-pix-direct-jd`

Com este bump, o próximo dispatch dessa linha vai **falhar de propósito** no guard de resolução:

```
::error::No stable 'plugin-br-pix-direct-jd' chart tag has an appVersion in the 1.10 line.
Refusing to apply a legacy patch to the mainline chart.
```

O motivo é dado: nenhuma tag estável do chart tem `appVersion` na linha `1.10` — todas estão em `1.0.0` ou `1.2.1-beta.*`, enquanto o app está em 1.10/1.11/1.12. É o guard funcionando (melhor abortar que sujar o mainline, como em #1880), mas a linha 1.10 só será entregue depois de sincronizar o `appVersion` do chart ou semear `hotfix/plugin-br-pix-direct-jd-<linha>.x` a partir de `main` — o receptor reusa a branch quando ela existe, sem precisar resolver tag. Outros charts, cujo `appVersion` acompanha o app, não são afetados.

Emissor correspondente: LerianStudio/plugin-br-pix-jd#99.