### PR TITLE
feat(lender): fail helm render when hardened posture lacks security acks

### DIFF
--- a/.github/configs/helm-render-values/lender.yaml
+++ b/.github/configs/helm-render-values/lender.yaml
@@ -2,6 +2,16 @@
 # Enables BOTH components so the render gate exercises the console path, and
 # supplies the required-when-enabled values. No real credentials.
 lender:
+  configmap:
+    # The chart defaults to the hardened posture (DEPLOYMENT_MODE/ENV_NAME
+    # production, TLS_TERMINATED_UPSTREAM true), which the render gate in
+    # templates/_helpers.tpl refuses to render without these acknowledgements —
+    # mirroring the application's own boot validation. Supplied here so the CI
+    # render exercises the hardened path, which is the one operators install.
+    AUTH_M2M_INVERSION_ENABLED: "true"
+    TRUST_PROXY_ENABLED: "true"
+    TRUSTED_PROXIES: "10.0.0.0/8"
+
   secrets:
     # lender.secrets.POSTGRES_PASSWORD is `required` when useExistingSecret=false.
     POSTGRES_PASSWORD: "ci-dummy-not-a-real-secret"

--- a/charts/lender/templates/_helpers.tpl
+++ b/charts/lender/templates/_helpers.tpl
@@ -81,3 +81,57 @@ Allows overriding it for multi-namespace deployments in combined charts.
 {{- define "global.namespace" -}}
 {{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end }}
