### PR TITLE
feat(charts): br-consignado-gw api extraVolumes/Mounts for file credentials; writable nginx conf.d on the ui

### DIFF
--- a/charts/br-consignado-gw/templates/api-deployment.yaml
+++ b/charts/br-consignado-gw/templates/api-deployment.yaml
@@ -68,6 +68,14 @@ spec:
             failureThreshold: {{ .Values.api.readinessProbe.failureThreshold }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
+          {{- with .Values.api.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.api.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/br-consignado-gw/templates/ui-deployment.yaml
+++ b/charts/br-consignado-gw/templates/ui-deployment.yaml
@@ -64,8 +64,16 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            # The nginx-unprivileged entrypoint renders /etc/nginx/templates/*
+            # into conf.d at boot (envsubst); with readOnlyRootFilesystem the
+            # write fails and the container crash-loops, so conf.d is a
+            # writable emptyDir.
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: nginx-conf
           emptyDir: {}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:

--- a/charts/br-consignado-gw/values.yaml
+++ b/charts/br-consignado-gw/values.yaml
@@ -65,6 +65,12 @@ api:
   useExistingSecret: false
   existingSecretName: ""
   extraEnvVars: []
+  # Extra pod volumes / container mounts for file-shaped credentials the API
+  # reads from disk (Kafka SASL_SSL CA + SCRAM files via STREAMING_KAFKA_*_FILE,
+  # ICP-Brasil A1 client certificate via DATAPREV_CERT_FILE/DATAPREV_KEY_FILE).
+  # The operator supplies the Secret (e.g. an AVP-rendered raw resource).
+  extraVolumes: []
+  extraVolumeMounts: []
 
 # The Vite SPA is intentionally separate from the API but shares its ingress
 # host. Runtime API_BASE_URL must remain empty (same origin): the console


### PR DESCRIPTION
First real boot on benedita (lerian-internal-gitops#2112, image 2.0.0-beta.3) surfaced two chart gaps:

1. **API cannot mount file-shaped credentials.** The app reads Kafka SASL_SSL material from files (`STREAMING_KAFKA_TLS_CA_FILE`, `STREAMING_KAFKA_SASL_USERNAME_FILE/PASSWORD_FILE`) — the benedita RedPanda is SASL_SSL, so streaming stays degraded and readiness never turns — and will read the ICP-Brasil A1 pair the same way at Dataprev homologation (`DATAPREV_CERT_FILE/KEY_FILE`). Adds `api.extraVolumes` + `api.extraVolumeMounts` passthrough; the operator supplies the Secret (AVP-rendered raw resource in GitOps).

2. **UI crash-loops under readOnlyRootFilesystem.** The nginx-unprivileged entrypoint renders `/etc/nginx/templates/*` into `conf.d` at boot (envsubst) and the read-only root refuses the write (observed: `can't create /etc/nginx/conf.d/default.conf: Read-only file system`). `conf.d` becomes a writable emptyDir; root filesystem stays read-only.

`helm lint` clean; render verified with the extra volumes set and unset (no-op when unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDCsufJe11sWn2366SxLpv