### PR TITLE
feat(common): cover reporter SD-advertise + MT redis-CA contract

### DIFF
--- a/charts/lerian-common/templates/_multi_tenant.tpl
+++ b/charts/lerian-common/templates/_multi_tenant.tpl
@@ -40,6 +40,8 @@ Inputs (dict):
   emitRedis          (opt)  bool — REDIS_HOST / REDIS_PORT (6379) / REDIS_TLS
   requiredRedisHost  (opt)  bool — REDIS_HOST uses `required` vs default ""
   redisTlsDefault    (opt)  string — default for REDIS_TLS ("false"; "true" for tracer)
+  emitRedisCaCert    (opt)  bool — MULTI_TENANT_REDIS_CA_CERT (default ""); under emitRedis.
+                            For charts whose tenant-redis supports a CA cert (e.g. reporter).
   emitPool           (opt)  bool — MAX_TENANT_POOLS (100) + IDLE_TIMEOUT_SEC (300)
   emitCache          (opt)  bool — TIMEOUT (30) + CACHE_TTL_SEC (120) + CONNECTIONS_CHECK_INTERVAL_SEC (30)
   emitEnvironment    (opt)  bool — MULTI_TENANT_ENVIRONMENT (default "")
@@ -85,6 +87,10 @@ MULTI_TENANT_REDIS_HOST: {{ $redisHost | quote }}
 MULTI_TENANT_REDIS_PORT: {{ $redisPort | quote }}
 {{- $redisTls := ($g.redisTls | default (.redisTlsDefault | default "false")) -}}{{- if hasKey $c "MULTI_TENANT_REDIS_TLS" -}}{{- $redisTls = index $c "MULTI_TENANT_REDIS_TLS" -}}{{- end }}
 MULTI_TENANT_REDIS_TLS: {{ $redisTls | quote }}
+{{- if .emitRedisCaCert }}
+{{- $redisCaCert := ($g.redisCaCert | default "") -}}{{- if hasKey $c "MULTI_TENANT_REDIS_CA_CERT" -}}{{- $redisCaCert = index $c "MULTI_TENANT_REDIS_CA_CERT" -}}{{- end }}
+MULTI_TENANT_REDIS_CA_CERT: {{ $redisCaCert | quote }}
+{{- end }}
 {{- end }}
 {{- if .emitPool }}
 {{- $maxPools := "100" -}}{{- if hasKey $c "MULTI_TENANT_MAX_TENANT_POOLS" -}}{{- $maxPools = index $c "MULTI_TENANT_MAX_TENANT_POOLS" -}}{{- end }}
@@ -214,6 +220,7 @@ Inputs (dict):
       "MULTI_TENANT_REDIS_HOST" ""
       "MULTI_TENANT_REDIS_PORT" "6379"
       "MULTI_TENANT_REDIS_TLS" "false"
+      "MULTI_TENANT_REDIS_CA_CERT" ""
       "MULTI_TENANT_TIMEOUT" "30"
       "MULTI_TENANT_CACHE_TTL_SEC" "120"
       "MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" "30" -}}

--- a/charts/lerian-common/templates/_service_discovery.tpl
+++ b/charts/lerian-common/templates/_service_discovery.tpl
@@ -254,6 +254,8 @@ Inputs (dict):
 {{- define "lerian-common.serviceDiscovery.envFlat" -}}
 {{- $std := dict
       "SD_ADDRESS" "localhost:8500"
+      "SD_ADVERTISE_ADDRESS" ""
+      "SD_ADVERTISE_PORT" "0"
       "SD_ALLOW_STALE" ""
       "SD_DIAL_TIMEOUT" ""
       "SD_ENABLED" "false"
@@ -271,7 +273,7 @@ Inputs (dict):
       "SD_WATCH_WAIT_TIME" ""
       "SD_WORKLOAD" "" -}}
 {{- $keys := .keys | default (list
-      "SD_ADDRESS" "SD_ALLOW_STALE" "SD_DIAL_TIMEOUT" "SD_ENABLED"
+      "SD_ADDRESS" "SD_ADVERTISE_ADDRESS" "SD_ADVERTISE_PORT" "SD_ALLOW_STALE" "SD_DIAL_TIMEOUT" "SD_ENABLED"
       "SD_EXTERNAL_ADDRESS" "SD_EXTERNAL_PORT" "SD_INTERNAL_ADDRESS"
       "SD_INTERNAL_PORT" "SD_INTERNAL_SCHEME" "SD_PREFER_VIEW"
       "SD_RESPONSE_HEADER_TIMEOUT" "SD_SEED_TIMEOUT" "SD_TLS"


### PR DESCRIPTION
## What

Two **additive, backward-compatible** extensions to lerian-common config helpers so the
reporter (and any app on the same libs) can adopt them instead of hand-written `configmap`
passthrough — part of productizing reporter fully onto lerian-common.

### 1. `serviceDiscovery.envFlat` — SD advertise contract
Add `SD_ADVERTISE_ADDRESS` + `SD_ADVERTISE_PORT` to `$std` (and the default key list). This
covers lib-service-discovery's **advertise/agent** contract (`SD_ADDRESS` + `SD_ADVERTISE_*`
+ `SD_WORKLOAD` + `SD_TLS_SKIP_VERIFY`), which is distinct from the `SD_INTERNAL_*` /
`SD_EXTERNAL_*` topology the helper already supported. Reporter uses the advertise flavor.

### 2. `multiTenant.env` / `.envFlat` — tenant-redis CA cert
Add an opt-in `emitRedisCaCert` flag to `multiTenant.env` → emits `MULTI_TENANT_REDIS_CA_CERT`
(under `emitRedis`), and add the key to `multiTenant.envFlat`'s `$std`. For charts whose
tenant-redis uses TLS with a CA cert (reporter).

## Why this is safe

- **Zero consumers today**: no chart in the repo includes `serviceDiscovery.env(Flat)` or
  `multiTenant.env(Flat)` yet (grep: 0). These helpers exist but are not yet wired anywhere.
- **Purely additive**: new `$std` keys are emitted only when a chart lists them in `keys`;
  the new flag defaults off. No existing render changes.
- **Verified**: a throwaway consumer chart renders `SD_ADVERTISE_ADDRESS`/`SD_ADVERTISE_PORT`
  and `MULTI_TENANT_REDIS_CA_CERT` correctly; `helm lint` clean.

## Follow-up (not in this PR)

Once released, the reporter chart bumps its lerian-common dependency and rewires its SD block
(`serviceDiscovery.envFlat`) and multi-tenant block (`multiTenant.env` with `emitRedisCaCert`)
to consume these instead of raw passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)