+
+{{/*
+Hardened security gate — render-time mirror of the lender application's own boot
+validation: internal/bootstrap/config_validation.go (hardenedSecurityGateArmed,
+validateHardenedSecurityConfig, normalizeSecurityModes,
+validateExplicitSecurityModeEnvironment) and internal/bootstrap/tls_enforcement.go
+(moneyPathRequiresTLS).
+
+The application stays the authority: it re-validates every one of these at boot and
+refuses to start when they fail. This gate exists only so the operator learns at
+`helm install`/`helm upgrade` time instead of through a CrashLoopBackOff whose reason
+is buried in the pod log. ANY drift between the two must be resolved in the
+application's favour — fix this helper, never the application.
+
+The Deployment injects the whole ConfigMap through envFrom, so every key declared in
+lender.configmap is a SET environment variable in the container. A key present but
+blank is therefore rejected exactly as the app rejects it; a key removed from an
+overlay with `null` is genuinely absent and falls back to the app default
+(ENV_NAME=development, DEPLOYMENT_MODE=local).
+*/}}
+{{- define "lender.validateHardenedSecurity" -}}
+{{- $cm := .Values.lender.configmap | default dict -}}
+{{- $rawEnvName := "development" -}}
+{{- if hasKey $cm "ENV_NAME" -}}{{- $rawEnvName = $cm.ENV_NAME | toString -}}{{- end -}}
+{{- $rawMode := "local" -}}
+{{- if hasKey $cm "DEPLOYMENT_MODE" -}}{{- $rawMode = $cm.DEPLOYMENT_MODE | toString -}}{{- end -}}
+{{- $envName := $rawEnvName | trim | lower -}}
+{{- $mode := $rawMode | trim | lower -}}
+{{- if not (has $envName (list "development" "local" "test" "staging" "production")) -}}
+{{- fail (printf "\n\nlender.configmap.ENV_NAME=%q is not a valid environment.\nValid values: development, local, test, staging, production.\nThe lender application refuses to boot on any other value (internal/bootstrap/config_validation.go).\n" $rawEnvName) -}}
+{{- end -}}
+{{- if not (has $mode (list "local" "test" "staging" "production" "saas" "byoc")) -}}
+{{- fail (printf "\n\nlender.configmap.DEPLOYMENT_MODE=%q is not a valid deployment mode.\nValid values: local, test, staging, production, saas, byoc.\nThe lender application refuses to boot on any other value (internal/bootstrap/config_validation.go).\n" $rawMode) -}}
+{{- end -}}
+{{/* strconv.ParseBool truthy set, lowercased — matching it exactly keeps the gate from
+     rejecting a value ("1", "t") that the application would happily accept. */}}
+{{- $truthy := list "true" "t" "1" -}}
+{{- $ack := has ($cm.AUTH_M2M_INVERSION_ENABLED | default "false" | toString | trim | lower) $truthy -}}
+{{- $tlsUpstream := has ($cm.TLS_TERMINATED_UPSTREAM | default "false" | toString | trim | lower) $truthy -}}
+{{- $trustProxy := has ($cm.TRUST_PROXY_ENABLED | default "false" | toString | trim | lower) $truthy -}}
+{{- $trustedProxies := $cm.TRUSTED_PROXIES | default "" | toString | trim -}}
+{{- $armed := or (has $mode (list "saas" "production" "byoc")) (eq $envName "production") -}}
+{{- if and $trustProxy (empty $trustedProxies) -}}
+{{- fail (printf "\n\nlender.configmap.TRUST_PROXY_ENABLED=true with an empty lender.configmap.TRUSTED_PROXIES.\nThe lender application refuses to boot: trusting proxy headers with no trusted proxy list\nlets any client spoof the client IP.\nSet lender.configmap.TRUSTED_PROXIES to the ingress/load-balancer IPs or CIDRs (e.g. \"10.0.0.0/8\").\n") -}}
+{{- end -}}
+{{- if $armed -}}
+{{- if not $ack -}}
+{{- fail (printf "\n\nHardened deployment (DEPLOYMENT_MODE=%q, ENV_NAME=%q) requires the M2M inversion acknowledgement.\nSet:\n  lender.configmap.AUTH_M2M_INVERSION_ENABLED: \"true\"\nWhy: in a hardened posture the lender issues its own machine-to-machine credentials\ninstead of forwarding the caller's token. The flag is a conscious acknowledgement, so\nthe chart does not default it — the lender application refuses to boot without it\n(internal/bootstrap/config_validation.go).\nThe gate arms when DEPLOYMENT_MODE is one of saas, production, byoc, or ENV_NAME is production.\n" $mode $envName) -}}
+{{- end -}}
+{{- if and $tlsUpstream (or (not $trustProxy) (empty $trustedProxies)) -}}
+{{- fail (printf "\n\nHardened deployment (DEPLOYMENT_MODE=%q, ENV_NAME=%q) with TLS_TERMINATED_UPSTREAM=true requires trusted proxies.\nSet BOTH:\n  lender.configmap.TRUST_PROXY_ENABLED: \"true\"\n  lender.configmap.TRUSTED_PROXIES: \"10.0.0.0/8\"   # ingress/load-balancer IPs or CIDRs\nWhy: TLS terminates upstream, so the client IP and scheme reach the lender only through\nproxy headers. Honouring those headers without a trusted proxy list would let any client\nspoof them — the lender application refuses to boot in that state\n(internal/bootstrap/config_validation.go).\n" $mode $envName) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/lender/templates/_helpers.tpl
+++ b/charts/lender/templates/_helpers.tpl
@@ -126,6 +126,11 @@ overlay with `null` is genuinely absent and falls back to the app default
 {{- if and $trustProxy (empty $trustedProxies) -}}
 {{- fail (printf "\n\nlender.configmap.TRUST_PROXY_ENABLED=true with an empty lender.configmap.TRUSTED_PROXIES.\nThe lender application refuses to boot: trusting proxy headers with no trusted proxy list\nlets any client spoof the client IP.\nSet lender.configmap.TRUSTED_PROXIES to the ingress/load-balancer IPs or CIDRs (e.g. \"10.0.0.0/8\").\n") -}}
 {{- end -}}
+{{- range (splitList "," $trustedProxies) -}}
+{{- if has (. | trim) (list "0.0.0.0/0" "::/0") -}}
+{{- fail (printf "\n\nlender.configmap.TRUSTED_PROXIES contains %q, which trusts every client.\nThe lender application rejects 0.0.0.0/0 and ::/0: an all-client trusted proxy range\nlets any client spoof proxy headers, defeating the trust list entirely\n(internal/bootstrap/config_validation.go).\nSet lender.configmap.TRUSTED_PROXIES to the specific ingress/load-balancer IPs or CIDRs (e.g. \"10.0.0.0/8\").\n" (. | trim)) -}}
+{{- end -}}
+{{- end -}}
 {{- if $armed -}}
 {{- if not $ack -}}
 {{- fail (printf "\n\nHardened deployment (DEPLOYMENT_MODE=%q, ENV_NAME=%q) requires the M2M inversion acknowledgement.\nSet:\n  lender.configmap.AUTH_M2M_INVERSION_ENABLED: \"true\"\nWhy: in a hardened posture the lender issues its own machine-to-machine credentials\ninstead of forwarding the caller's token. The flag is a conscious acknowledgement, so\nthe chart does not default it — the lender application refuses to boot without it\n(internal/bootstrap/config_validation.go).\nThe gate arms when DEPLOYMENT_MODE is one of saas, production, byoc, or ENV_NAME is production.\n" $mode $envName) -}}

--- a/charts/lender/templates/lender/configmap.yaml
+++ b/charts/lender/templates/lender/configmap.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.lender.enabled }}
+{{- /* Fails the render when the hardened security posture is declared without the
+       keys the lender application demands at boot. Mirror of
+       internal/bootstrap/config_validation.go — see the helper for the full note. */}}
+{{- include "lender.validateHardenedSecurity" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/lender/values-template.yaml
+++ b/charts/lender/values-template.yaml
@@ -56,7 +56,21 @@ lender:
     targetMemoryUtilizationPercentage: 80
 
   configmap:
-    ENV_NAME: ""
+    # ENV_NAME must be one of development, local, test, staging, production, and
+    # DEPLOYMENT_MODE one of local, test, staging, production, saas, byoc. The whole
+    # ConfigMap is injected with envFrom, so a blank value here is a SET-but-empty
+    # environment variable and the application refuses to boot on it.
+    ENV_NAME: "production"
+    DEPLOYMENT_MODE: "production"
+    # Hardened posture (armed by DEPLOYMENT_MODE saas/production/byoc, or ENV_NAME
+    # production) requires the M2M inversion acknowledgement below. Flip it to "true"
+    # consciously — `helm install` refuses to render until you do.
+    AUTH_M2M_INVERSION_ENABLED: "false"
+    # With TLS terminated upstream, hardened deployments also require a trusted proxy
+    # list: set TRUSTED_PROXIES to your ingress/load-balancer IPs or CIDRs.
+    TLS_TERMINATED_UPSTREAM: "true"
+    TRUST_PROXY_ENABLED: "false"
+    TRUSTED_PROXIES: ""
     SERVER_ADDRESS: ":4017"
     LOG_LEVEL: "info"
     POSTGRES_HOST: ""

--- a/charts/lender/values.schema.json
+++ b/charts/lender/values.schema.json
@@ -20,7 +20,21 @@
       "type": "object",
       "properties": {
         "configmap": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "AUTH_M2M_INVERSION_ENABLED": {
+              "description": "Acknowledgement that the lender issues its own machine-to-machine credentials instead of forwarding the caller's token. Required (\"true\") when the hardened gate is armed: DEPLOYMENT_MODE in saas/production/byoc, or ENV_NAME production. Not defaulted to \"true\" on purpose; templates/_helpers.tpl fails the render when it is missing.",
+              "type": ["string", "boolean"]
+            },
+            "TRUST_PROXY_ENABLED": {
+              "description": "Honour proxy headers for client IP and scheme. Required (\"true\") when the hardened gate is armed and TLS_TERMINATED_UPSTREAM is \"true\". Enabling it with an empty TRUSTED_PROXIES fails the render and fails application boot.",
+              "type": ["string", "boolean"]
+            },
+            "TRUSTED_PROXIES": {
+              "description": "Comma-separated ingress/load-balancer IPs or CIDRs whose proxy headers are trusted, e.g. \"10.0.0.0/8\". Must be non-empty whenever TRUST_PROXY_ENABLED is true; the application rejects 0.0.0.0/0 and ::/0.",
+              "type": "string"
+            }
+          }
         },
         "secrets": {
           "type": "object"

--- a/charts/lender/values.yaml
+++ b/charts/lender/values.yaml
@@ -177,7 +177,14 @@ lender:
     # Application Settings
     ENV_NAME: "production"
     LOG_LEVEL: "info"
+    # Hardened posture: BYOC customers run production posture by design. The gate arms
+    # when DEPLOYMENT_MODE is one of saas, production, byoc, or ENV_NAME is production.
     DEPLOYMENT_MODE: "production"
+    # Acknowledgement that the lender issues its own machine-to-machine credentials
+    # instead of forwarding the caller's token. Deliberately NOT defaulted to "true":
+    # the operator must declare it consciously. A hardened deployment refuses to boot
+    # without it, and `helm install` refuses to render (templates/_helpers.tpl).
+    AUTH_M2M_INVERSION_ENABLED: "false"
     SERVER_ADDRESS: ":4017"
     HTTP_BODY_LIMIT_BYTES: "104857600"
 
@@ -197,6 +204,14 @@ lender:
 
     # TLS
     TLS_TERMINATED_UPSTREAM: "true"
+    # Required when the hardened gate is armed AND TLS_TERMINATED_UPSTREAM=true: with TLS
+    # terminated upstream the client IP and scheme arrive only through proxy headers, so
+    # they are only trustworthy behind a declared proxy list. Set TRUSTED_PROXIES to the
+    # ingress/load-balancer IPs or CIDRs (comma-separated, e.g. "10.0.0.0/8"); 0.0.0.0/0
+    # is rejected by the application. Enabling TRUST_PROXY_ENABLED with an empty
+    # TRUSTED_PROXIES fails the render and fails app boot.
+    TRUST_PROXY_ENABLED: "false"
+    TRUSTED_PROXIES: ""
 
     # Tenancy
     DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
## What this is

Port of **LerianStudio/helm-internal#81** to the chart that actually publishes the live OCI artifact `ghcr.io/lerianstudio/lender-helm` — the one the fleet and customers pin. The internal chart is marked `deprecated: true`; this repo's `develop` is the source of truth, so the gate has to live here to protect real installs.

## Problem

The lender application arms a **hardened security gate** when `DEPLOYMENT_MODE` is one of `saas`/`production`/`byoc`, **or** `ENV_NAME` is `production`. Armed, it refuses to boot unless:

- `AUTH_M2M_INVERSION_ENABLED=true`; and
- when `TLS_TERMINATED_UPSTREAM=true`, also `TRUST_PROXY_ENABLED=true` with a non-empty `TRUSTED_PROXIES`.

This chart defaults to `DEPLOYMENT_MODE: "production"`, `ENV_NAME: "production"` and `TLS_TERMINATED_UPSTREAM: "true"`, and declared none of those keys. Installing it as-is produced a `CrashLoopBackOff` with the reason buried in the pod log — the operator had to read application source to learn which variable was missing.

Now `helm install`/`helm upgrade` **fails at render** with a message naming the exact key to set and why.

## Decisions kept

- **`DEPLOYMENT_MODE: "production"` stays the chart default.** BYOC customers run production posture by design — founder decision, not reopened here.
- **`AUTH_M2M_INVERSION_ENABLED` is NOT defaulted to `"true"`.** It is an acknowledgement flag: the operator must declare it consciously. It ships as `"false"` so the gate fires.
- **The application remains the authority.** It re-validates all of this at boot; the chart only moves discovery to install time. Any drift is resolved in the application's favour — the helper says so in its header comment.

## What changed

- `charts/lender/templates/_helpers.tpl` — new `lender.validateHardenedSecurity`, a documented render-time mirror of `internal/bootstrap/config_validation.go` (`hardenedSecurityGateArmed`, `validateHardenedSecurityConfig`, `normalizeSecurityModes`, `validateExplicitSecurityModeEnvironment`) and `tls_enforcement.go` (`moneyPathRequiresTLS`). Validates the `ENV_NAME`/`DEPLOYMENT_MODE` enums, the M2M acknowledgement, and the trusted-proxy pair. Truthiness matches Go's `strconv.ParseBool` (`true`/`t`/`1`) so a value the application accepts is never rejected by the chart.
- `charts/lender/templates/lender/configmap.yaml` — invokes the helper.
- `charts/lender/values.yaml` — `AUTH_M2M_INVERSION_ENABLED`, `TRUST_PROXY_ENABLED`, `TRUSTED_PROXIES` added as documented first-class keys next to `DEPLOYMENT_MODE` and the TLS block.
- `charts/lender/values-template.yaml` — reflects the new keys, and no longer ships a blank `ENV_NAME`: the Deployment injects the ConfigMap with `envFrom`, so a blank value is a set-but-empty variable the application rejects at boot.
- `charts/lender/values.schema.json` — the three keys documented. The two flags are typed `["string", "boolean"]` so `--set` without `--set-string` is not rejected for a value the template handles fine. **Nothing is added to `required`** — the render gate is what demands them, conditionally on the posture.
- `.github/configs/helm-render-values/lender.yaml` — CI render fixture supplies the acknowledgements, so the render gate keeps exercising the hardened path (the posture operators actually install) instead of failing on it.

## Template scenarios verified

All runs supply `--set-string lender.secrets.POSTGRES_PASSWORD=x` to get past the pre-existing `required` on the secret.

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | chart defaults | FAIL — missing M2M acknowledgement | FAIL, message names `lender.configmap.AUTH_M2M_INVERSION_ENABLED` |
| 2 | acknowledgement + `TRUST_PROXY_ENABLED=true` + `TRUSTED_PROXIES=10.0.0.0/8` | render | 8 resources |
| 3a | `DEPLOYMENT_MODE=local`, `ENV_NAME` left at `production` | FAIL — gate still armed via `ENV_NAME` | FAIL as expected |
| 3b | `DEPLOYMENT_MODE=local` + `ENV_NAME=development`, no acknowledgement | render — gate disarmed | 8 resources |
| 4 | `DEPLOYMENT_MODE=banana` | FAIL — enum | FAIL, lists the six valid modes |
| 5 | `DEPLOYMENT_MODE=byoc` + acknowledgement, `TLS_TERMINATED_UPSTREAM=false`, `ENV_NAME=staging` | render — BYOC arms the gate, no proxy requirement without upstream TLS | 8 resources |
| 6 | `TRUST_PROXY_ENABLED=true` with empty `TRUSTED_PROXIES`, gate disarmed | FAIL — application rejects this regardless of the gate | FAIL as expected |
| 7 | acknowledgement given as `"1"` (ParseBool truthy) | render | 8 resources |
| 8 | `-f values-template.yaml` | FAIL on the acknowledgement, not on a blank `ENV_NAME` | FAIL as expected |
| 9 | acknowledgement via `--set` (unquoted YAML bool) | render — schema must not reject it | 8 resources |

Repo tooling, run locally:

```
helm lint charts/lender                                              -> 1 chart(s) linted, 0 chart(s) failed
go run ./validate-helm-charts --root ../.. --strict                  -> 0 current violation(s), 0 baseline entries
go run ./validate-helm-charts --root ../.. --render-gate --charts lender
                                                                     -> lender: ok (render-ok)
go run ./validate-helm-charts --root ../.. --render-gate --all       -> all charts ok, exit 0
```

The full `--all` render was run because touching `.github/configs/helm-render-values/**` makes the workflow widen the render scope to every chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)