### PR TITLE
fix(pipe): name chart line branches maintenance/, matching the app repos

### DIFF
--- a/.github/workflows/app-sync.yml
+++ b/.github/workflows/app-sync.yml
@@ -11,15 +11,20 @@ on:
 jobs:
   update:
     # v1.55.0 honours the is_legacy_patch/version_line fields the senders already emit,
-    # routing a maintenance-line release to hotfix/<chart>-<major>.<minor>.x (cut from
-    # main) instead of overwriting the mainline chart. release.yml already releases from
-    # hotfix/*.x, so this closes the loop. Contract is additive between the two versions:
+    # routing a maintenance-line release to <prefix>/<chart>-<major>.<minor>.x (cut from
+    # main) instead of overwriting the mainline chart. release.yml releases from those
+    # branches, so this closes the loop. Contract is additive between the two versions:
     # only the four legacy_* inputs appear, none removed or renamed, secrets unchanged.
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-update-chart.yml@v1.55.0
     with:
       payload: ${{ inputs.payload }}
       # develop is retired for this repo (see the PR template): mainline updates belong on main.
       base_branch: main
+      # Chart line branches use the same prefix as the app repos' maintenance lines,
+      # instead of the action's `hotfix` default. Every existing chart line branch must
+      # be renamed to this prefix: the resolver looks the branch up by <prefix>/<chart>-<line>.x
+      # and would otherwise create a second, duplicate line off main.
+      legacy_branch_prefix: maintenance
       slack_notification: true
     secrets:
       APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
       - develop
-      # Chart line branches for legacy patches, e.g. hotfix/midaz-5.7.x
+      # Chart line branches for legacy patches, e.g. maintenance/midaz-5.7.x.
+      # maintenance/* is the convention; hotfix/* stays accepted so lines created
+      # under the old prefix keep releasing until they are renamed.
+      - 'maintenance/*.x'
       - 'hotfix/*.x'
     paths-ignore:
       - 'README.md'
@@ -55,15 +58,15 @@ jobs:
           RANGE=""
 
           case "${REF_NAME}" in
-            hotfix/*.x)
-              STEM="${REF_NAME#hotfix/}"
+            maintenance/*.x|hotfix/*.x)
+              STEM="${REF_NAME#*/}"
               # Leading zeros are rejected: semver reads 01.02.x as an invalid range
               CHART=$(printf '%s' "${STEM}" | sed -nE 's/^(.+)-(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.x$/\1/p')
               RANGE=$(printf '%s' "${STEM}" | sed -nE 's/^.+-((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.x)$/\1/p')
 
               # The trigger glob is looser than this parser, so a branch such as
-              # hotfix/foo.x or hotfix/midaz-5.x reaches here unparsed. Falling
-              # through would release every changed chart without a range.
+              # maintenance/foo.x or maintenance/midaz-5.x reaches here unparsed.
+              # Falling through would release every changed chart without a range.
               if [ -z "${CHART}" ] || [ -z "${RANGE}" ]; then
                 echo "::error::'${REF_NAME}' looks like a chart line branch but does not match <chart>-<major>.<minor>.x — refusing to release"
                 exit 1


### PR DESCRIPTION
# Midaz Pull Request Checklist

## Pull Request Type

- [ ] Midaz
- [ ] Plugin Access Manager
- [ ] Plugin CRM
- [ ] Reporter
- [ ] Plugin Fees
- [ ] Plugin BR PIX Direct JD
- [ ] Plugin BR PIX Indirect BTG
- [ ] Plugin BR PIX Switch
- [ ] Plugin BR Bank Transfer
- [ ] Otel Collector
- [x] Pipeline
- [ ] Documentation
- [ ] Fetcher
- [ ] BR STA
- [ ] BR CCS
- [ ] BR SLC
- [ ] Common

## Checklist

- [x] I have tested these changes locally (or cut an **Alpha Release** from my branch — see below).
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] This PR modifies **only one chart** (or is a single shared `pipe`/`doc` change).
- [x] I did **not** hand-edit `Chart.yaml` `version`, `CHANGELOG.md`, or the README version matrix (CI owns these).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Chart line branches usavam o prefixo `hotfix/`, enquanto os repos de app que elas servem usam `maintenance/` (ex.: `maintenance/v1.10.x` no `plugin-br-pix-jd`). Mesmo conceito, dois nomes — este PR unifica em `maintenance/`.

### O que muda

| Arquivo | Mudança |
|---|---|
| `app-sync.yml` | passa `legacy_branch_prefix: maintenance` em vez de usar o default `hotfix` da action |
| `release.yml` | dispara em `maintenance/*.x` **e** `hotfix/*.x`; o parser tira o prefixo com `${REF_NAME#*/}` |

Manter `hotfix/` aceito é o que torna o rename seguro: uma linha ainda no nome antigo continua liberando, em vez de ficar muda no instante em que isto mergear.

### ⚠️ Renames necessários (senão a linha duplica)

O resolver procura a branch por `<prefix>/<chart>-<line>.x`. Uma linha deixada em `hotfix/` **não será encontrada** e o próximo dispatch dela vai cortar uma segunda linha, duplicada, a partir de `main`:

```
hotfix/plugin-br-pix-direct-jd-1.2.x  ->  maintenance/plugin-br-pix-direct-jd-1.2.x
hotfix/pix-btg-3.4.x                  ->  maintenance/pix-btg-3.4.x
```

Eu renomeio a `plugin-br-pix-direct-jd` junto com o merge. **A `pix-btg-3.4.x` é de outro produto — não vou renomear sem o dono saber.** Ela continua liberando normalmente (o parser aceita os dois prefixos), mas precisa do rename antes do próximo dispatch da linha 3.4 do `pix-btg`, senão duplica.

`hotfix/reporter-config-contract` não é chart line (não casa com `<chart>-<major>.<minor>.x`) e não é afetada.

### Verificação

Parser exercitado com os dois prefixos e com as formas malformadas que o glob do trigger deixa passar:

```
maintenance/plugin-br-pix-direct-jd-1.2.x  chart=plugin-br-pix-direct-jd  range=1.2.x
hotfix/pix-btg-3.4.x                       chart=pix-btg                  range=3.4.x
maintenance/foo.x                          chart=<vazio>  range=<vazio>  -> rejeitado
hotfix/midaz-5.x                           chart=<vazio>  range=<vazio>  -> rejeitado
```

O contexto de onde isso vem: LerianStudio/plugin-br-pix-jd#101 e #1885, que fecharam o ciclo de patch da linha 1.10 do app até o chart `1.2.9`.