### PR TITLE
feat(lender): apiPaths seam on the console ingress for same-origin serving

### DIFF
--- a/charts/lender/templates/lenderConsole/ingress.yaml
+++ b/charts/lender/templates/lenderConsole/ingress.yaml
@@ -30,6 +30,20 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+          # SAME-ORIGIN PROXY (same pattern as the matcher chart): the console
+          # defaults to API_BASE_URL="" (same-origin), so these prefixes route
+          # API traffic to the lender API Service on the SAME host; "/" routes
+          # to the console. nginx uses longest-prefix matching, so the API
+          # prefixes win over /.
+          {{- range $.Values.lenderConsole.ingress.apiPaths }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "lender.fullname" $ }}
+                port:
+                  number: {{ $.Values.lender.service.port }}
+          {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
             pathType: {{ .pathType }}

--- a/charts/lender/templates/lenderConsole/ingress.yaml
+++ b/charts/lender/templates/lenderConsole/ingress.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.lenderConsole.enabled .Values.lenderConsole.ingress.enabled }}
+{{- if and (not .Values.lender.enabled) (gt (len .Values.lenderConsole.ingress.apiPaths) 0) }}
+{{- fail (printf "\n\nlenderConsole.ingress.apiPaths is set but lender.enabled=false.\nThe API prefixes route to the lender API Service (%s), which is only created\nwhen lender.enabled=true — rendering these routes anyway would send API traffic\nto a missing Service (503).\nEither set lender.enabled=true or remove lenderConsole.ingress.apiPaths.\n" (include "lender.fullname" .)) -}}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/lender/values.yaml
+++ b/charts/lender/values.yaml
@@ -480,6 +480,10 @@ lenderConsole:
         paths:
           - path: /
             pathType: Prefix
+    # -- API prefixes routed to the lender API Service on the console host
+    # (same-origin: one host serves the console at / and the API under these
+    # prefixes). Empty keeps the console-only ingress.
+    apiPaths: []
     # -- TLS configuration for ingress
     tls: []
 


### PR DESCRIPTION
## What

The console ingress gains `lenderConsole.ingress.apiPaths` (default `[]`): prefixes listed there route to the **lender API Service** on the same host, while `/` keeps routing to the console. Same pattern the matcher chart ships (`ui.ingress.apiPaths`).

## Why

The console image already defaults to `API_BASE_URL=""` (same-origin). With this seam a deployment can serve console + API from ONE host (`lender.<tier>.lerian.net`): the CORS ceremony on the API dies, the bearer token stops crossing origins, and one hostname per tier disappears from the edge. benedita adopts it right after this releases (gitops PR follows).

## Compatibility

Default `[]` renders the exact ingress shipped today — no change for any existing deployment.

Rendered and linted locally (`helm lint` clean; `helm template` shows the API prefixes backed by the lender Service on 4017 and `/` on the console Service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDCsufJe11sWn2366SxLpv